### PR TITLE
Add basic storybook stories

### DIFF
--- a/src/components/ActivityCard/ActivityCard.stories.tsx
+++ b/src/components/ActivityCard/ActivityCard.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ActivityCard } from '@/components';
+import type { Activity, DayPlan } from '@/types';
+
+const sampleActivity: Activity & { dayId?: string } = {
+  id: '1',
+  title: 'Visit museum',
+  color: 'red',
+  duration: 2,
+  budget: 20,
+  imageUrl: 'https://placehold.co/400x200',
+};
+
+const sampleDays: DayPlan[] = [
+  { id: 'd1', label: 'Day 1', activities: [] },
+  { id: 'd2', label: 'Day 2', activities: [] },
+];
+
+const meta = {
+  title: 'Components/ActivityCard',
+  component: ActivityCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ActivityCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    activity: sampleActivity,
+    availableDays: sampleDays,
+    onChangeDay: () => {},
+    onChangePosition: () => {},
+    bgColor: '',
+    onChangeColor: () => {},
+    onDelete: () => {},
+    onApplyCatalogItem: () => {},
+  },
+};

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Button } from '@/components';
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Click me',
+  },
+};

--- a/src/components/PlannerClient/PlannerClient.stories.tsx
+++ b/src/components/PlannerClient/PlannerClient.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import PlannerClient from '@/app/planner/PlannerClient';
+import Providers from '@/components/Providers';
+
+const meta = {
+  title: 'Components/PlannerClient',
+  component: PlannerClient,
+  decorators: [
+    (Story) => (
+      <Providers>
+        <Story />
+      </Providers>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof PlannerClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/Page.tsx
+++ b/src/stories/Page.tsx
@@ -36,7 +36,7 @@ export const Page: React.FC = () => {
         <ul>
           <li>
             Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            &quot;args&quot; of child component stories
           </li>
           <li>
             Assemble data in the page component from your services. You can mock these services out


### PR DESCRIPTION
## Summary
- add a story for the `Button` component
- add a story for `ActivityCard`
- add a story for `PlannerClient` wrapped with `Providers`
- fix lint error in example `Page` story

## Testing
- `npm run lint`
- `npm run test` *(fails: playwright browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_688695cbaf488322ba9a3719f4a1cc9a