### PR TITLE
Add insert-between button

### DIFF
--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -32,7 +32,7 @@ export interface PlannerBoardProps {
   /** Called when user clicks a card to edit */
   onSelectActivity: (activity: Activity) => void;
   /** Called when user clicks + New Card Button */
-  onAddNew: (dayId: string) => void;
+  onAddNew: (dayId: string, index?: number) => void;
   /** Inline title update */
   onUpdateTitle: (id: string, title: string) => void;
 }

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -99,9 +99,9 @@ export default function PlannerClient() {
           updateActivity(id, { title: newTitle });
         }}
         /* Create a blank activity and immediately open the modal */
-        onAddNew={(dayId) => {
+        onAddNew={(dayId, insertIdx) => {
           const idx = days.findIndex((d) => d.id === dayId);
-          const blank = addBlankActivity(idx);
+          const blank = addBlankActivity(idx, insertIdx);
           setSelectedActivity({ ...blank, dayId });
         }}
       />

--- a/src/components/planner/dnd/DayColumn.tsx
+++ b/src/components/planner/dnd/DayColumn.tsx
@@ -12,7 +12,7 @@ interface DayColumnProps {
   day: DayPlan;
   onRemove?: () => void;
   onSelectActivity?: (activity: Activity) => void;
-  onAddNew: (dayId: string) => void; // add a blank activity to this day
+  onAddNew: (dayId: string, index?: number) => void; // add a blank activity to this day
   onUpdateTitle?: (id: string, title: string) => void;
 }
 
@@ -39,21 +39,29 @@ export default function DayColumn({
         strategy={verticalListSortingStrategy}
       >
         <ul ref={setNodeRef} className={`space-y-3 mb-4 ${isOver ? 'ring-2 ring-primary/40' : ''}`}>
-          {day.activities.map((activity) => (
-            <SortableItem
-              key={activity.id}
-              id={activity.id}
-              activity={activity}
-              onSelect={() => onSelectActivity?.(activity)}
-              onTitleSave={(newTitle) => onUpdateTitle?.(activity.id, newTitle)}
-            />
+          {day.activities.map((activity, idx) => (
+            <React.Fragment key={activity.id}>
+              <SortableItem
+                id={activity.id}
+                activity={activity}
+                onSelect={() => onSelectActivity?.(activity)}
+                onTitleSave={(newTitle) => onUpdateTitle?.(activity.id, newTitle)}
+              />
+              {idx < day.activities.length - 1 && (
+                <AddNewCard
+                  dayId={day.id}
+                  index={idx + 1}
+                  onAddNew={onAddNew}
+                />
+              )}
+            </React.Fragment>
           ))}
         </ul>
       </SortableContext>
 
       {/* Add a “New card” button at the bottom */}
       <div className="flex justify-center">
-        <AddNewCard dayId={day.id} onAddNew={onAddNew} />
+        <AddNewCard dayId={day.id} index={day.activities.length} onAddNew={onAddNew} />
       </div>
     </section>
   );

--- a/src/components/ui/BtnAddNewCard.tsx
+++ b/src/components/ui/BtnAddNewCard.tsx
@@ -12,10 +12,11 @@ import {
 
 interface AddNewCardProps {
   dayId: string;
-  onAddNew: (dayId: string) => void;
+  index?: number;
+  onAddNew: (dayId: string, index?: number) => void;
 }
 
-export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
+export default function AddNewCard({ dayId, index, onAddNew }: AddNewCardProps) {
   const baseColor = DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX];
   const hoverColor = COLOR_HOVER_CLASSES[DEFAULT_NEW_CARD_COLOR_INDEX];
   const foregroundColor = COLOR_FOREGROUND_VALUES[DEFAULT_NEW_CARD_COLOR_INDEX];
@@ -24,7 +25,7 @@ export default function AddNewCard({ dayId, onAddNew }: AddNewCardProps) {
   return (
     <button
       type="button"
-      onClick={() => onAddNew(dayId)}
+      onClick={() => onAddNew(dayId, index)}
       className={`p-2 cursor-pointer ${borderColor} ${baseColor} bg-background ${hoverColor} flex items-center w-full h-10 rounded-lg transition`}
     >
       <Plus size={18} className="mr-2" style={{ color: foregroundColor }} />

--- a/src/hooks/useDnDPlanner.ts
+++ b/src/hooks/useDnDPlanner.ts
@@ -147,7 +147,7 @@ export function useDnDPlanner(initial: DayPlan[] = []) {
    * Pushes a completely blank activity onto the given day (by index).
    * Returns the newly created Activity so the caller can e.g. open an editor.
    */
-  function addBlankActivity(dayIndex = 0): Activity {
+  function addBlankActivity(dayIndex = 0, insertIndex?: number): Activity {
     const blank: Activity = {
       id: `blank-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       title: '',
@@ -164,7 +164,12 @@ export function useDnDPlanner(initial: DayPlan[] = []) {
           activities: [],
         };
       }
-      copy[dayIndex].activities.push(blank);
+      const acts = copy[dayIndex].activities;
+      if (insertIndex === undefined || insertIndex < 0 || insertIndex > acts.length) {
+        acts.push(blank);
+      } else {
+        acts.splice(insertIndex, 0, blank);
+      }
       return copy;
     });
     return blank;


### PR DESCRIPTION
## Summary
- add `index` parameter to `AddNewCard` for inserting
- render `AddNewCard` between activities in `DayColumn`
- allow specifying insertion index when adding blank cards
- pass index through `PlannerBoard` and `PlannerClient`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be5020cb08322bedea3e99882e454