### PR TITLE
Add position change dropdowns

### DIFF
--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -30,6 +30,7 @@ export interface PlannerBoardProps {
   onAddActivity: (dayId: string, index?: number) => void;
   onUpdateTitle: (id: string, title: string) => void;
   onChangeDay: (activityId: string, dayId: string) => void;
+  onChangePosition: (activityId: string, index: number) => void;
   onChangeColor: (activityId: string, color: string) => void;
   onDelete: (activityId: string) => void;
 }
@@ -50,6 +51,7 @@ export default function PlannerBoard({
   onAddActivity,
   onUpdateTitle,
   onChangeDay,
+  onChangePosition,
   onChangeColor,
   onDelete,
 }: PlannerBoardProps) {
@@ -80,6 +82,7 @@ export default function PlannerBoard({
               onSelectActivity={onSelectActivity}
               onUpdateTitle={onUpdateTitle}
               onChangeDay={(activityId, dayId) => onChangeDay(activityId, dayId)}
+              onChangePosition={(activityId, idx) => onChangePosition(activityId, idx)}
               onChangeColor={(activityId, color) => onChangeColor(activityId, color)}
               onDelete={onDelete}
             />
@@ -94,6 +97,7 @@ export default function PlannerBoard({
             activity={active}
             availableDays={days}
             onChangeDay={(newDayId) => onChangeDay(active.id, newDayId)}
+            onChangePosition={(idx) => onChangePosition(active.id, idx)}
             onChangeColor={(newColor) => onChangeColor(active.id, newColor)}
             bgColor={active.color}
             onDelete={() => onDelete(active.id)}

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -66,6 +66,7 @@ export default function PlannerClient() {
     selectedActivity,
     setSelectedActivity,
     changeDay,
+    changePosition,
     addBlankAndSelect,
     closeModal,
     save,
@@ -160,6 +161,7 @@ export default function PlannerClient() {
           onUpdateTitle={(id, title) => updateActivity(id, { title })}
           onAddActivity={(dayId, insertIdx) => addBlankAndSelect(dayId, insertIdx)}
           onChangeDay={changeDay}
+          onChangePosition={changePosition}
           onChangeColor={(id, color) => changeColor(id, color)}
           onDelete={removeActivity}
         />
@@ -175,6 +177,7 @@ export default function PlannerClient() {
           onColorChange={(newColor) => changeColor(selectedActivity.id, newColor)}
           days={days}
           onChangeDay={(dayId) => changeDay(selectedActivity.id, dayId)}
+          onChangePosition={(idx) => changePosition(selectedActivity.id, idx)}
         />
       )}
       <OnboardingModal open={showOnboarding} onClose={() => setShowOnboarding(false)} />

--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -14,6 +14,7 @@ export interface ActivityCardProps {
   onSelect?: () => void;
   onTitleSave?: (newTitle: string) => void;
   onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
   availableDays: DayPlan[];
   bgColor: string;
   onChangeColor: (color: string) => void;
@@ -27,6 +28,7 @@ export default function ActivityCard({
   onSelect,
   onTitleSave,
   onChangeDay,
+  onChangePosition,
   onDelete,
   bgColor,
   onChangeColor,
@@ -150,6 +152,7 @@ export default function ActivityCard({
               bgColor={bgColor}
               onChangeColor={onChangeColor}
               onChangeDay={onChangeDay}
+              onChangePosition={onChangePosition}
               onSave={save}
               onCancel={cancel}
               onDelete={() => onDelete?.()}

--- a/src/components/planner/dnd/ActivityCardEditing.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.tsx
@@ -3,9 +3,15 @@
 
 import React, { useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { Palette, ArrowLeftRight, Trash2, Search } from 'lucide-react';
+import { Palette, ArrowLeftRight, ArrowUpDown, Trash2, Search } from 'lucide-react';
 import type { Activity, DayPlan, CatalogActivity } from '@/types';
-import { Button, CardColorsPopup, DayPickerPopup, CatalogSearchPopup } from '@/components';
+import {
+  Button,
+  CardColorsPopup,
+  DayPickerPopup,
+  CatalogSearchPopup,
+  PositionPickerPopup,
+} from '@/components';
 import { useCardPopups, useWindowSize, useFlexibleRef, useEscapeKey } from '@/hooks';
 import { cn } from '@/lib/utils';
 
@@ -15,6 +21,7 @@ interface Props {
   bgColor: string;
   onChangeColor: (color: string) => void;
   onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
   onSave: () => void;
   onCancel: () => void;
   onDelete: () => void;
@@ -30,6 +37,7 @@ export default function ActivityCardEditing({
   bgColor,
   onChangeColor,
   onChangeDay,
+  onChangePosition,
   onSave,
   onCancel,
   onDelete,
@@ -41,12 +49,16 @@ export default function ActivityCardEditing({
   const {
     colorButtonRef,
     dateButtonRef,
+    positionButtonRef,
     isColorPickerOpen,
     isDatePickerOpen,
+    isPositionPickerOpen,
     handleColorButtonClick,
     handleDateButtonClick,
+    handlePositionButtonClick,
     setIsColorPickerOpen,
     setIsDatePickerOpen,
+    setIsPositionPickerOpen,
   } = useCardPopups();
   const searchButtonRef = useFlexibleRef();
   const [isCatalogOpen, setIsCatalogOpen] = useState(false);
@@ -58,6 +70,10 @@ export default function ActivityCardEditing({
 
   const gap = 8;
   const buttonGroupWidth = buttonRect?.width ?? 160;
+
+  const currentDay = availableDays.find((d) => d.id === activity.dayId);
+  const currentIndex = currentDay?.activities.findIndex((a) => a.id === activity.id) ?? -1;
+  const totalPositions = currentDay?.activities.length ?? 0;
 
   const position =
     cardRect && window.innerWidth - cardRect.right - gap >= buttonGroupWidth ? 'right' : 'left';
@@ -95,7 +111,7 @@ export default function ActivityCardEditing({
             onClick={handleDateButtonClick}
           >
             <ArrowLeftRight className="size-4" aria-hidden="true" />
-            Move
+            Move Day
           </Button>
           <div className="relative mb-1">
             {isDatePickerOpen && availableDays?.length > 0 && (
@@ -109,6 +125,33 @@ export default function ActivityCardEditing({
                   }}
                   onClose={() => setIsDatePickerOpen(false)}
                   triggerRef={dateButtonRef}
+                />
+              </div>
+            )}
+          </div>
+
+          <Button
+            ref={positionButtonRef}
+            size="sm"
+            variant="icon"
+            type="button"
+            onClick={handlePositionButtonClick}
+          >
+            <ArrowUpDown className="size-4" aria-hidden="true" />
+            Move Position
+          </Button>
+          <div className="relative mb-1">
+            {isPositionPickerOpen && totalPositions > 0 && (
+              <div className="absolute top-1 left-full z-50">
+                <PositionPickerPopup
+                  total={totalPositions}
+                  selected={currentIndex}
+                  onSelect={(idx: number) => {
+                    onChangePosition(idx);
+                    setIsPositionPickerOpen(false);
+                  }}
+                  onClose={() => setIsPositionPickerOpen(false)}
+                  triggerRef={positionButtonRef}
                 />
               </div>
             )}
@@ -152,6 +195,7 @@ export default function ActivityCardEditing({
               setIsCatalogOpen((p) => !p);
               setIsColorPickerOpen(false);
               setIsDatePickerOpen(false);
+              setIsPositionPickerOpen(false);
             }}
           >
             <Search className="size-4" aria-hidden="true" />

--- a/src/components/planner/dnd/DayColumn.tsx
+++ b/src/components/planner/dnd/DayColumn.tsx
@@ -15,6 +15,7 @@ interface DayColumnProps {
   onAddActivity: (dayId: string, index?: number) => void;
   onUpdateTitle?: (id: string, title: string) => void;
   onChangeDay: (activityId: string, dayId: string) => void;
+  onChangePosition: (activityId: string, index: number) => void;
   onChangeColor: (activityId: string, color: string) => void;
   onDelete: (activityId: string) => void;
 }
@@ -30,6 +31,7 @@ export default function DayColumn({
   onAddActivity,
   onUpdateTitle,
   onChangeDay,
+  onChangePosition,
   onChangeColor,
   onDelete,
 }: DayColumnProps) {
@@ -60,6 +62,7 @@ export default function DayColumn({
                 onSelect={() => onSelectActivity?.({ ...activity, dayId: day.id })}
                 onTitleSave={(newTitle) => onUpdateTitle?.(activity.id, newTitle)}
                 onChangeDay={(newDayId) => onChangeDay(activity.id, newDayId)}
+                onChangePosition={(idx) => onChangePosition(activity.id, idx)}
                 onChangeColor={(newColor) => onChangeColor(activity.id, newColor)}
                 onDelete={() => onDelete(activity.id)}
                 bgColor={activity.color}

--- a/src/components/planner/dnd/SortableItem.tsx
+++ b/src/components/planner/dnd/SortableItem.tsx
@@ -18,6 +18,7 @@ export interface SortableItemProps {
   dragOverlay?: boolean;
   className?: string;
   onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
   onChangeColor: (color: string) => void;
   bgColor: string;
   onDelete: () => void;
@@ -30,6 +31,7 @@ export default function SortableItem({
   onSelect,
   onTitleSave,
   onChangeDay,
+  onChangePosition,
   onChangeColor,
   onDelete,
   bgColor,
@@ -46,6 +48,7 @@ export default function SortableItem({
           onSelect={onSelect}
           onTitleSave={onTitleSave}
           onChangeDay={onChangeDay}
+          onChangePosition={onChangePosition}
           onChangeColor={onChangeColor}
           onDelete={onDelete}
           bgColor={bgColor}
@@ -81,6 +84,7 @@ export default function SortableItem({
         onSelect={onSelect}
         onTitleSave={onTitleSave}
         onChangeDay={onChangeDay}
+        onChangePosition={onChangePosition}
         onChangeColor={onChangeColor}
         onDelete={onDelete}
         bgColor={bgColor}

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -18,6 +18,7 @@ interface ActivityModalProps {
   onColorChange: (color: string) => void;
   days: DayPlan[];
   onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
 }
 
 export default function ActivityModal({
@@ -30,6 +31,7 @@ export default function ActivityModal({
   onColorChange,
   days,
   onChangeDay,
+  onChangePosition,
 }: ActivityModalProps) {
   useEscapeKey({ onClose, isActive: open });
 
@@ -80,6 +82,7 @@ export default function ActivityModal({
             onColorChange={onColorChange}
             availableDays={days}
             onChangeDay={onChangeDay}
+            onChangePosition={onChangePosition}
             onCatalogSelect={handleCatalogSelect}
           />
           <ActivityModalForm activity={draft} onSave={onSave} color={color} />

--- a/src/components/planner/modal/ActivityModalHeader.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.tsx
@@ -15,6 +15,7 @@ import {
   CardColorButton,
   CardColorsPopup,
   DayPickerPopup,
+  PositionPickerPopup,
   CatalogSearchPopup,
   SearchCatalogButton,
 } from '@/components';
@@ -31,6 +32,7 @@ export default function ActivityModalHeader({
   onColorChange,
   availableDays,
   onChangeDay,
+  onChangePosition,
   onCatalogSelect,
 }: {
   activity: Activity & { dayId?: string };
@@ -40,17 +42,22 @@ export default function ActivityModalHeader({
   onColorChange: (color: string) => void;
   availableDays: DayPlan[];
   onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
   onCatalogSelect: (item: CatalogActivity) => void;
 }) {
   const {
     colorButtonRef,
     dateButtonRef,
+    positionButtonRef,
     isColorPickerOpen,
     isDatePickerOpen,
+    isPositionPickerOpen,
     handleColorButtonClick,
     handleDateButtonClick,
+    handlePositionButtonClick,
     setIsColorPickerOpen,
     setIsDatePickerOpen,
+    setIsPositionPickerOpen,
   } = useCardPopups();
   const searchButtonRef = useFlexibleRef();
   const [isCatalogOpen, setIsCatalogOpen] = useState(false);
@@ -63,6 +70,9 @@ export default function ActivityModalHeader({
   }, [activity.imageUrl]);
 
   const currentDayLabel = availableDays.find((d) => d.id === activity.dayId)?.label;
+  const currentDay = availableDays.find((d) => d.id === activity.dayId);
+  const currentIndex = currentDay?.activities.findIndex((a) => a.id === activity.id) ?? -1;
+  const totalPositions = currentDay?.activities.length ?? 0;
 
   return (
     <>
@@ -102,16 +112,28 @@ export default function ActivityModalHeader({
 
         {/* Header buttons */}
         <div className="relative z-10 flex items-center justify-between p-2">
-          <Button
-            ref={dateButtonRef}
-            size="sm"
-            variant="icon"
-            type="button"
-            onClick={handleDateButtonClick}
-          >
-            {currentDayLabel ?? 'Change Day'}
-            <ChevronDown className="size-4" aria-hidden="true" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              ref={dateButtonRef}
+              size="sm"
+              variant="icon"
+              type="button"
+              onClick={handleDateButtonClick}
+            >
+              {currentDayLabel ?? 'Change Day'}
+              <ChevronDown className="size-4" aria-hidden="true" />
+            </Button>
+            <Button
+              ref={positionButtonRef}
+              size="sm"
+              variant="icon"
+              type="button"
+              onClick={handlePositionButtonClick}
+            >
+              Change Position
+              <ChevronDown className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
           <div className="flex items-center gap-2">
             <RemoveCardButton onClick={onDelete} />
             <CardColorButton ref={colorButtonRef} onClick={handleColorButtonClick} />
@@ -122,6 +144,7 @@ export default function ActivityModalHeader({
                 setIsCatalogOpen((p) => !p);
                 setIsColorPickerOpen(false);
                 setIsDatePickerOpen(false);
+                setIsPositionPickerOpen(false);
               }}
             ></SearchCatalogButton>
 
@@ -156,6 +179,20 @@ export default function ActivityModalHeader({
               }}
               onClose={() => setIsDatePickerOpen(false)}
               triggerRef={dateButtonRef}
+            />
+          </div>
+        )}
+        {isPositionPickerOpen && totalPositions > 0 && (
+          <div className="absolute top-[3rem] left-[9rem] z-50">
+            <PositionPickerPopup
+              total={totalPositions}
+              selected={currentIndex}
+              onSelect={(idx: number) => {
+                onChangePosition(idx);
+                setIsPositionPickerOpen(false);
+              }}
+              onClose={() => setIsPositionPickerOpen(false)}
+              triggerRef={positionButtonRef}
             />
           </div>
         )}

--- a/src/components/ui/popups/PositionPickerPopup.tsx
+++ b/src/components/ui/popups/PositionPickerPopup.tsx
@@ -1,0 +1,61 @@
+// src/components/ui/popups/PositionPickerPopup.tsx
+'use client';
+
+import React, { useRef } from 'react';
+import FocusTrap from 'focus-trap-react';
+import { CloseButton } from '@/components';
+import { usePopupOutsideHandler, useEscapeKey } from '@/hooks';
+
+interface Props {
+  total: number;
+  selected?: number;
+  onSelect: (index: number) => void;
+  onClose: () => void;
+  triggerRef?: React.RefObject<HTMLElement>;
+}
+
+export default function PositionPickerPopup({
+  total,
+  selected,
+  onSelect,
+  onClose,
+  triggerRef,
+}: Props) {
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  usePopupOutsideHandler({ popupRef, triggerRef, onClose });
+  useEscapeKey({ onClose, triggerRef });
+
+  return (
+    <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true, escapeDeactivates: false }}>
+      <div
+        ref={popupRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="position-picker-popup-title"
+        tabIndex={-1}
+        className="w-[200px] bg-[var(--background)] rounded-lg shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <div className="flex items-center justify-between px-4 py-2 border-b">
+          <h3 id="position-picker-popup-title" className="font-bold">
+            Change Position
+          </h3>
+          <CloseButton onClick={onClose} />
+        </div>
+        <ul className="space-y-1">
+          {Array.from({ length: total }).map((_, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                onClick={() => onSelect(i)}
+                className={`w-full text-left rounded px-2 py-1 hover:bg-accent ${selected === i ? 'bg-accent' : ''}`}
+              >
+                {i + 1}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </FocusTrap>
+  );
+}

--- a/src/components/ui/popups/index.ts
+++ b/src/components/ui/popups/index.ts
@@ -4,3 +4,4 @@ export { default as CardColorsPopup } from './CardColorsPopup';
 export { default as DayPickerPopup } from './DayPickerPopup';
 export { default as InfoPopup } from './InfoPopup';
 export { default as CatalogSearchPopup } from './CatalogSearchPopup';
+export { default as PositionPickerPopup } from './PositionPickerPopup';

--- a/src/hooks/planner/useSelectedActivity.ts
+++ b/src/hooks/planner/useSelectedActivity.ts
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 import type { Activity, DayPlan } from '@/types';
-import { moveActivityToDay } from '@/utils';
+import { moveActivityToDay, moveActivityPosition } from '@/utils';
 
 /**
  * Manages the currently selected activity for editing in the planner.
@@ -82,10 +82,15 @@ export function useSelectedActivity(
     }
   };
 
+  const changePosition = (activityId: string, newIndex: number) => {
+    setDays((prev) => moveActivityPosition(prev, activityId, newIndex));
+  };
+
   return {
     selectedActivity,
     setSelectedActivity,
     changeDay,
+    changePosition,
     addBlankAndSelect,
     closeModal,
     save,

--- a/src/hooks/ui/useCardPopups.ts
+++ b/src/hooks/ui/useCardPopups.ts
@@ -12,28 +12,42 @@ import { useFlexibleRef } from './useFlexibleRef';
 export function useCardPopups() {
   const colorButtonRef = useFlexibleRef();
   const dateButtonRef = useFlexibleRef();
+  const positionButtonRef = useFlexibleRef();
 
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+  const [isPositionPickerOpen, setIsPositionPickerOpen] = useState(false);
 
   function handleColorButtonClick() {
     setIsColorPickerOpen((prev) => !prev);
     setIsDatePickerOpen(false);
+    setIsPositionPickerOpen(false);
   }
 
   function handleDateButtonClick() {
     setIsDatePickerOpen((prev) => !prev);
     setIsColorPickerOpen(false);
+    setIsPositionPickerOpen(false);
+  }
+
+  function handlePositionButtonClick() {
+    setIsPositionPickerOpen((prev) => !prev);
+    setIsColorPickerOpen(false);
+    setIsDatePickerOpen(false);
   }
 
   return {
     colorButtonRef,
     dateButtonRef,
+    positionButtonRef,
     isColorPickerOpen,
     setIsColorPickerOpen,
     isDatePickerOpen,
     setIsDatePickerOpen,
+    isPositionPickerOpen,
+    setIsPositionPickerOpen,
     handleColorButtonClick,
     handleDateButtonClick,
+    handlePositionButtonClick,
   } as const;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './formatDayPlan';
 export * from './initialDays';
 export * from './syncDaysWithTripRange';
 export * from './moveActivityToDay';
+export * from './moveActivityPosition';

--- a/src/utils/moveActivityPosition.test.ts
+++ b/src/utils/moveActivityPosition.test.ts
@@ -1,0 +1,23 @@
+// src/utils/moveActivityPosition.test.ts
+
+import { moveActivityPosition } from '@/utils/moveActivityPosition';
+import type { DayPlan, Activity } from '@/types';
+
+function build(id: string): Activity {
+  return { id, title: id.toUpperCase(), color: 'red' };
+}
+
+describe('moveActivityPosition', () => {
+  it('reorders activity within the same day without mutating input', () => {
+    const a1 = build('a1');
+    const a2 = build('a2');
+    const a3 = build('a3');
+    const days: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [a1, a2, a3] }];
+    const snapshot = JSON.parse(JSON.stringify(days));
+
+    const result = moveActivityPosition(days, 'a1', 2);
+
+    expect(days).toEqual(snapshot);
+    expect(result[0].activities.map((a) => a.id)).toEqual(['a2', 'a3', 'a1']);
+  });
+});

--- a/src/utils/moveActivityPosition.ts
+++ b/src/utils/moveActivityPosition.ts
@@ -1,0 +1,27 @@
+// src/utils/moveActivityPosition.ts
+
+import type { DayPlan } from '@/types';
+
+/**
+ * Moves an activity to a new index within its current day.
+ * Returns a new days array without mutating the input.
+ */
+export function moveActivityPosition(
+  days: DayPlan[],
+  activityId: string,
+  newIndex: number
+): DayPlan[] {
+  const copy = days.map((d) => ({ ...d, activities: [...d.activities] }));
+
+  for (const day of copy) {
+    const idx = day.activities.findIndex((a) => a.id === activityId);
+    if (idx !== -1) {
+      const [moved] = day.activities.splice(idx, 1);
+      const target = Math.max(0, Math.min(newIndex, day.activities.length));
+      day.activities.splice(target, 0, moved);
+      break;
+    }
+  }
+
+  return copy;
+}


### PR DESCRIPTION
## Summary
- allow moving cards to specific positions
- introduce `PositionPickerPopup`
- wire position changing through editing UI and modal
- support position popup state in `useCardPopups`
- expose new move utility

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfa9932ec832284da86b2c16466eb