### PR TITLE
refactor: unify icons and buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react": "^19.0.0",
     "react-day-picker": "^9.7.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0",
     "shadcn-ui": "^0.9.5",
     "tailwind-merge": "^3.3.1"
   },

--- a/src/components/planner/catalog/DestinationCard.tsx
+++ b/src/components/planner/catalog/DestinationCard.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import Image from 'next/image';
-import { FaClock } from 'react-icons/fa';
+import { Clock } from 'lucide-react';
 import RemoveCardButton from '@/components/ui/IcoRemoveCard';
 import BtnDestinationAction from '@/components/ui/BtnDestinationAction';
 import type { CatalogActivity } from '@/types/itinerary';
@@ -55,7 +55,7 @@ export default function DestinationCard({
       {/* Duration | Price chips */}
       <div className="flex items-center text-sm text-[var(--muted-foreground)] mb-2 space-x-2">
         <span className="flex items-center gap-1">
-          <FaClock /> {duration} min
+          <Clock className="w-4 h-4" /> {duration} min
         </span>
         <span>|</span>
         <span>{price}</span>

--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
-import { FaRegClock, FaHourglassHalf } from 'react-icons/fa';
+import { Clock, Hourglass } from 'lucide-react';
 import type { Activity } from '@/types/itinerary';
 import { EMPTY_ACTIVITY_TITLE } from '@/constants/ui';
 
@@ -65,14 +65,14 @@ export default function ActivityCard({ activity, onSelect }: ActivityCardProps) 
             {/* Conditionally render start time */}
             {startTime?.trim() && (
               <span className="inline-flex items-center gap-2">
-                <FaRegClock />
+                <Clock className="w-4 h-4" />
                 {startTime}
               </span>
             )}
             {/* Conditionally render duration */}
             {duration! > 0 && (
               <span className="inline-flex items-center gap-2">
-                <FaHourglassHalf />
+                <Hourglass className="w-4 h-4" />
                 {duration}
               </span>
             )}

--- a/src/components/ui/AutocompleteInput.tsx
+++ b/src/components/ui/AutocompleteInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { FaMapMarkerAlt } from 'react-icons/fa';
+import { MapPin } from 'lucide-react';
 
 /**
  * Very small autocomplete component.
@@ -14,7 +14,7 @@ export default function AutocompleteInput({
   options,
   onSelect,
   placeholder = 'Search…',
-  leftIcon = <FaMapMarkerAlt className="text-gray-400" />,
+  leftIcon = <MapPin className="text-gray-400 w-4 h-4" />,
 }: {
   value: string;
   onChange: (v: string) => void;

--- a/src/components/ui/BtnAddNewCard.tsx
+++ b/src/components/ui/BtnAddNewCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { FiPlus } from 'react-icons/fi';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 import {
   DEFAULT_NEW_CARD_COLOR_INDEX,
   DEFAULT_COLORS,
@@ -22,16 +23,16 @@ export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
   const borderColor = COLOR_BORDER_CLASSES[DEFAULT_NEW_CARD_COLOR_INDEX];
 
   return (
-    <button
+    <Button
       type="button"
       onClick={() => onAddNew(dayId)}
-      className={`p-2 cursor-pointer ${borderColor} ${baseColor} bg-background ${hoverColor} flex items-center w-full h-10 rounded-lg transition`}
+      className={`p-2 ${borderColor} ${baseColor} ${hoverColor} flex items-center w-full h-10`}
+      style={{ backgroundColor: 'var(--background)' }}
     >
-      <FiPlus className="mr-2" style={{ color: foregroundColor }} />
-
+      <Plus className="mr-2" style={{ color: foregroundColor }} />
       <span className="text-sm font-medium" style={{ color: 'var(--foreground)' }}>
         New Card
       </span>
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/BtnDestinationAction.tsx
+++ b/src/components/ui/BtnDestinationAction.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import React from 'react';
-import { FaCheck } from 'react-icons/fa';
+import { Check } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 
 interface DestinationActionButtonProps {
   added: boolean;
@@ -17,33 +18,27 @@ export default function DestinationActionButton({
 }: DestinationActionButtonProps) {
   if (added) {
     return (
-      <button
+      <Button
         onClick={onRemove}
-        className="mt-auto px-4 py-2 rounded flex items-center justify-center gap-1 hover:opacity-90"
-        style={{
-          backgroundColor: 'var(--secondary)',
-          color: 'var(--secondary-foreground)',
-        }}
+        className="mt-auto flex items-center justify-center gap-1"
+        style={{ backgroundColor: 'var(--secondary)', color: 'var(--secondary-foreground)' }}
       >
-        <FaCheck />
+        <Check className="w-4 h-4" />
         Added
-      </button>
+      </Button>
     );
   }
 
   return (
-    <button
+    <Button
       onClick={(e) => {
         e.stopPropagation();
         onAdd();
       }}
-      className="mt-auto px-4 py-2 rounded hover:opacity-90"
-      style={{
-        backgroundColor: 'var(--primary)',
-        color: 'var(--primary-foreground)',
-      }}
+      className="mt-auto"
+      style={{ backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }}
     >
       Add to Planner
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/BtnOpenCatalog.tsx
+++ b/src/components/ui/BtnOpenCatalog.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import React from 'react';
-import { FiCompass } from 'react-icons/fi';
+import { Compass } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 
 interface OpenPanelButtonProps {
   onClick: () => void;
@@ -14,17 +15,14 @@ export default function OpenPanelButton({
   title = 'Add Adventures',
 }: OpenPanelButtonProps) {
   return (
-    <button
+    <Button
       onClick={onClick}
       aria-label={title}
-      className="flex cursor-pointer items-center gap-2 px-4 py-2 rounded hover:opacity-90 transition-colors"
-      style={{
-        backgroundColor: 'var(--primary)',
-        color: 'var(--primary-foreground)',
-      }}
+      className="flex cursor-pointer items-center gap-2"
+      style={{ backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }}
     >
-      <FiCompass size={18} className="transform transition duration-300" />
+      <Compass size={18} className="transform transition duration-300" />
       <span className="text-sm font-medium whitespace-nowrap">{title}</span>
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/IcoRemoveCard.tsx
+++ b/src/components/ui/IcoRemoveCard.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React from 'react';
-import { FaTrashAlt } from 'react-icons/fa';
+import { Trash2 } from 'lucide-react';
 
 /**
  * Floating round-red button used by cards that are already in the planner.
@@ -25,7 +25,7 @@ export default function RemoveCardButton({
           flex items-center justify-center focus:outline-none focus:ring-2
           transition-transform duration-300 hover:scale-110"
     >
-      <FaTrashAlt size={18} className="transform transition duration-300 group:hover:scale-105" />
+      <Trash2 size={18} className="transform transition duration-300 group-hover:scale-105" />
     </button>
   );
 }

--- a/src/components/ui/IcoSettingsToggle.tsx
+++ b/src/components/ui/IcoSettingsToggle.tsx
@@ -2,21 +2,19 @@
 'use client';
 
 import React from 'react';
-import { FaSlidersH } from 'react-icons/fa';
+import { Sliders } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 
 /** Reusable animated button that toggles the config sidebar */
 export default function SettingsToggleButton({ onClick }: { onClick: () => void }) {
   return (
-    <button
+    <Button
       title="Toggle config"
       onClick={onClick}
-      className="
-        text-xl bg-background text-gray-600 hover:text-gray-800
-        transition-transform duration-300
-        transform hover:scale-110 hover:-rotate-90
-      "
+      variant="ghost"
+      className="text-xl bg-background text-gray-600 hover:text-gray-800 transform transition-transform duration-300 hover:scale-110 hover:-rotate-90"
     >
-      <FaSlidersH />
-    </button>
+      <Sliders />
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- remove react-icons dep
- switch all components to lucide-react icons
- refactor various UI buttons to reuse the shared `Button` component

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692f9e66e08322855895bb89e8cbc2