### PR TITLE
Update image editing handlers

### DIFF
--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -16,7 +16,7 @@ import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 
 import { DayColumn, SortableItem, DragOverlayFallback } from '@/components';
 import { useActivitiesById } from '@/hooks';
-import type { Activity, DayPlan } from '@/types';
+import type { Activity, DayPlan, CatalogActivity } from '@/types';
 
 export interface PlannerBoardProps {
   days: DayPlan[];
@@ -34,6 +34,8 @@ export interface PlannerBoardProps {
   onChangePosition: (activityId: string, index: number) => void;
   onChangeColor: (activityId: string, color: string) => void;
   onDelete: (activityId: string) => void;
+  onUpdateImage?: (activityId: string, url: string) => void;
+  onApplyCatalogItem?: (activityId: string, item: CatalogActivity) => void;
 }
 
 /**
@@ -56,6 +58,8 @@ export default function PlannerBoard({
   onChangePosition,
   onChangeColor,
   onDelete,
+  onUpdateImage,
+  onApplyCatalogItem,
 }: PlannerBoardProps) {
   const byId = useActivitiesById(days);
   const active = activeId ? byId[activeId] : null;
@@ -88,6 +92,8 @@ export default function PlannerBoard({
               onChangePosition={(activityId, idx) => onChangePosition(activityId, idx)}
               onChangeColor={(activityId, color) => onChangeColor(activityId, color)}
               onDelete={onDelete}
+              onUpdateImage={onUpdateImage}
+              onApplyCatalogItem={onApplyCatalogItem}
             />
           </div>
         ))}
@@ -105,6 +111,8 @@ export default function PlannerBoard({
             onChangeColor={(newColor) => onChangeColor(active.id, newColor)}
             bgColor={active.color}
             onDelete={() => onDelete(active.id)}
+            onUpdateImage={(url) => onUpdateImage?.(active.id, url)}
+            onApplyCatalogItem={(item) => onApplyCatalogItem?.(active.id, item)}
             aria-grabbed="true"
             aria-label={`Dragging ${active.title}`}
           />

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -81,6 +81,15 @@ export default function PlannerClient() {
     addBlankActivity,
   });
 
+  const handleUpdateImage = (id: string, url: string) => {
+    updateActivity(id, { imageUrl: url });
+    setSelectedActivity((prev) => (prev && prev.id === id ? { ...prev, imageUrl: url } : prev));
+  };
+
+  const handleApplyCatalogItem = (id: string, item: CatalogActivity) => {
+    handleUpdateImage(id, item.imageUrl || '');
+  };
+
   // Build a Set of activity IDs already placed on the board
   const activitiesById = useActivitiesById(days);
   const addedIds = useMemo(() => new Set(Object.keys(activitiesById)), [activitiesById]);
@@ -188,6 +197,8 @@ export default function PlannerClient() {
                     onChangeDay={changeDay}
                     onChangePosition={changePosition}
                     onChangeColor={(id, color) => changeColor(id, color)}
+                    onUpdateImage={handleUpdateImage}
+                    onApplyCatalogItem={handleApplyCatalogItem}
                     onDelete={removeActivity}
                   />
                 )}

--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -19,6 +19,7 @@ export interface ActivityCardProps {
   onChangeColor: (color: string) => void;
   onDelete: () => void;
   onApplyCatalogItem?: (item: CatalogActivity) => void;
+  onUpdateImage?: (url: string) => void;
   dest: string;
 }
 
@@ -33,6 +34,7 @@ export default function ActivityCard({
   bgColor,
   onChangeColor,
   onApplyCatalogItem,
+  onUpdateImage,
   dest,
 }: ActivityCardProps) {
   const { title, duration, budget, color, imageUrl } = activity;
@@ -147,7 +149,10 @@ export default function ActivityCard({
               title={title}
               draftTitle={draft}
               onDraftTitleChange={setDraft}
-              onSave={save}
+              onSave={(url) => {
+                onUpdateImage?.(url);
+                save();
+              }}
               inputRef={inputRef}
               imageUrl={editedImageUrl}
               address={activity.address}
@@ -164,10 +169,16 @@ export default function ActivityCard({
               onChangeColor={onChangeColor}
               onChangeDay={onChangeDay}
               onChangePosition={onChangePosition}
-              onSave={save}
+              onSave={(url) => {
+                onUpdateImage?.(url);
+                save();
+              }}
               onCancel={cancel}
               onDelete={onDelete}
-              onApplyCatalogItem={onApplyCatalogItem}
+              onApplyCatalogItem={(item) => {
+                onApplyCatalogItem?.(item);
+                setEditedImageUrl(item.imageUrl || '');
+              }}
               editedImageUrl={editedImageUrl}
               setEditedImageUrl={setEditedImageUrl}
               dest={dest}

--- a/src/components/planner/dnd/ActivityCardEditing.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.tsx
@@ -16,7 +16,7 @@ interface Props {
   onChangeColor: (color: string) => void;
   onChangeDay: (dayId: string) => void;
   onChangePosition: (index: number) => void;
-  onSave: () => void;
+  onSave: (imageUrl: string) => void;
   onCancel: () => void;
   onDelete: () => void;
   onApplyCatalogItem?: (item: CatalogActivity) => void;
@@ -81,7 +81,12 @@ export default function ActivityCardEditing({
   return (
     <>
       <div className="relative z-50 mt-2 flex">
-        <Button type="button" size="sm" className="cursor-pointer" onClick={onSave}>
+        <Button
+          type="button"
+          size="sm"
+          className="cursor-pointer"
+          onClick={() => onSave(editedImageUrl)}
+        >
           Update
         </Button>
       </div>

--- a/src/components/planner/dnd/DayColumn.tsx
+++ b/src/components/planner/dnd/DayColumn.tsx
@@ -6,7 +6,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useDroppable } from '@dnd-kit/core';
 
 import { SortableItem, AddCardButton } from '@/components';
-import type { DayPlan, Activity } from '@/types';
+import type { DayPlan, Activity, CatalogActivity } from '@/types';
 
 interface DayColumnProps {
   day: DayPlan;
@@ -19,6 +19,8 @@ interface DayColumnProps {
   onChangePosition: (activityId: string, index: number) => void;
   onChangeColor: (activityId: string, color: string) => void;
   onDelete: (activityId: string) => void;
+  onUpdateImage?: (activityId: string, url: string) => void;
+  onApplyCatalogItem?: (activityId: string, item: CatalogActivity) => void;
 }
 
 /**
@@ -36,6 +38,8 @@ export default function DayColumn({
   onChangePosition,
   onChangeColor,
   onDelete,
+  onUpdateImage,
+  onApplyCatalogItem,
 }: DayColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: day.id });
 
@@ -68,6 +72,8 @@ export default function DayColumn({
                 onChangePosition={(idx) => onChangePosition(activity.id, idx)}
                 onChangeColor={(newColor) => onChangeColor(activity.id, newColor)}
                 onDelete={() => onDelete(activity.id)}
+                onUpdateImage={(url) => onUpdateImage?.(activity.id, url)}
+                onApplyCatalogItem={(item) => onApplyCatalogItem?.(activity.id, item)}
                 bgColor={activity.color}
               />
               {idx < day.activities.length - 1 && (

--- a/src/components/planner/dnd/SortableItem.tsx
+++ b/src/components/planner/dnd/SortableItem.tsx
@@ -7,7 +7,7 @@ import { useSortable } from '@dnd-kit/sortable';
 
 import { cn } from '@/lib';
 import { ActivityCard } from '@/components';
-import type { Activity, DayPlan } from '@/types';
+import type { Activity, DayPlan, CatalogActivity } from '@/types';
 
 export interface SortableItemProps {
   id: string;
@@ -23,6 +23,8 @@ export interface SortableItemProps {
   onChangeColor: (color: string) => void;
   bgColor: string;
   onDelete: () => void;
+  onUpdateImage?: (url: string) => void;
+  onApplyCatalogItem?: (item: CatalogActivity) => void;
 }
 
 export default function SortableItem({
@@ -36,6 +38,8 @@ export default function SortableItem({
   onChangePosition,
   onChangeColor,
   onDelete,
+  onUpdateImage,
+  onApplyCatalogItem,
   bgColor,
   dragOverlay = false,
   className,
@@ -65,6 +69,8 @@ export default function SortableItem({
           onChangePosition={onChangePosition}
           onChangeColor={onChangeColor}
           onDelete={onDelete}
+          onUpdateImage={onUpdateImage}
+          onApplyCatalogItem={onApplyCatalogItem}
           bgColor={bgColor}
         />
       </div>
@@ -99,6 +105,8 @@ export default function SortableItem({
           onChangePosition={onChangePosition}
           onChangeColor={onChangeColor}
           onDelete={onDelete}
+          onUpdateImage={onUpdateImage}
+          onApplyCatalogItem={onApplyCatalogItem}
           bgColor={bgColor}
         />
       </div>

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -56,6 +56,10 @@ export default function ActivityModal({
     }));
   }
 
+  function handleImageChange(url: string) {
+    setDraft((prev) => ({ ...prev, imageUrl: url }));
+  }
+
   if (!open) return null;
 
   return ReactDOM.createPortal(
@@ -93,6 +97,7 @@ export default function ActivityModal({
             onChangeDay={onChangeDay}
             onChangePosition={onChangePosition}
             onCatalogSelect={handleCatalogSelect}
+            onImageChange={handleImageChange}
           />
           <ActivityModalForm activity={draft} onSave={onSave} color={color} />
         </div>

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -22,6 +22,7 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
   const [editedAddress, setEditedAddress] = useState(activity.address ?? '');
   const [duration, setDuration] = useState<number>(activity.duration || 0);
   const [budget, setBudget] = useState<number>(activity.budget || 0);
+  const [editedImageUrl, setEditedImageUrl] = useState(activity.imageUrl ?? '');
   const { results: addressResults, loading: addressLoading } =
     useDestinationAutocomplete(editedAddress);
   const [addressOpen, setAddressOpen] = useState(false);
@@ -33,6 +34,7 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
     setEditedAddress(activity.address ?? '');
     setDuration(activity.duration || 0);
     setBudget(activity.budget || 0);
+    setEditedImageUrl(activity.imageUrl ?? '');
   }, [activity]);
 
   // Automatically focus the title input only when the activity title is empty.
@@ -170,7 +172,7 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
               color,
               duration: Number(duration),
               budget,
-              imageUrl: activity.imageUrl,
+              imageUrl: editedImageUrl,
             })
           }
           className="focus:ring-primary focus:ring-2 focus:ring-offset-2 focus:outline-none"

--- a/src/components/planner/modal/ActivityModalHeader.test.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.test.tsx
@@ -61,6 +61,7 @@ const defaultProps = {
   availableDays: [] as DayPlan[],
   onChangeDay: () => {},
   dest: 'rome',
+  onImageChange: () => {},
 };
 
 it('opens catalog popup and selects an item', () => {

--- a/src/components/planner/modal/ActivityModalHeader.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.tsx
@@ -34,6 +34,7 @@ export default function ActivityModalHeader({
   onChangeDay,
   onChangePosition,
   onCatalogSelect,
+  onImageChange,
 }: {
   activity: Activity & { dayId?: string };
   dest: string;
@@ -45,6 +46,7 @@ export default function ActivityModalHeader({
   onChangeDay: (dayId: string) => void;
   onChangePosition: (index: number) => void;
   onCatalogSelect: (item: CatalogActivity) => void;
+  onImageChange: (url: string) => void;
 }) {
   const {
     colorButtonRef,
@@ -100,6 +102,7 @@ export default function ActivityModalHeader({
               e.stopPropagation();
               setShowRemove(false);
               setEditedImageUrl('');
+              onImageChange('');
             }}
           >
             Remove photo
@@ -141,8 +144,14 @@ export default function ActivityModalHeader({
           <div className="absolute top-[3rem] right-[1rem] z-50">
             <CardColorsPopup
               imageUrl={editedImageUrl}
-              onChangeImage={(url: string) => setEditedImageUrl(url)}
-              onClearImage={() => setEditedImageUrl('')}
+              onChangeImage={(url: string) => {
+                setEditedImageUrl(url);
+                onImageChange(url);
+              }}
+              onClearImage={() => {
+                setEditedImageUrl('');
+                onImageChange('');
+              }}
               selectedColor={bgColor}
               onChangeColor={(selectedColor: string) => {
                 onColorChange(selectedColor);
@@ -176,7 +185,9 @@ export default function ActivityModalHeader({
               dest={dest}
               onSelect={(item) => {
                 onCatalogSelect(item);
-                setEditedImageUrl(item.imageUrl || '');
+                const url = item.imageUrl || '';
+                setEditedImageUrl(url);
+                onImageChange(url);
                 setIsCatalogOpen(false);
               }}
               onClose={() => setIsCatalogOpen(false)}


### PR DESCRIPTION
## Summary
- support updating images when applying catalog items
- propagate edited images in modal forms and card editing
- wire remove-photo button to clear modal draft image

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68886a07f86c83229a44b8e7c995c319