### PR TITLE
fix: keep focus when editing activities budget

### DIFF
--- a/src/components/budget/activities/ActivitiesBudget.test.tsx
+++ b/src/components/budget/activities/ActivitiesBudget.test.tsx
@@ -14,21 +14,33 @@ describe('ActivitiesBudget', () => {
     },
   ];
 
-  it('calls onUpdate when budget input loses focus', () => {
-    const onUpdate = vi.fn();
-    render(<ActivitiesBudget open days={days} onUpdate={onUpdate} onClose={() => {}} />);
-    const input = screen.getByPlaceholderText('Budget') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '50' } });
-    fireEvent.blur(input);
-    expect(onUpdate).toHaveBeenCalledWith('a1', 50);
-  });
-
   it('calls onClose when clicking outside the dialog', () => {
     const onClose = vi.fn();
     render(<ActivitiesBudget open days={days} onUpdate={() => {}} onClose={onClose} />);
     const dialog = screen.getByRole('dialog');
     fireEvent.click(dialog.parentElement as HTMLElement);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('allows moving focus between inputs without closing', () => {
+    const onClose = vi.fn();
+    const multiple: DayPlan[] = [
+      {
+        id: 'd1',
+        label: 'Day 1',
+        activities: [
+          { id: 'a1', title: 'Museum', color: '', budget: 10 },
+          { id: 'a2', title: 'Park', color: '', budget: 5 },
+        ],
+      },
+    ];
+    render(<ActivitiesBudget open days={multiple} onUpdate={() => {}} onClose={onClose} />);
+    const inputs = screen.getAllByPlaceholderText('Budget') as HTMLInputElement[];
+    fireEvent.focus(inputs[0]);
+    fireEvent.blur(inputs[0]);
+    fireEvent.focus(inputs[1]);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('saves all edited budgets when closing', () => {

--- a/src/components/budget/activities/ActivitiesBudget.tsx
+++ b/src/components/budget/activities/ActivitiesBudget.tsx
@@ -100,7 +100,6 @@ export default function ActivitiesBudget({ open, days, onUpdate, onClose }: Acti
                   labelId={`budget-${act.id}`}
                   value={inputs[act.id] ?? ''}
                   onValueChange={(v) => setInputs((prev) => ({ ...prev, [act.id]: v }))}
-                  onBlur={() => onUpdate(act.id, normalizeAmount(inputs[act.id] ?? '0'))}
                   inputSize="sm"
                   background="default"
                   placeholder="Budget"


### PR DESCRIPTION
## Summary
- remove blur handler from ActivitiesBudget inputs so focus switching doesn't close the popup
- add regression test ensuring focus can move between activity inputs

## Testing
- `npm run format`
- `npm run lint`
- `npx vitest run` *(fails: focus-trap requires tabbable node)*

------
https://chatgpt.com/codex/tasks/task_e_687ceff88afc8322b5189fb6e64c7710