### PR TITLE
Add AGENTS doc with repo guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Coding conventions
+
+- **Language**: All documentation, inline code comments, commit messages and PR descriptions must be written in English.
+- **Formatting**: Run `npm run format` before committing. The project uses Prettier with semicolons, single quotes and `printWidth` 100.
+- **Linting**: Ensure `npm run lint` passes.
+- **Tests**: Execute `npm run test` and make sure tests succeed.
+- **Commit style**: Use short, imperative, English commit messages. Prefix with `feat:`, `fix:`, `chore:`, etc. when applicable.
+


### PR DESCRIPTION
## Summary
- establish repository guidelines in a new `AGENTS.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c205d028483228e86cf291ba37233