### PR TITLE
Improve handleDragOver cloning

### DIFF
--- a/src/hooks/useDnDPlanner.test.ts
+++ b/src/hooks/useDnDPlanner.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDnDPlanner } from './useDnDPlanner';
+import type { DayPlan, Activity } from '@/types/itinerary';
+
+describe('handleDragOver', () => {
+  function setup() {
+    const a1: Activity = { id: 'a1', title: 'A1', color: 'red' };
+    const a2: Activity = { id: 'a2', title: 'A2', color: 'red' };
+    const b1: Activity = { id: 'b1', title: 'B1', color: 'red' };
+
+    const initial: DayPlan[] = [
+      { id: 'day1', label: 'Day 1', activities: [a1, a2] },
+      { id: 'day2', label: 'Day 2', activities: [b1] },
+    ];
+    const { result } = renderHook(() => useDnDPlanner(initial));
+    return { result };
+  }
+
+  it('reorders within the same day', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: 'a1' },
+        over: { id: 'a2' },
+      } as any);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+  });
+
+  it('moves activity across days', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: 'a1' },
+        over: { id: 'day2' },
+      } as any);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+});

--- a/src/hooks/useDnDPlanner.ts
+++ b/src/hooks/useDnDPlanner.ts
@@ -46,38 +46,43 @@ export function useDnDPlanner(initial: DayPlan[] = []) {
     if (!over || active.id === over.id) return;
 
     setDays((prev) => {
-      // 1) clone days e cada activities
-      const daysCopy = prev.map((d) => ({
-        ...d,
-        activities: [...d.activities],
-      }));
-
-      // 2) encontrar índices
-      const srcDayIdx = daysCopy.findIndex((d) => d.activities.some((a) => a.id === active.id));
-      const dstDayIdx = daysCopy.findIndex(
+      // 1) localizar índices no estado atual
+      const srcDayIdx = prev.findIndex((d) => d.activities.some((a) => a.id === active.id));
+      const dstDayIdx = prev.findIndex(
         (d) => d.id === over.id || d.activities.some((a) => a.id === over.id)
       );
       if (srcDayIdx < 0 || dstDayIdx < 0) return prev;
 
-      const srcActivities = daysCopy[srcDayIdx].activities;
-      const dstActivities = daysCopy[dstDayIdx].activities;
+      // 2) clonar apenas os dias afetados e suas atividades
+      const updated = [...prev];
+      const srcDay = { ...prev[srcDayIdx], activities: [...prev[srcDayIdx].activities] };
+      const dstDay =
+        srcDayIdx === dstDayIdx
+          ? srcDay
+          : { ...prev[dstDayIdx], activities: [...prev[dstDayIdx].activities] };
 
-      const oldIdx = srcActivities.findIndex((a) => a.id === active.id);
+      updated[srcDayIdx] = srcDay;
+      updated[dstDayIdx] = dstDay;
+
+      const srcActs = srcDay.activities;
+      const dstActs = dstDay.activities;
+
+      const oldIdx = srcActs.findIndex((a) => a.id === active.id);
       const overIdx =
-        daysCopy[dstDayIdx].id === over.id
-          ? dstActivities.length
-          : dstActivities.findIndex((a) => a.id === over.id);
+        prev[dstDayIdx].id === over.id
+          ? dstActs.length
+          : dstActs.findIndex((a) => a.id === over.id);
 
-      // 3) faz o movimento sem mutar prev
+      // 3) aplicar movimento sem mutar o estado original
       let moved: Activity;
       if (srcDayIdx === dstDayIdx) {
-        daysCopy[srcDayIdx].activities = arrayMove(srcActivities, oldIdx, overIdx);
+        srcDay.activities = arrayMove(srcActs, oldIdx, overIdx);
       } else {
-        [moved] = srcActivities.splice(oldIdx, 1);
-        dstActivities.splice(overIdx, 0, moved);
+        [moved] = srcActs.splice(oldIdx, 1);
+        dstActs.splice(overIdx, 0, moved);
       }
 
-      return daysCopy;
+      return updated;
     });
   }
 


### PR DESCRIPTION
## Summary
- refactor `handleDragOver` to clone only modified days
- add tests ensuring drag logic for moving within and across days

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac85226c832281ddc8cbe53614b0