### PR TITLE
Add address field to activities

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -291,7 +291,8 @@ This document summarizes each React component in the repository. It follows the 
 - **External Hooks:** `useEscapeKey`
 - **Side-effects:** portal rendering, updates draft when activity changes
 - **Accessibility:** focus trap, ARIA labels, keyboard shortcuts
-- **Interactions:** edit fields, change day/position, pick color
+- **Interactions:** edit fields (title, address, notes), change day/position, pick color
+  - Address field provides Geoapify autocomplete suggestions while typing.
 - **Performance notes:** none
 
 ---

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -231,6 +231,7 @@ export default function PlannerClient() {
           addActivity({
             id: item.id,
             title: item.name,
+            address: item.address,
             latitude: item.latitude,
             longitude: item.longitude,
             color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,

--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -108,6 +108,7 @@ export default function ActivityCard({
             onSave={save}
             inputRef={inputRef}
             imageUrl={imageUrl}
+            address={activity.address}
             duration={duration}
             twBg={twBg}
             budget={budget}
@@ -149,6 +150,7 @@ export default function ActivityCard({
               onSave={save}
               inputRef={inputRef}
               imageUrl={editedImageUrl}
+              address={activity.address}
               duration={duration}
               twBg={twBg}
               budget={budget}

--- a/src/components/planner/dnd/ActivityCardBase.tsx
+++ b/src/components/planner/dnd/ActivityCardBase.tsx
@@ -8,6 +8,7 @@ import { EMPTY_ACTIVITY_TITLE } from '@/constants';
 
 interface ActivityCardBaseProps {
   title: string;
+  address?: string;
   draftTitle?: string;
   onDraftTitleChange?: (value: string) => void;
   onSave?: () => void;
@@ -22,6 +23,7 @@ interface ActivityCardBaseProps {
 
 export default function ActivityCardBase({
   title,
+  address,
   draftTitle,
   onDraftTitleChange,
   onSave,
@@ -82,7 +84,10 @@ export default function ActivityCardBase({
             style={{ verticalAlign: 'top' }}
           />
         ) : (
-          <h4 className="px-2 py-1 text-sm">{title.trim() ? title : EMPTY_ACTIVITY_TITLE}</h4>
+          <>
+            <h4 className="px-2 py-1 text-sm">{title.trim() ? title : EMPTY_ACTIVITY_TITLE}</h4>
+            {address && <p className="text-muted-foreground px-2 pb-1 text-xs">{address}</p>}
+          </>
         )}
 
         {/* Meta */}

--- a/src/components/planner/dnd/ActivityCardEditing.test.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/components', async () => {
     name: 'Stub Place',
     description: 'info',
     imageUrl: 'photo.jpg',
+    address: 'Street',
     category: '',
   };
   function CatalogSearchPopup({
@@ -107,6 +108,7 @@ describe('ActivityCardEditing', () => {
       name: 'Stub Place',
       description: 'info',
       imageUrl: 'photo.jpg',
+      address: 'Street',
       category: '',
     });
     expect(setEditedImageUrl).toHaveBeenCalledWith('photo.jpg');

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -50,6 +50,7 @@ export default function ActivityModal({
       ...prev,
       title: item.name,
       description: item.description,
+      address: item.address,
       imageUrl: item.imageUrl,
       category: item.category,
     }));

--- a/src/components/planner/modal/ActivityModalForm.test.tsx
+++ b/src/components/planner/modal/ActivityModalForm.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import ActivityModalForm from './ActivityModalForm';
+import type { Activity } from '@/types';
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    useDestinationAutocomplete: () => ({
+      results: [{ name: 'Rome, Italy', latitude: 0, longitude: 0 }],
+      loading: false,
+      error: false,
+    }),
+  };
+});
+
+describe('ActivityModalForm', () => {
+  it('saves edited address', () => {
+    const activity: Activity = { id: 'a1', title: 'Visit', color: '' };
+    const onSave = vi.fn();
+    render(<ActivityModalForm activity={activity} onSave={onSave} color="" />);
+    const addressInput = screen.getByLabelText('Address');
+    fireEvent.change(addressInput, { target: { value: 'Ro' } });
+    const option = screen.getByRole('button', { name: 'Rome, Italy' });
+    fireEvent.mouseDown(option);
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ address: 'Rome, Italy' }));
+  });
+});

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -7,7 +7,8 @@ import { DollarSign, Hourglass } from 'lucide-react';
 
 import type { Activity } from '@/types';
 import { EMPTY_ACTIVITY_TITLE } from '@/constants';
-import { UpdateButton, Input } from '@/components';
+import { UpdateButton, Input, Spinner } from '@/components';
+import { useDestinationAutocomplete } from '@/hooks';
 
 interface ActivityModalFormProps {
   activity: Activity;
@@ -18,13 +19,18 @@ interface ActivityModalFormProps {
 export default function ActivityModalForm({ activity, onSave, color }: ActivityModalFormProps) {
   const [editedTitle, setEditedTitle] = useState(activity.title);
   const [editedDescription, setEditedDescription] = useState(activity.description ?? '');
+  const [editedAddress, setEditedAddress] = useState(activity.address ?? '');
   const [duration, setDuration] = useState<number>(activity.duration || 0);
   const [budget, setBudget] = useState<number>(activity.budget || 0);
+  const { results: addressResults, loading: addressLoading } =
+    useDestinationAutocomplete(editedAddress);
+  const [addressOpen, setAddressOpen] = useState(false);
 
   // Update internal state when the activity prop changes
   useEffect(() => {
     setEditedTitle(activity.title);
     setEditedDescription(activity.description ?? '');
+    setEditedAddress(activity.address ?? '');
     setDuration(activity.duration || 0);
     setBudget(activity.budget || 0);
   }, [activity]);
@@ -54,6 +60,45 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
         aria-required="true"
         className="focus:ring-primary mx-4 mb-4 content-center rounded px-2 py-2 text-2xl font-bold focus:ring-2 focus:ring-offset-2 focus:outline-none"
       />
+
+      {/* Address */}
+      <div className="relative mx-4 mb-4">
+        <label htmlFor="activity-address" className="mb-1 block text-xs font-bold">
+          Address
+        </label>
+        <input
+          id="activity-address"
+          type="text"
+          value={editedAddress}
+          onChange={(e) => {
+            setEditedAddress(e.target.value);
+            setAddressOpen(true);
+          }}
+          onBlur={() => setAddressOpen(false)}
+          className="focus:ring-primary w-full rounded px-2 py-1 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none"
+          placeholder="Location"
+          autoComplete="off"
+        />
+        {addressLoading && <Spinner className="absolute top-1 right-1 size-4" />}
+        {addressOpen && addressResults.length > 0 && (
+          <ul className="bg-background absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded border text-sm shadow">
+            {addressResults.map((r) => (
+              <li key={`${r.latitude}-${r.longitude}`}>
+                <button
+                  type="button"
+                  className="hover:bg-accent w-full px-2 py-1 text-left"
+                  onMouseDown={() => {
+                    setEditedAddress(r.name);
+                    setAddressOpen(false);
+                  }}
+                >
+                  {r.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       {/* Duration & Budget group */}
       <fieldset className="mb-4 flex gap-2 px-4" aria-labelledby="time-budget-legend">
@@ -121,6 +166,7 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
             onSave({
               title: editedTitle.trim(),
               description: editedDescription,
+              address: editedAddress,
               color,
               duration: Number(duration),
               budget,

--- a/src/components/planner/modal/ActivityModalHeader.test.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.test.tsx
@@ -14,6 +14,7 @@ vi.mock('@/components', async () => {
     name: 'Stub Item',
     description: 'desc',
     imageUrl: 'img.png',
+    address: 'Some street',
     category: '',
   };
   function CatalogSearchPopup({
@@ -79,6 +80,7 @@ it('opens catalog popup and selects an item', () => {
     name: 'Stub Item',
     description: 'desc',
     imageUrl: 'img.png',
+    address: 'Some street',
     category: '',
   });
   expect(screen.getByAltText('Test')).toHaveAttribute('src', 'img.png');

--- a/src/lib/geoapify.ts
+++ b/src/lib/geoapify.ts
@@ -203,6 +203,7 @@ export async function fetchGeoapifyCatalog(
     const base: CatalogActivity = {
       id,
       name: p.name || p.formatted || 'Ponto turístico',
+      address: p.formatted,
       category: p.categories?.[0] ?? 'sight',
       rating: p.rank?.popularity,
       latitude: p.lat,
@@ -273,6 +274,7 @@ export async function fetchGeoapifySearch(
     activities.push({
       id: String(p.place_id),
       name: p.name || p.formatted || text,
+      address: p.formatted,
       category: p.categories?.[0] ?? 'sight',
       rating: p.rank?.popularity,
       latitude: p.lat,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,8 @@ export interface Activity {
   title: string;
   color: string;
   description?: string;
+  /** Optional street address */
+  address?: string;
   duration?: number;
   startTime?: string;
   imageUrl?: string;
@@ -27,6 +29,8 @@ export interface CatalogActivity {
   name: string;
   category: string;
   description?: string;
+  /** Formatted address if available */
+  address?: string;
   imageUrl?: string;
   rating?: number;
   latitude?: number;


### PR DESCRIPTION
## Summary
- extend Activity and CatalogActivity with optional address
- include formatted address when fetching from Geoapify
- pass address through catalog functions and planner client
- show address on activity cards
- allow editing address in ActivityModalForm with autocomplete
- test ActivityModalForm address behaviour
- update existing tests and docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888617bac4483229af24bc7d1bdb734