### PR TITLE
Add integration tests for planner features

### DIFF
--- a/src/stories/Page.tsx
+++ b/src/stories/Page.tsx
@@ -36,7 +36,7 @@ export const Page: React.FC = () => {
         <ul>
           <li>
             Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            &quot;args&quot; of child component stories
           </li>
           <li>
             Assemble data in the page component from your services. You can mock these services out

--- a/src/tests/integration/budgetSave.spec.tsx
+++ b/src/tests/integration/budgetSave.spec.tsx
@@ -1,0 +1,30 @@
+// src/tests/integration/budgetSave.spec.tsx
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useBudget } from '@/hooks/useBudget';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('budget persistence integration', () => {
+  it('saves budget and entries to localStorage', async () => {
+    const { result } = renderHook(() => useBudget('plan1', 0));
+
+    act(() => {
+      result.current.setBudget(200);
+      result.current.setDesc('Taxi');
+      result.current.setAmount(50);
+      result.current.handleAdd();
+    });
+
+    await waitFor(() =>
+      expect(localStorage.getItem('budget-plan1')).toBe(
+        JSON.stringify({
+          budget: 200,
+          entries: [{ description: 'Taxi', category: 'transport', amount: 50 }],
+        })
+      )
+    );
+  });
+});

--- a/src/tests/integration/dragAndDrop.spec.tsx
+++ b/src/tests/integration/dragAndDrop.spec.tsx
@@ -1,0 +1,37 @@
+// src/tests/integration/dragAndDrop.spec.tsx
+
+import { renderHook, act } from '@testing-library/react';
+import type { DragStartEvent, DragOverEvent } from '@dnd-kit/core';
+import { useDnDPlanner } from '@/hooks/useDnDPlanner';
+import type { DayPlan, Activity } from '@/types';
+
+describe('drag and drop integration', () => {
+  function setup(initial?: DayPlan[]) {
+    const a1: Activity = { id: 'a1', title: 'A1', color: 'red' };
+    const a2: Activity = { id: 'a2', title: 'A2', color: 'red' };
+    const b1: Activity = { id: 'b1', title: 'B1', color: 'red' };
+    const days: DayPlan[] = initial ?? [
+      { id: 'day1', label: 'Day 1', activities: [a1, a2] },
+      { id: 'day2', label: 'Day 2', activities: [b1] },
+    ];
+    const { result } = renderHook(() => useDnDPlanner(days));
+    return { result };
+  }
+
+  it('moves activity across days via drag events', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const overEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragOverEvent> as DragOverEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      result.current.handleDragOver(overEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+});

--- a/src/tests/integration/mapRender.spec.tsx
+++ b/src/tests/integration/mapRender.spec.tsx
@@ -1,0 +1,52 @@
+// src/tests/integration/mapRender.spec.tsx
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import MapView from '@/app/planner/MapView';
+import type { DayPlan } from '@/types';
+
+const map = { fitBounds: vi.fn() };
+const markers: Array<{ title?: string }> = [];
+
+vi.mock('react-leaflet', () => {
+  const React = require('react');
+  return {
+    MapContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    TileLayer: () => null,
+    Marker: (props: { title?: string }) => {
+      markers.push(props);
+      return null;
+    },
+    Polyline: () => null,
+    useMap: () => map,
+  };
+});
+
+vi.mock('leaflet', () => ({
+  __esModule: true,
+  default: {
+    divIcon: () => ({}),
+    latLngBounds: vi.fn(() => ({})),
+  },
+}));
+
+afterEach(() => {
+  map.fitBounds.mockClear();
+  markers.length = 0;
+});
+
+describe('map render integration', () => {
+  it('renders markers for activities', () => {
+    const days: DayPlan[] = [
+      {
+        id: 'd1',
+        label: 'Day 1',
+        activities: [{ id: 'a1', title: 'Walk', color: 'red', latitude: 1, longitude: 1 }],
+      },
+    ];
+
+    render(<MapView days={days} onSelectActivity={() => {}} />);
+    expect(markers[0].title).toBe('Walk');
+  });
+});


### PR DESCRIPTION
## Summary
- escape quotes in Storybook page
- add drag and drop integration spec
- add budget persistence integration spec
- add map render integration spec

## Testing
- `npm run lint`
- `npm run test` *(fails: Playwright browsers unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688695cc69108322abd4b24f5ba345d8