### PR TITLE
Update tests with vitest import

### DIFF
--- a/src/components/budget/activities/ActivitiesBudget.test.tsx
+++ b/src/components/budget/activities/ActivitiesBudget.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ActivitiesBudget from './ActivitiesBudget';
 import type { DayPlan } from '@/types';
+import { vi } from 'vitest';
 
 describe('ActivitiesBudget', () => {
   const days: DayPlan[] = [

--- a/src/components/onboarding/OnboardingModal.test.tsx
+++ b/src/components/onboarding/OnboardingModal.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import OnboardingModal from './OnboardingModal';
 import { ONBOARDING_STEPS } from '@/constants';
+import { vi } from 'vitest';
 
 describe('OnboardingModal', () => {
   it('renders all onboarding steps when open', () => {

--- a/src/components/planner/catalog/DestinationFilterPanel.test.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import DestinationFilterPanel from './DestinationFilterPanel';
+import { vi } from 'vitest';
 
 const activities = [
   {

--- a/src/components/ui/popups/CatalogSearchPopup.test.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CatalogSearchPopup } from '@/components';
 import type { CatalogActivity } from '@/types';
+import { vi } from 'vitest';
 
 // Mock hooks used by CatalogSearchPopup
 const catalog: CatalogActivity[] = [

--- a/src/hooks/catalog/useDestinationCatalog.test.ts
+++ b/src/hooks/catalog/useDestinationCatalog.test.ts
@@ -2,6 +2,7 @@
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDestinationCatalog } from './useDestinationCatalog';
+import { vi } from 'vitest';
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/hooks/catalog/useDestinationFilter.test.tsx
+++ b/src/hooks/catalog/useDestinationFilter.test.tsx
@@ -2,6 +2,7 @@
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDestinationFilter } from './useDestinationFilter';
+import { vi } from 'vitest';
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/hooks/ui/useWindowSize.test.ts
+++ b/src/hooks/ui/useWindowSize.test.ts
@@ -3,6 +3,7 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { useWindowSize } from './useWindowSize';
+import { vi } from 'vitest';
 
 afterEach(() => {
   vi.restoreAllMocks();


### PR DESCRIPTION
## Summary
- include `vi` helper import in unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Your focus-trap must have at least one container with at least one tabbable node in it at all times)*

------
https://chatgpt.com/codex/tasks/task_e_687d1aab48748322ba82f84ea3d2115f