### PR TITLE
Replace raw buttons with Button component

### DIFF
--- a/src/components/planner/catalog/CategoryFilterBar.tsx
+++ b/src/components/planner/catalog/CategoryFilterBar.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React from 'react';
+import { Button } from '@/components/ui/button';
 
 /**
  * Horizontal scrollable pill list.
@@ -21,15 +22,19 @@ export default function CategoryFilterBar({
       {categories.map((cat) => {
         const isOn = active.has(cat);
         return (
-          <button
+          <Button
             key={cat}
             onClick={() => onToggle(cat)}
-            className={`whitespace-nowrap px-3 py-1 rounded-full text-sm border transition
-            ${isOn ? 'bg-[var(--muted)] text-[var(--muted-foreground)]' : 'bg-[var(--card)] text-[var(--card-foreground)] hover:bg-[var(--muted)] hover:text-[var(--muted-foreground)]'}
-            `}
+            size="sm"
+            variant="ghost"
+            className={`whitespace-nowrap px-3 py-1 rounded-full text-sm border transition ${
+              isOn
+                ? 'bg-[var(--muted)] text-[var(--muted-foreground)]'
+                : 'bg-[var(--card)] text-[var(--card-foreground)] hover:bg-[var(--muted)] hover:text-[var(--muted-foreground)]'
+            }`}
           >
             {cat}
-          </button>
+          </Button>
         );
       })}
     </div>

--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { FaRegClock, FaHourglassHalf } from 'react-icons/fa';
+import { Button } from '@/components/ui/button';
 import type { Activity } from '@/types/itinerary';
 import { EMPTY_ACTIVITY_TITLE } from '@/constants/ui';
 
@@ -36,11 +37,11 @@ export default function ActivityCard({ activity, onSelect }: ActivityCardProps) 
   /* ======================================================================================== */
 
   return (
-    <button
+    <Button
       type="button"
       onClick={onSelect}
-      className="group w-full text-left flex items-stretch rounded-lg border
-        shadow-sm bg-white overflow-hidden hover:shadow-md transition cursor-grab"
+      variant="ghost"
+      className="group w-full text-left flex items-stretch rounded-lg border shadow-sm bg-white overflow-hidden hover:shadow-md transition cursor-grab hover:bg-white"
     >
       {/* main content */}
       <div className={`flex-1 p-3 flex flex-col ${twBg ?? ''}`}>
@@ -79,6 +80,6 @@ export default function ActivityCard({ activity, onSelect }: ActivityCardProps) 
           </div>
         )}
       </div>
-    </button>
+    </Button>
   );
 }

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -6,6 +6,7 @@ import ActivityHeaderCard from '@/components/planner/modal/ActivityHeaderCard';
 import ColorSwatchPicker from '@/components/ui/ColorSwatchPicker';
 import type { Activity } from '@/types/itinerary';
 import { EMPTY_ACTIVITY_TITLE } from '@/constants/ui';
+import { Button } from '@/components/ui/button';
 
 interface ActivityModalFormProps {
   activity: Activity;
@@ -91,7 +92,7 @@ export default function ActivityModalForm({
 
       {/* Footer: Cancel & Update */}
       <div className="px-4 py-3 flex justify-center gap-2">
-        <button
+        <Button
           onClick={() =>
             onSave({
               title: editedTitle.trim(),
@@ -101,7 +102,7 @@ export default function ActivityModalForm({
               duration: Number(duration),
             })
           }
-          className={`px-4 py-2 rounded text-sm ${
+          className={`px-4 py-2 text-sm ${
             editedTitle.trim()
               ? 'bg-blue-600 text-white hover:bg-blue-700'
               : 'bg-gray-300 text-gray-500 cursor-not-allowed'
@@ -109,7 +110,7 @@ export default function ActivityModalForm({
           disabled={!editedTitle.trim()}
         >
           Update
-        </button>
+        </Button>
       </div>
     </>
   );

--- a/src/components/ui/BtnAddNewCard.tsx
+++ b/src/components/ui/BtnAddNewCard.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { FiPlus } from 'react-icons/fi';
+import { Button } from '@/components/ui/button';
 import {
   DEFAULT_NEW_CARD_COLOR_INDEX,
   DEFAULT_COLORS,
@@ -22,9 +23,10 @@ export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
   const borderColor = COLOR_BORDER_CLASSES[DEFAULT_NEW_CARD_COLOR_INDEX];
 
   return (
-    <button
+    <Button
       type="button"
       onClick={() => onAddNew(dayId)}
+      variant="ghost"
       className={`p-2 cursor-pointer ${borderColor} ${baseColor} bg-background ${hoverColor} flex items-center w-full h-10 rounded-lg transition`}
     >
       <FiPlus className="mr-2" style={{ color: foregroundColor }} />
@@ -32,6 +34,6 @@ export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
       <span className="text-sm font-medium" style={{ color: 'var(--foreground)' }}>
         New Card
       </span>
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/BtnDestinationAction.tsx
+++ b/src/components/ui/BtnDestinationAction.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { FaCheck } from 'react-icons/fa';
+import { Button } from '@/components/ui/button';
 
 interface DestinationActionButtonProps {
   added: boolean;
@@ -17,33 +18,26 @@ export default function DestinationActionButton({
 }: DestinationActionButtonProps) {
   if (added) {
     return (
-      <button
+      <Button
         onClick={onRemove}
-        className="mt-auto px-4 py-2 rounded flex items-center justify-center gap-1 hover:opacity-90"
-        style={{
-          backgroundColor: 'var(--secondary)',
-          color: 'var(--secondary-foreground)',
-        }}
+        variant="secondary"
+        className="mt-auto flex items-center justify-center gap-1"
       >
         <FaCheck />
         Added
-      </button>
+      </Button>
     );
   }
 
   return (
-    <button
+    <Button
       onClick={(e) => {
         e.stopPropagation();
         onAdd();
       }}
-      className="mt-auto px-4 py-2 rounded hover:opacity-90"
-      style={{
-        backgroundColor: 'var(--primary)',
-        color: 'var(--primary-foreground)',
-      }}
+      className="mt-auto"
     >
       Add to Planner
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/BtnOpenCatalog.tsx
+++ b/src/components/ui/BtnOpenCatalog.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { FiCompass } from 'react-icons/fi';
+import { Button } from '@/components/ui/button';
 
 interface OpenPanelButtonProps {
   onClick: () => void;
@@ -14,17 +15,9 @@ export default function OpenPanelButton({
   title = 'Add Adventures',
 }: OpenPanelButtonProps) {
   return (
-    <button
-      onClick={onClick}
-      aria-label={title}
-      className="flex cursor-pointer items-center gap-2 px-4 py-2 rounded hover:opacity-90 transition-colors"
-      style={{
-        backgroundColor: 'var(--primary)',
-        color: 'var(--primary-foreground)',
-      }}
-    >
+    <Button onClick={onClick} aria-label={title} className="flex items-center gap-2">
       <FiCompass size={18} className="transform transition duration-300" />
       <span className="text-sm font-medium whitespace-nowrap">{title}</span>
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/ColorSwatchPicker.tsx
+++ b/src/components/ui/ColorSwatchPicker.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { DEFAULT_COLORS } from '@/constants/colors';
+import { Button } from '@/components/ui/button';
 
 /**
  * Click-a-colour control.
@@ -21,14 +22,14 @@ export default function ColorSwatchPicker({
   return (
     <div className="flex flex-wrap gap-2 justify-center items-center">
       {colors.map((c) => (
-        <button
+        <Button
           key={c}
+          size="icon"
+          variant="ghost"
           onClick={() => onChange(c)}
-          className={`
-        w-12 h-12 rounded-full shadow border-2
-        ${c.startsWith('#') ? '' : c}          /* tailwind class */
-        ${value === c ? 'ring-2 ring-black' : 'border-white'}
-      `}
+          className={`w-12 h-12 rounded-full shadow border-2 ${c.startsWith('#') ? '' : c} ${
+            value === c ? 'ring-2 ring-black' : 'border-white'
+          }`}
           style={c.startsWith('#') ? { backgroundColor: c } : undefined}
           aria-label={c}
         />

--- a/src/components/ui/DatePicker.tsx
+++ b/src/components/ui/DatePicker.tsx
@@ -4,6 +4,7 @@ import { CalendarIcon } from 'lucide-react';
 import { DateRange } from 'react-day-picker';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/PopOver';
 import { Calendar } from '@/components/ui/Calendar';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 interface Props {
@@ -24,9 +25,11 @@ export function DateRangePicker({ className, value, onChange }: Props) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
+        <Button
+          variant="outline"
+          size="sm"
           className={cn(
-            'w-full flex items-center justify-between rounded border px-4 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary transition',
+            'w-full flex items-center justify-between bg-background',
             !value?.from && 'text-muted-foreground italic',
             className
           )}
@@ -34,7 +37,7 @@ export function DateRangePicker({ className, value, onChange }: Props) {
         >
           <span>{label}</span>
           <CalendarIcon className="h-4 w-4 text-gray-400" />
-        </button>
+        </Button>
       </PopoverTrigger>
 
       <PopoverContent className="p-0 mt-2 shadow-lg min-w-[500px]" align="start" side="bottom">

--- a/src/components/ui/IcoClose.tsx
+++ b/src/components/ui/IcoClose.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 /**
  * Animated “X” close button.
@@ -16,18 +17,17 @@ export default function CloseButton({
   title?: string;
 }) {
   return (
-    <button
+    <Button
       onClick={onClick}
       aria-label={title}
-      className="cursor-pointer bg-background relative group w-8 h-8 backdrop-blur-sm rounded
-          border border-bg-gray-200 hover:bg-gray-200
-          flex items-center justify-center focus:outline-none focus:ring-2
-          transition-transform hover:scale-110"
+      size="icon"
+      variant="ghost"
+      className="bg-background relative group w-8 h-8 backdrop-blur-sm rounded border border-bg-gray-200 hover:bg-gray-200 focus:outline-none focus:ring-2 transition-transform hover:scale-110"
     >
       <X
         size={20}
         className="transform transition duration-300 group-hover:scale-105 group-hover:rotate-90"
       />
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/IcoRemoveCard.tsx
+++ b/src/components/ui/IcoRemoveCard.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { FaTrashAlt } from 'react-icons/fa';
+import { Button } from '@/components/ui/button';
 
 /**
  * Floating round-red button used by cards that are already in the planner.
@@ -17,15 +18,14 @@ export default function RemoveCardButton({
   className?: string;
 }) {
   return (
-    <button
+    <Button
       onClick={onClick}
       aria-label={title}
-      className="cursor-pointer bg-background relative w-8 h-8 backdrop-blur-sm rounded
-          border border-bg-gray-200 hover:bg-gray-200
-          flex items-center justify-center focus:outline-none focus:ring-2
-          transition-transform duration-300 hover:scale-110"
+      size="icon"
+      variant="ghost"
+      className="bg-background relative w-8 h-8 backdrop-blur-sm rounded border border-bg-gray-200 hover:bg-gray-200 focus:outline-none focus:ring-2 transition-transform duration-300 hover:scale-110"
     >
       <FaTrashAlt size={18} className="transform transition duration-300 group:hover:scale-105" />
-    </button>
+    </Button>
   );
 }

--- a/src/components/ui/IcoSettingsToggle.tsx
+++ b/src/components/ui/IcoSettingsToggle.tsx
@@ -3,20 +3,19 @@
 
 import React from 'react';
 import { FaSlidersH } from 'react-icons/fa';
+import { Button } from '@/components/ui/button';
 
 /** Reusable animated button that toggles the config sidebar */
 export default function SettingsToggleButton({ onClick }: { onClick: () => void }) {
   return (
-    <button
+    <Button
       title="Toggle config"
       onClick={onClick}
-      className="
-        text-xl bg-background text-gray-600 hover:text-gray-800
-        transition-transform duration-300
-        transform hover:scale-110 hover:-rotate-90
-      "
+      size="icon"
+      variant="ghost"
+      className="text-xl bg-background text-gray-600 hover:text-gray-800 transition-transform duration-300 transform hover:scale-110 hover:-rotate-90"
     >
       <FaSlidersH />
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- refactor UI by replacing `<button>` elements with the shared `Button` component
- choose appropriate variants and sizes for each button instance
- adjust classes and imports accordingly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693bb4ed708322a4c50a37fd3f07bd