### PR TITLE
Update Add New card handler to pass day id

### DIFF
--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -32,7 +32,7 @@ export interface PlannerBoardProps {
   /** Called when user clicks a card to edit */
   onSelectActivity: (activity: Activity) => void;
   /** Called when user clicks + New Card Button */
-  onAddNew: () => void;
+  onAddNew: (dayId: string) => void;
 }
 
 export default function PlannerBoard({

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -96,9 +96,10 @@ export default function PlannerClient() {
           setSelectedActivity(activity);
         }}
         /* Create a blank activity and immediately open the modal */
-        onAddNew={() => {
-          const blank = addBlankActivity();
-          setSelectedActivity(blank);
+        onAddNew={(dayId) => {
+          const idx = days.findIndex((d) => d.id === dayId);
+          const blank = addBlankActivity(idx);
+          setSelectedActivity({ ...blank, dayId });
         }}
       />
 

--- a/src/components/planner/dnd/DayColumn.tsx
+++ b/src/components/planner/dnd/DayColumn.tsx
@@ -12,7 +12,7 @@ interface DayColumnProps {
   day: DayPlan;
   onRemove?: () => void;
   onSelectActivity?: (activity: Activity) => void;
-  onAddNew: () => void; // add a blank activity to this day
+  onAddNew: (dayId: string) => void; // add a blank activity to this day
 }
 
 /**

--- a/src/components/ui/BtnAddNewCard.tsx
+++ b/src/components/ui/BtnAddNewCard.tsx
@@ -12,10 +12,10 @@ import {
 
 interface AddNewCardProps {
   dayId: string;
-  onAddNew: () => void;
+  onAddNew: (dayId: string) => void;
 }
 
-export default function AddNewCard({ onAddNew }: AddNewCardProps) {
+export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
   const baseColor = DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX];
   const hoverColor = COLOR_HOVER_CLASSES[DEFAULT_NEW_CARD_COLOR_INDEX];
   const foregroundColor = COLOR_FOREGROUND_VALUES[DEFAULT_NEW_CARD_COLOR_INDEX];
@@ -24,7 +24,7 @@ export default function AddNewCard({ onAddNew }: AddNewCardProps) {
   return (
     <button
       type="button"
-      onClick={onAddNew}
+      onClick={() => onAddNew(dayId)}
       className={`p-2 cursor-pointer ${borderColor} ${baseColor} bg-background ${hoverColor} flex items-center w-full h-10 rounded-lg transition`}
     >
       <FiPlus className="mr-2" style={{ color: foregroundColor }} />


### PR DESCRIPTION
## Summary
- ensure `BtnAddNewCard` calls `onAddNew` with `dayId`
- forward `dayId` through `DayColumn` to `PlannerBoard`
- allow `PlannerBoard` to send day IDs to the handler
- update `PlannerClient` to create a new blank activity for the selected day

## Testing
- `npm test` *(fails: `vitest: not found`)*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868b364b5f08322bd5179e46db361c4