### PR TITLE
Add rating and review sort options

### DIFF
--- a/src/components/planner/catalog/SortSelector.tsx
+++ b/src/components/planner/catalog/SortSelector.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-export const sortModes = ['A-Z', 'Price', 'Duration'] as const;
+export const sortModes = ['A-Z', 'Price', 'Duration', 'Rating', 'Reviews'] as const;
 export type SortMode = (typeof sortModes)[number]; // <- union type
 
 /** Tiny select used in DestinationFilterPanel */

--- a/src/hooks/catalog/useDestinationCatalog.test.ts
+++ b/src/hooks/catalog/useDestinationCatalog.test.ts
@@ -16,6 +16,8 @@ const activities = [
     image_url: '',
     price: '$15',
     category: 'outdoors',
+    rating: 4.2,
+    reviewcount: '100',
   },
   {
     id: '2',
@@ -25,6 +27,8 @@ const activities = [
     image_url: '',
     price: '$20',
     category: 'culture',
+    rating: 4.8,
+    reviewcount: '50',
   },
   {
     id: '3',
@@ -34,6 +38,8 @@ const activities = [
     image_url: '',
     price: '$5',
     category: 'outdoors',
+    rating: 3.9,
+    reviewcount: '150',
   },
 ];
 
@@ -80,6 +86,32 @@ describe('useDestinationCatalog', () => {
 
     act(() => {
       result.current.setSortMode('Duration');
+    });
+
+    expect(result.current.visibleItems.map((a) => a.name)).toEqual([
+      'City Walk',
+      'Beach Fun',
+      'Museum Tour',
+    ]);
+  });
+
+  it('sorts by rating and reviews', async () => {
+    const { result } = renderHook(() => useDestinationCatalog(true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.setSortMode('Rating');
+    });
+
+    expect(result.current.visibleItems.map((a) => a.name)).toEqual([
+      'Museum Tour',
+      'Beach Fun',
+      'City Walk',
+    ]);
+
+    act(() => {
+      result.current.setSortMode('Reviews');
     });
 
     expect(result.current.visibleItems.map((a) => a.name)).toEqual([

--- a/src/hooks/catalog/useDestinationCatalog.ts
+++ b/src/hooks/catalog/useDestinationCatalog.ts
@@ -61,6 +61,10 @@ export function useDestinationCatalog(isOpen: boolean, city = 'salvador') {
           return a.price.localeCompare(b.price);
         case 'Duration':
           return a.duration - b.duration;
+        case 'Rating':
+          return (b.rating ?? 0) - (a.rating ?? 0);
+        case 'Reviews':
+          return parseInt(b.reviewcount ?? '0', 10) - parseInt(a.reviewcount ?? '0', 10);
         default:
           return a.name.localeCompare(b.name);
       }


### PR DESCRIPTION
## Summary
- allow sorting catalog by rating and by review count
- test coverage for new sort modes

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf14d40fc8322a443d90de0a21a83