### PR TITLE
Refactor popups to use shared component

### DIFF
--- a/src/components/ui/popups/CardColorsPopup.tsx
+++ b/src/components/ui/popups/CardColorsPopup.tsx
@@ -2,10 +2,8 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import FocusTrap from 'focus-trap-react';
 import { DEFAULT_COLORS, COLOR_NAMES } from '@/constants';
-import { Button, CloseButton } from '@/components';
-import { usePopupOutsideHandler, useEscapeKey } from '@/hooks';
+import { Button, CloseButton, Popup } from '@/components';
 
 interface CardColorsPopupProps {
   imageUrl: string;
@@ -30,109 +28,90 @@ export default function CardColorsPopup({
 }: CardColorsPopupProps) {
   const [tempImageUrl, setTempImageUrl] = useState(imageUrl);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
-
-  usePopupOutsideHandler({
-    popupRef,
-    triggerRef,
-    onClose,
-  });
-
-  useEscapeKey({ onClose, triggerRef });
 
   return (
-    <FocusTrap
-      focusTrapOptions={{
-        clickOutsideDeactivates: true,
-        escapeDeactivates: false,
-      }}
+    <Popup
+      triggerRef={triggerRef}
+      onClose={onClose}
+      className="w-[304px]"
+      aria-labelledby="card-color-popup-title"
     >
-      <div
-        ref={popupRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="card-color-popup-title"
-        tabIndex={-1}
-        className="bg-[var(--background)] rounded-lg shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-4 py-2 border-b">
-          <h3 id="card-color-popup-title" className="font-bold">
-            Card Background
-          </h3>
-          <CloseButton onClick={onClose} />
+      <div className="flex items-center justify-between px-4 py-2 border-b">
+        <h3 id="card-color-popup-title" className="font-bold">
+          Card Background
+        </h3>
+        <CloseButton onClick={onClose} />
+      </div>
+      <div className="p-4 gap-4">
+        {tempImageUrl && (
+          <Button
+            size="sm"
+            variant="muted"
+            type="button"
+            className="cursor-pointer"
+            onClick={() => {
+              setTempImageUrl('');
+              onClearImage();
+            }}
+          >
+            Remove photo
+          </Button>
+        )}
+
+        {/* Color Section */}
+        <div className="my-4 py-4 border-b-1">
+          <span className="text-xs font-bold mb-1 block">Colors</span>
+          <div className="flex justify-between flex-wrap gap-2">
+            {colors.map((c) => {
+              const label = COLOR_NAMES[c] ?? c;
+              return (
+                <button
+                  key={c}
+                  onClick={() => onChangeColor(c)}
+                  className={`w-[31%] h-10 shadow-xl rounded-xs border-2 ${
+                    c.startsWith('#') ? '' : c
+                  } ${selectedColor === c ? 'ring-2 ring-primary' : 'border-background'}`}
+                  style={c.startsWith('#') ? { backgroundColor: c } : undefined}
+                  aria-label={label}
+                />
+              );
+            })}
+          </div>
         </div>
-        <div className="p-4 gap-4 w-[304px] bg-background rounded-lg shadow-xl">
-          {tempImageUrl && (
-            <Button
-              size="sm"
-              variant="muted"
-              type="button"
-              className="cursor-pointer"
-              onClick={() => {
-                setTempImageUrl('');
-                onClearImage();
-              }}
-            >
-              Remove photo
-            </Button>
-          )}
 
-          {/* Color Section */}
-          <div className="my-4 py-4 border-b-1">
-            <span className="text-xs font-bold mb-1 block">Colors</span>
-            <div className="flex justify-between flex-wrap gap-2">
-              {colors.map((c) => {
-                const label = COLOR_NAMES[c] ?? c;
-                return (
-                  <button
-                    key={c}
-                    onClick={() => onChangeColor(c)}
-                    className={`w-[31%] h-10 shadow-xl rounded-xs border-2 ${
-                      c.startsWith('#') ? '' : c
-                    } ${selectedColor === c ? 'ring-2 ring-primary' : 'border-background'}`}
-                    style={c.startsWith('#') ? { backgroundColor: c } : undefined}
-                    aria-label={label}
-                  />
-                );
-              })}
-            </div>
-          </div>
+        <div className="space-y-2">
+          <Button
+            size="sm"
+            variant="muted"
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Upload image
+          </Button>
 
-          <div className="space-y-2">
-            <Button
-              size="sm"
-              variant="muted"
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-            >
-              Upload image
-            </Button>
-
-            <input
-              id="upload-image"
-              name="upload-image"
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (!file) return;
-                const reader = new FileReader();
-                reader.onloadend = () => {
-                  if (reader.result) {
-                    const result = String(reader.result);
-                    setTempImageUrl(result);
-                    onChangeImage(result);
-                  }
-                };
-                reader.readAsDataURL(file);
-              }}
-              className="hidden"
-            />
-          </div>
+          <input
+            id="upload-image"
+            name="upload-image"
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onloadend = () => {
+                if (reader.result) {
+                  const result = String(reader.result);
+                  setTempImageUrl(result);
+                  onChangeImage(result);
+                }
+              };
+              reader.readAsDataURL(file);
+            }}
+            className="hidden"
+          />
         </div>
       </div>
-    </FocusTrap>
+    </Popup>
   );
 }

--- a/src/components/ui/popups/CatalogSearchPopup.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.tsx
@@ -1,10 +1,9 @@
 // src/components/ui/popups/CatalogSearchPopup.tsx
 'use client';
 
-import React, { useRef } from 'react';
-import FocusTrap from 'focus-trap-react';
-import { CloseButton, Spinner } from '@/components';
-import { usePopupOutsideHandler, useEscapeKey, useDestinationCatalog } from '@/hooks';
+import React from 'react';
+import { CloseButton, Spinner, Popup } from '@/components';
+import { useDestinationCatalog } from '@/hooks';
 import type { CatalogActivity } from '@/types';
 
 interface CatalogSearchPopupProps {
@@ -20,74 +19,58 @@ export default function CatalogSearchPopup({
   onClose,
   triggerRef,
 }: CatalogSearchPopupProps) {
-  const popupRef = useRef<HTMLDivElement>(null);
-
   const { visibleItems, search, setSearch, loading, error } = useDestinationCatalog(open);
 
-  usePopupOutsideHandler({ popupRef, triggerRef, onClose, isOpen: open });
-  useEscapeKey({ onClose, isActive: open, triggerRef });
-
-  if (!open) return null;
-
   return (
-    <FocusTrap
-      active={open}
-      focusTrapOptions={{
-        clickOutsideDeactivates: true,
-        escapeDeactivates: false,
-      }}
+    <Popup
+      open={open}
+      triggerRef={triggerRef}
+      onClose={onClose}
+      aria-labelledby="catalog-search-popup-title"
+      size="md"
     >
-      <div
-        ref={popupRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="catalog-search-popup-title"
-        tabIndex={-1}
-        className="w-72 bg-[var(--background)] rounded-lg shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
-      >
-        <div className="flex items-center justify-between px-4 py-2 border-b">
-          <h3 id="catalog-search-popup-title" className="font-bold">
-            Search Catalog
-          </h3>
-          <CloseButton onClick={onClose} />
-        </div>
-        <div className="p-2 space-y-2">
-          <input
-            id="catalog-search-input"
-            name="search"
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search"
-            className="w-full border rounded px-2 py-1 text-sm"
-          />
-          {loading && (
-            <div className="flex items-center gap-2 text-sm">
-              <Spinner className="size-4" />
-              <span>Loading...</span>
-            </div>
-          )}
-          {error && <p className="text-sm text-red-500">{error}</p>}
-          {!loading && !error && (
-            <ul className="max-h-60 overflow-y-auto space-y-1">
-              {visibleItems.map((item) => (
-                <li key={item.id}>
-                  <button
-                    type="button"
-                    className="w-full text-left rounded px-2 py-1 hover:bg-accent"
-                    onClick={() => {
-                      onSelect(item);
-                      onClose();
-                    }}
-                  >
-                    {item.name}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+      <div className="flex items-center justify-between px-4 py-2 border-b">
+        <h3 id="catalog-search-popup-title" className="font-bold">
+          Search Catalog
+        </h3>
+        <CloseButton onClick={onClose} />
       </div>
-    </FocusTrap>
+      <div className="p-2 space-y-2">
+        <input
+          id="catalog-search-input"
+          name="search"
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search"
+          className="w-full border rounded px-2 py-1 text-sm"
+        />
+        {loading && (
+          <div className="flex items-center gap-2 text-sm">
+            <Spinner className="size-4" />
+            <span>Loading...</span>
+          </div>
+        )}
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {!loading && !error && (
+          <ul className="max-h-60 overflow-y-auto space-y-1">
+            {visibleItems.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  className="w-full text-left rounded px-2 py-1 hover:bg-accent"
+                  onClick={() => {
+                    onSelect(item);
+                    onClose();
+                  }}
+                >
+                  {item.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Popup>
   );
 }

--- a/src/components/ui/popups/DayPickerPopup.tsx
+++ b/src/components/ui/popups/DayPickerPopup.tsx
@@ -1,11 +1,9 @@
 // src/components/ui/popups/DayPickerPopup.tsx
 'use client';
 
-import React, { useRef } from 'react';
-import FocusTrap from 'focus-trap-react';
+import React from 'react';
 import type { DayPlan } from '@/types';
-import { CloseButton } from '@/components';
-import { usePopupOutsideHandler, useEscapeKey } from '@/hooks';
+import { CloseButton, Popup } from '@/components';
 
 interface Props {
   days: DayPlan[];
@@ -16,53 +14,34 @@ interface Props {
 }
 
 export default function DayPickerPopup({ days, selected, onSelect, onClose, triggerRef }: Props) {
-  const popupRef = useRef<HTMLDivElement>(null);
-
-  usePopupOutsideHandler({
-    popupRef,
-    triggerRef,
-    onClose,
-  });
-
-  useEscapeKey({ onClose, triggerRef });
-
   return (
-    <FocusTrap
-      focusTrapOptions={{
-        clickOutsideDeactivates: true,
-        escapeDeactivates: false,
-      }}
+    <Popup
+      triggerRef={triggerRef}
+      onClose={onClose}
+      size="sm"
+      aria-labelledby="day-picker-popup-title"
     >
-      <div
-        ref={popupRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="day-picker-popup-title"
-        tabIndex={-1}
-        className="w-[200px] bg-[var(--background)] rounded-lg shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
-      >
-        <div className="flex items-center justify-between px-4 py-2 border-b">
-          <h3 id="day-picker-popup-title" className="font-bold">
-            Change Day
-          </h3>
-          <CloseButton onClick={onClose} />
-        </div>
-        <ul className="space-y-1">
-          {days.map((d) => (
-            <li key={d.id}>
-              <button
-                type="button"
-                onClick={() => onSelect(d.id)}
-                className={`w-full text-left rounded px-2 py-1 hover:bg-accent ${
-                  selected === d.id ? 'bg-accent' : ''
-                }`}
-              >
-                {d.label}
-              </button>
-            </li>
-          ))}
-        </ul>
+      <div className="flex items-center justify-between px-4 py-2 border-b">
+        <h3 id="day-picker-popup-title" className="font-bold">
+          Change Day
+        </h3>
+        <CloseButton onClick={onClose} />
       </div>
-    </FocusTrap>
+      <ul className="space-y-1">
+        {days.map((d) => (
+          <li key={d.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(d.id)}
+              className={`w-full text-left rounded px-2 py-1 hover:bg-accent ${
+                selected === d.id ? 'bg-accent' : ''
+              }`}
+            >
+              {d.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Popup>
   );
 }

--- a/src/components/ui/popups/PositionPickerPopup.tsx
+++ b/src/components/ui/popups/PositionPickerPopup.tsx
@@ -1,10 +1,8 @@
 // src/components/ui/popups/PositionPickerPopup.tsx
 'use client';
 
-import React, { useRef } from 'react';
-import FocusTrap from 'focus-trap-react';
-import { CloseButton } from '@/components';
-import { usePopupOutsideHandler, useEscapeKey } from '@/hooks';
+import React from 'react';
+import { CloseButton, Popup } from '@/components';
 
 interface Props {
   total: number;
@@ -21,41 +19,34 @@ export default function PositionPickerPopup({
   onClose,
   triggerRef,
 }: Props) {
-  const popupRef = useRef<HTMLDivElement>(null);
-
-  usePopupOutsideHandler({ popupRef, triggerRef, onClose });
-  useEscapeKey({ onClose, triggerRef });
-
   return (
-    <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true, escapeDeactivates: false }}>
-      <div
-        ref={popupRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="position-picker-popup-title"
-        tabIndex={-1}
-        className="w-[200px] bg-[var(--background)] rounded-lg shadow-xl focus:outline-none focus:ring-2 focus:ring-primary"
-      >
-        <div className="flex items-center justify-between px-4 py-2 border-b">
-          <h3 id="position-picker-popup-title" className="font-bold">
-            Change Position
-          </h3>
-          <CloseButton onClick={onClose} />
-        </div>
-        <ul className="space-y-1">
-          {Array.from({ length: total }).map((_, i) => (
-            <li key={i}>
-              <button
-                type="button"
-                onClick={() => onSelect(i)}
-                className={`w-full text-left rounded px-2 py-1 hover:bg-accent ${selected === i ? 'bg-accent' : ''}`}
-              >
-                {i + 1}
-              </button>
-            </li>
-          ))}
-        </ul>
+    <Popup
+      triggerRef={triggerRef}
+      onClose={onClose}
+      size="sm"
+      aria-labelledby="position-picker-popup-title"
+    >
+      <div className="flex items-center justify-between px-4 py-2 border-b">
+        <h3 id="position-picker-popup-title" className="font-bold">
+          Change Position
+        </h3>
+        <CloseButton onClick={onClose} />
       </div>
-    </FocusTrap>
+      <ul className="space-y-1">
+        {Array.from({ length: total }).map((_, i) => (
+          <li key={i}>
+            <button
+              type="button"
+              onClick={() => onSelect(i)}
+              className={`w-full text-left rounded px-2 py-1 hover:bg-accent ${
+                selected === i ? 'bg-accent' : ''
+              }`}
+            >
+              {i + 1}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Popup>
   );
 }


### PR DESCRIPTION
## Summary
- reuse `Popup` in CardColorsPopup
- reuse `Popup` in DayPickerPopup
- reuse `Popup` in CatalogSearchPopup
- reuse `Popup` in PositionPickerPopup

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Your focus-trap must have at least one container with at least one tabbable node in it at all times)*

------
https://chatgpt.com/codex/tasks/task_e_687d2a520834832293e3a3a3b592ff51