### PR TITLE
Add unique plan ID with local storage

### DIFF
--- a/src/hooks/usePlanner.ts
+++ b/src/hooks/usePlanner.ts
@@ -1,8 +1,8 @@
 // src/hooks/usePlanner.ts
 'use client';
 
-import { useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { closestCenter } from '@dnd-kit/core';
 
 import { useTripRange } from '@/hooks/useTripRange';
@@ -22,9 +22,20 @@ import { syncDaysWithTripRange } from '@/utils/syncDaysWithTripRange';
 export function usePlanner(enabled: boolean) {
   /* ----------------------- URL + date range ----------------------- */
   const params = useSearchParams();
+  const router = useRouter();
   const dest = params.get('dest')?.trim().toLowerCase() ?? '';
+  const [planId] = useState(() => params.get('plan') ?? crypto.randomUUID());
 
-  const { tripDays, currentRange, handleRangeChange } = useTripRange(dest);
+  /* Ensure the unique plan id is reflected in the URL */
+  useEffect(() => {
+    if (!params.get('plan')) {
+      const search = new URLSearchParams(params.toString());
+      search.set('plan', planId);
+      router.replace(`/planner?${search.toString()}`, { scroll: false });
+    }
+  }, [planId, params, router]);
+
+  const { tripDays, currentRange, handleRangeChange } = useTripRange(dest, planId);
   // only fetch itinerary when `enabled` is true
   const { isLoading, error } = useItinerary(dest, { enabled });
 
@@ -42,10 +53,35 @@ export function usePlanner(enabled: boolean) {
     addBlankActivity,
   } = useDnDPlanner(buildInitialDays(tripDays));
 
+  const storageKey = `itinerary-${planId}`;
+
+  /* ---------------------- Load from localStorage ---------------------- */
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(storageKey) : null;
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setDays(parsed);
+        }
+      } catch {
+        /* ignore invalid JSON */
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+
   /* ------------------ Sync days on trip range change ------------------ */
   useEffect(() => {
     setDays((prevDays) => syncDaysWithTripRange(prevDays, tripDays));
   }, [tripDays, setDays]);
+
+  /* ---------------------- Persist to localStorage --------------------- */
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, JSON.stringify(days));
+    }
+  }, [storageKey, days]);
 
   /* --------------------------- export ----------------------------- */
   return {

--- a/src/hooks/useTripRange.ts
+++ b/src/hooks/useTripRange.ts
@@ -6,7 +6,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { eachDayOfInterval, parseISO } from 'date-fns';
 import { DateRange } from 'react-day-picker';
 
-export function useTripRange(dest: string) {
+export function useTripRange(dest: string, planId?: string) {
   const params = useSearchParams();
   const router = useRouter();
 
@@ -24,10 +24,13 @@ export function useTripRange(dest: string) {
 
   function handleRangeChange(r: DateRange | undefined) {
     if (r?.from && r?.to) {
-      router.replace(
-        `/planner?dest=${dest}&start=${r.from.toISOString()}&end=${r.to.toISOString()}`,
-        { scroll: false }
-      );
+      const search = new URLSearchParams({
+        dest,
+        start: r.from.toISOString(),
+        end: r.to.toISOString(),
+      });
+      if (planId) search.set('plan', planId);
+      router.replace(`/planner?${search.toString()}`, { scroll: false });
     }
   }
 


### PR DESCRIPTION
## Summary
- persist itinerary locally using a unique `plan` id
- keep the `plan` id in the URL for future sharing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing type definitions)*
- `npm run test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc4942d508322bde3eca46f7a6ae1