### PR TITLE
Show onboarding per plan

### DIFF
--- a/src/app/planner/PlannerClient.test.tsx
+++ b/src/app/planner/PlannerClient.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import PlannerClient from './PlannerClient';
+
+let mockPlanId = 'plan1';
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    usePlanner: () => ({
+      planId: mockPlanId,
+      dest: 'rome',
+      days: [{ id: 'd1', label: 'Day 1', activities: [] }],
+      setDays: vi.fn(),
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      isLoading: false,
+      error: null,
+      activeId: null,
+      sensors: [],
+      collisionDetection: vi.fn(),
+      handleDragStart: vi.fn(),
+      handleDragOver: vi.fn(),
+      handleDragEnd: vi.fn(),
+      addActivity: vi.fn(),
+      removeActivity: vi.fn(),
+      updateActivity: vi.fn(),
+      addBlankActivity: vi.fn(),
+    }),
+    usePlanTitle: () => ({ title: 'Trip', setTitle: vi.fn() }),
+    useSelectedActivity: () => ({
+      selectedActivity: null,
+      setSelectedActivity: vi.fn(),
+      changeDay: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+      closeModal: vi.fn(),
+      save: vi.fn(),
+      deleteActivity: vi.fn(),
+      changeColor: vi.fn(),
+    }),
+    useActivitiesById: () => ({}),
+  };
+});
+
+vi.mock('@/app/planner/PlannerBoard', () => ({
+  default: () => <div data-testid="board" />,
+}));
+vi.mock('@/app/planner/BudgetPanel', () => ({
+  default: () => <div data-testid="budget" />,
+}));
+vi.mock('@/components', async () => {
+  const actual = await vi.importActual<typeof import('@/components')>('@/components');
+  return {
+    ...actual,
+    DestinationFilterPanel: () => null,
+    DateRangePicker: () => <div data-testid="date-picker" />,
+    OpenPanelButton: (props: any) => <button onClick={props.onClick}>Open</button>,
+    ModeToggleButton: () => <div data-testid="mode-toggle" />,
+    ActivityModal: () => null,
+    LoadingScreen: () => <div>Loading...</div>,
+  };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('PlannerClient onboarding', () => {
+  it('shows onboarding for a new plan id even if another plan was seen', () => {
+    localStorage.setItem('planner-onboarding-shown-plan1', 'true');
+    mockPlanId = 'plan2';
+    render(<PlannerClient />);
+    expect(screen.getAllByText('Your planner is ready').length).toBeGreaterThan(0);
+    expect(localStorage.getItem('planner-onboarding-shown-plan2')).toBe('true');
+  });
+});

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -56,12 +56,13 @@ export default function PlannerClient() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const seen = localStorage.getItem('planner-onboarding-shown');
+    const storageKey = `planner-onboarding-shown-${planId}`;
+    const seen = localStorage.getItem(storageKey);
     if (!seen) {
       setShowOnboarding(true);
-      localStorage.setItem('planner-onboarding-shown', 'true');
+      localStorage.setItem(storageKey, 'true');
     }
-  }, []);
+  }, [planId]);
 
   const {
     selectedActivity,


### PR DESCRIPTION
## Summary
- display onboarding per plan ID
- test onboarding logic across plan IDs

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_687c1986f7688322aa870d6c3ccf59f3