### PR TITLE
Implement Geoapify search hook

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -370,6 +370,18 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** open/close, select options
 - **Performance notes:** none
 
+### CatalogSearchPopup
+
+- **Location:** `src/components/ui/popups/CatalogSearchPopup.tsx`
+- **Responsibility:** Search widget that queries `/api/search` for Geoapify places.
+- **Props:** `{ open, onSelect, onClose, triggerRef? }`
+- **State:** `search` string
+- **External Hooks:** `useGeoapifySearch`
+- **Side-effects:** none
+- **Accessibility:** labelled input, popup list
+- **Interactions:** type to search and pick a result
+- **Performance notes:** results fetched with React Query
+
 ---
 
 ## Planner Page Components

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -149,6 +149,27 @@ export function useDestinationAutocomplete(query: string);
 const { results } = useDestinationAutocomplete(search);
 ```
 
+### `useGeoapifySearch`
+
+_File: `src/hooks/useGeoapifySearch.ts`_
+
+```ts
+export function useGeoapifySearch(query: string);
+```
+
+- **Inputs**
+  - `query`: search text.
+- **Outputs**
+  Catalog `results`, loading and error flags.
+- **Lifecycle**
+  Fetches `/api/search?q=` when the query has at least 3 characters.
+- **Exceptions**
+  Sets an error state when the request fails.
+
+```ts
+const { results } = useGeoapifySearch(query);
+```
+
 ### `useActivitiesById`
 
 _File: `src/hooks/useActivitiesById.ts`_

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,22 @@
+// src/app/api/search/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchGeoapifySearch } from '@/lib/geoapify';
+
+/**
+ * API route that proxies Geoapify place search results.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q');
+  if (!q) {
+    return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
+  }
+
+  try {
+    const data = await fetchGeoapifySearch(q);
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to search.' }, { status: 500 });
+  }
+}

--- a/src/components/planner/dnd/ActivityCardEditing.test.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.test.tsx
@@ -4,7 +4,33 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import ActivityCardEditing from './ActivityCardEditing';
-import type { Activity, DayPlan } from '@/types';
+import type { Activity, DayPlan, CatalogActivity } from '@/types';
+
+vi.mock('@/components', async () => {
+  const actual = await vi.importActual<typeof import('@/components')>('@/components');
+  const stubItem: CatalogActivity = {
+    id: 'c1',
+    name: 'Stub Place',
+    description: 'info',
+    imageUrl: 'photo.jpg',
+    category: '',
+  };
+  function CatalogSearchPopup({
+    open,
+    onSelect,
+  }: {
+    open: boolean;
+    onSelect: (i: CatalogActivity) => void;
+  }) {
+    if (!open) return null;
+    return (
+      <div data-testid="catalog-popup">
+        <button onClick={() => onSelect(stubItem)}>Pick</button>
+      </div>
+    );
+  }
+  return { ...actual, CatalogSearchPopup };
+});
 
 function renderComponent() {
   const cardRef = React.createRef<HTMLDivElement>();
@@ -24,6 +50,7 @@ function renderComponent() {
     onSave: vi.fn(),
     onCancel: vi.fn(),
     onDelete: vi.fn(),
+    onApplyCatalogItem: vi.fn(),
     editedImageUrl: '',
     setEditedImageUrl: vi.fn(),
     cardRef,
@@ -61,5 +88,26 @@ describe('ActivityCardEditing', () => {
     const daySelect = screen.getByLabelText('Day');
     fireEvent.change(daySelect, { target: { value: 'd2' } });
     expect(onChangeDay).toHaveBeenCalledWith('d2');
+  });
+
+  it('selects catalog item and updates image', () => {
+    const { onApplyCatalogItem, setEditedImageUrl } = renderComponent();
+
+    const searchBtn = screen.getByRole('button', { name: /search catalog/i });
+    fireEvent.click(searchBtn);
+
+    const popup = screen.getByTestId('catalog-popup');
+    expect(popup).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Pick'));
+
+    expect(onApplyCatalogItem).toHaveBeenCalledWith({
+      id: 'c1',
+      name: 'Stub Place',
+      description: 'info',
+      imageUrl: 'photo.jpg',
+      category: '',
+    });
+    expect(setEditedImageUrl).toHaveBeenCalledWith('photo.jpg');
   });
 });

--- a/src/components/planner/modal/ActivityModalHeader.test.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.test.tsx
@@ -12,8 +12,8 @@ vi.mock('@/components', async () => {
   const stubItem: CatalogActivity = {
     id: '1',
     name: 'Stub Item',
-    description: '',
-    imageUrl: '',
+    description: 'desc',
+    imageUrl: 'img.png',
     category: '',
   };
   function CatalogSearchPopup({
@@ -71,7 +71,14 @@ it('opens catalog popup and selects an item', () => {
 
   fireEvent.click(screen.getByText('Pick Stub'));
 
-  expect(handleSelect).toHaveBeenCalledTimes(1);
+  expect(handleSelect).toHaveBeenCalledWith({
+    id: '1',
+    name: 'Stub Item',
+    description: 'desc',
+    imageUrl: 'img.png',
+    category: '',
+  });
+  expect(screen.getByAltText('Test')).toHaveAttribute('src', 'img.png');
   expect(screen.queryByTestId('catalog-popup')).not.toBeInTheDocument();
 });
 

--- a/src/components/ui/popups/CatalogSearchPopup.test.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.test.tsx
@@ -1,0 +1,33 @@
+// src/components/ui/popups/CatalogSearchPopup.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import CatalogSearchPopup from './CatalogSearchPopup';
+import type { CatalogActivity } from '@/types';
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    useGeoapifySearch: (query: string) => ({
+      results: query ? ([{ id: '1', name: 'Museum', category: 'sight' }] as CatalogActivity[]) : [],
+      loading: false,
+      error: false,
+    }),
+  };
+});
+
+describe('CatalogSearchPopup', () => {
+  it('renders search results and handles selection', () => {
+    const handleSelect = vi.fn();
+    render(<CatalogSearchPopup open onSelect={handleSelect} onClose={() => {}} />);
+
+    const input = screen.getByPlaceholderText('Search');
+    fireEvent.change(input, { target: { value: 'mus' } });
+
+    const itemBtn = screen.getByRole('button', { name: 'Museum' });
+    fireEvent.click(itemBtn);
+
+    expect(handleSelect).toHaveBeenCalledWith({ id: '1', name: 'Museum', category: 'sight' });
+  });
+});

--- a/src/components/ui/popups/CatalogSearchPopup.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { CloseButton, Spinner, Popup } from '@/components';
-import { useDestinationCatalog } from '@/hooks';
+import { useGeoapifySearch } from '@/hooks';
 import type { CatalogActivity } from '@/types';
 
 interface CatalogSearchPopupProps {
@@ -19,7 +19,8 @@ export default function CatalogSearchPopup({
   onClose,
   triggerRef,
 }: CatalogSearchPopupProps) {
-  const { visibleItems, search, setSearch, loading, error } = useDestinationCatalog(open);
+  const [search, setSearch] = React.useState('');
+  const { results, loading, error } = useGeoapifySearch(search);
 
   return (
     <Popup
@@ -57,7 +58,7 @@ export default function CatalogSearchPopup({
         {error && <p className="text-sm text-red-500">{error}</p>}
         {!loading && !error && (
           <ul className="max-h-60 space-y-1 overflow-y-auto">
-            {visibleItems.map((item) => (
+            {results.map((item) => (
               <li key={item.id}>
                 <button
                   type="button"

--- a/src/hooks/fetchSearch.ts
+++ b/src/hooks/fetchSearch.ts
@@ -1,0 +1,15 @@
+// src/hooks/fetchSearch.ts
+import type { CatalogActivity } from '@/types';
+
+/**
+ * Fetches catalog search results via the local API.
+ */
+export async function fetchSearch(query: string): Promise<CatalogActivity[]> {
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`/api/search?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to search: HTTP ${res.status}`);
+  }
+  const data: { activities: CatalogActivity[] } = await res.json();
+  return data.activities;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -24,6 +24,8 @@ export * from './useCatalog';
 export * from './useDestinationCatalog';
 export * from './useCatalogActivities';
 export * from './useDestinationAutocomplete';
+export * from './useGeoapifySearch';
 
 export { fetchAutocomplete } from './fetchAutocomplete';
 export { fetchCatalog, type CatalogApiResponse } from './fetchCatalog';
+export { fetchSearch } from './fetchSearch';

--- a/src/hooks/useGeoapifySearch.ts
+++ b/src/hooks/useGeoapifySearch.ts
@@ -1,0 +1,23 @@
+// src/hooks/useGeoapifySearch.ts
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchSearch } from '@/hooks/fetchSearch';
+import type { CatalogActivity } from '@/types';
+
+/**
+ * Runs a Geoapify place search when the query has 3+ characters.
+ */
+export function useGeoapifySearch(query: string) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['geoapify-search', query],
+    queryFn: () => fetchSearch(query),
+    enabled: query.length >= 3,
+  });
+
+  return {
+    results: data ?? ([] as CatalogActivity[]),
+    loading: isLoading,
+    error: isError,
+  };
+}

--- a/src/lib/geoapify.ts
+++ b/src/lib/geoapify.ts
@@ -228,3 +228,63 @@ export async function fetchGeoapifyCatalog(
 
   return { activities };
 }
+
+export async function fetchGeoapifyPlaceDetails(placeId: string) {
+  const key = process.env.GEOAPIFY_KEY;
+  if (!key) throw new Error('GEOAPIFY_KEY not set');
+
+  const details = await fetchPlaceDetails(placeId, key);
+  const description =
+    details?.features?.[0]?.properties?.wikipedia_extracts?.text ||
+    details?.features?.[0]?.properties?.details?.wikipedia_extracts?.text ||
+    details?.features?.[0]?.properties?.description;
+
+  const img = await resolveBestImage(placeId, key);
+  const lat = details?.features?.[0]?.properties?.lat;
+  const lon = details?.features?.[0]?.properties?.lon;
+  const imageUrl =
+    img?.url || (lat != null && lon != null ? staticMapThumbnail(lat, lon, key) : undefined);
+
+  return { description, imageUrl };
+}
+
+export async function fetchGeoapifySearch(
+  text: string
+): Promise<{ activities: CatalogActivity[] }> {
+  const key = process.env.GEOAPIFY_KEY;
+  if (!key) throw new Error('GEOAPIFY_KEY not set');
+
+  const base = 'https://api.geoapify.com/v2/places';
+  const url =
+    `${base}?` +
+    `name=${encodeURIComponent(text)}` +
+    `&categories=${encodeURIComponent(DEFAULT_CATEGORIES)}` +
+    `&limit=10&lang=pt&apiKey=${key}`;
+
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`Geoapify request failed: ${res.status}`);
+  }
+
+  const data = (await res.json()) as GeoapifyResponse;
+  const activities: CatalogActivity[] = [];
+  for (const f of data.features) {
+    const p = f.properties;
+    activities.push({
+      id: String(p.place_id),
+      name: p.name || p.formatted || text,
+      category: p.categories?.[0] ?? 'sight',
+      rating: p.rank?.popularity,
+      latitude: p.lat,
+      longitude: p.lon,
+    });
+  }
+
+  for (const act of activities) {
+    const details = await fetchGeoapifyPlaceDetails(act.id);
+    if (details.description) act.description = details.description;
+    if (details.imageUrl) act.imageUrl = details.imageUrl;
+  }
+
+  return { activities };
+}


### PR DESCRIPTION
## Summary
- add new `fetchGeoapifySearch` and `fetchGeoapifyPlaceDetails` helpers
- expose `/api/search` endpoint
- implement `useGeoapifySearch` hook with fetch helper
- update `CatalogSearchPopup` to use the hook
- adjust Activity modal tests for catalog details
- add tests for catalog popup
- document new hook and component

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888517bedf08322ab5ff772be1f6060