### PR TITLE
Expand FocusTrap options

### DIFF
--- a/src/components/budget/activities/ActivitiesBudget.tsx
+++ b/src/components/budget/activities/ActivitiesBudget.tsx
@@ -1,7 +1,7 @@
 // src/components/budget/activities/ActivitiesBudget.tsx
 'use client';
 
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { DollarSign } from 'lucide-react';
 import FocusTrap from 'focus-trap-react';
@@ -19,6 +19,8 @@ interface ActivitiesBudgetProps {
 
 export default function ActivitiesBudget({ open, days, onUpdate, onClose }: ActivitiesBudgetProps) {
   useEscapeKey({ onClose, isActive: open });
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const activities = useMemo(
     () => days.flatMap((day) => day.activities.map((a) => ({ ...a, dayLabel: day.label }))),
@@ -65,10 +67,12 @@ export default function ActivitiesBudget({ open, days, onUpdate, onClose }: Acti
           clickOutsideDeactivates: true,
           escapeDeactivates: false,
           initialFocus: false,
+          fallbackFocus: () => containerRef.current ?? document.body,
           tabbableOptions: { displayCheck: 'none' },
         }}
       >
         <div
+          ref={containerRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="activities-budget-title"

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -1,7 +1,7 @@
 // src/components/onboarding/OnboardingModal.tsx
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import FocusTrap from 'focus-trap-react';
 import ReactDOM from 'react-dom';
 import { OnboardingCarousel, CloseButton } from '@/components';
@@ -14,6 +14,8 @@ interface OnboardingModalProps {
 
 export default function OnboardingModal({ open, onClose }: OnboardingModalProps) {
   useEscapeKey({ onClose, isActive: open });
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   if (!open) return null;
 
@@ -28,9 +30,13 @@ export default function OnboardingModal({ open, onClose }: OnboardingModalProps)
           focusTrapOptions={{
             clickOutsideDeactivates: true,
             escapeDeactivates: false,
+            initialFocus: false,
+            fallbackFocus: () => containerRef.current ?? document.body,
+            tabbableOptions: { displayCheck: 'none' },
           }}
         >
           <div
+            ref={containerRef}
             role="dialog"
             aria-modal="true"
             aria-labelledby="onboarding-carousel-title"

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -1,7 +1,7 @@
 // src/components/planner/catalog/DestinationFilterPanel.tsx
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import FocusTrap from 'focus-trap-react';
 import { DestinationHeader, DestinationCardGrid, Spinner } from '@/components';
@@ -44,6 +44,8 @@ export default function DestinationFilterPanel({
 
   useEscapeKey({ onClose, isActive: isOpen });
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   if (!isOpen) return null;
 
   return ReactDOM.createPortal(
@@ -53,9 +55,13 @@ export default function DestinationFilterPanel({
         focusTrapOptions={{
           clickOutsideDeactivates: true,
           escapeDeactivates: false,
+          initialFocus: false,
+          fallbackFocus: () => containerRef.current ?? document.body,
+          tabbableOptions: { displayCheck: 'none' },
         }}
       >
         <div
+          ref={containerRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="destination-filter-title"

--- a/src/components/planner/dnd/ActivityCardEditing.test.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.test.tsx
@@ -54,7 +54,7 @@ describe('ActivityCardEditing', () => {
     });
 
     // day picker
-    const moveBtn = screen.getByRole('button', { name: /move/i });
+    const moveBtn = screen.getByRole('button', { name: /move day/i });
     fireEvent.click(moveBtn);
     await screen.findByRole('dialog', { name: /change day/i });
     const dayOption = screen.getByRole('button', { name: 'Day 2' });

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -1,7 +1,7 @@
 // src/components/planner/modal/ActivityModal.tsx
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import FocusTrap from 'focus-trap-react';
 import { ActivityModalHeader, ActivityModalForm } from '@/components';
@@ -35,6 +35,8 @@ export default function ActivityModal({
 }: ActivityModalProps) {
   useEscapeKey({ onClose, isActive: open });
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const [draft, setDraft] = useState(activity);
 
   useEffect(() => {
@@ -61,9 +63,13 @@ export default function ActivityModal({
         focusTrapOptions={{
           clickOutsideDeactivates: true,
           escapeDeactivates: false,
+          initialFocus: false,
+          fallbackFocus: () => containerRef.current ?? document.body,
+          tabbableOptions: { displayCheck: 'none' },
         }}
       >
         <div
+          ref={containerRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="activity-modal-title"

--- a/src/components/ui/popups/Popup.tsx
+++ b/src/components/ui/popups/Popup.tsx
@@ -62,7 +62,13 @@ export default function Popup({
   const popup = (
     <FocusTrap
       active={open}
-      focusTrapOptions={{ clickOutsideDeactivates: true, escapeDeactivates: false }}
+      focusTrapOptions={{
+        clickOutsideDeactivates: true,
+        escapeDeactivates: false,
+        initialFocus: false,
+        fallbackFocus: () => popupRef.current ?? document.body,
+        tabbableOptions: { displayCheck: 'none' },
+      }}
     >
       <div
         ref={popupRef}


### PR DESCRIPTION
## Summary
- update all FocusTrap usage to include fallback and tabbable options
- expose container refs for traps
- fix test selector for move day button

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687d7312d6048322b7836318179f4c7b