### PR TITLE
Add mock for focus-trap-react in tests

### DIFF
--- a/src/components/planner/dnd/ActivityCardEditing.test.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.test.tsx
@@ -54,7 +54,7 @@ describe('ActivityCardEditing', () => {
     });
 
     // day picker
-    const moveBtn = screen.getByRole('button', { name: /move/i });
+    const moveBtn = screen.getByRole('button', { name: /move day/i });
     fireEvent.click(moveBtn);
     await screen.findByRole('dialog', { name: /change day/i });
     const dayOption = screen.getByRole('button', { name: 'Day 2' });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: './vitest.setup.ts',
+    setupFiles: './vitest.setup.tsx',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,0 @@
-// vitest.setup.ts
-process.env.TZ = 'UTC';
-import '@testing-library/jest-dom';

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -1,0 +1,8 @@
+// vitest.setup.ts
+process.env.TZ = 'UTC';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+vi.mock('focus-trap-react', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));


### PR DESCRIPTION
## Summary
- mock FocusTrap in vitest setup to avoid runtime errors
- update setup file reference in Vitest config
- fix ActivityCardEditing test selector

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687d730c65f48322b837724a857ecb05