### PR TITLE
Add Rome inspiration page and home link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ While editing an activity, you can search the catalog directly from the modal or
   All planner and budget changes are saved to `localStorage` so they stay when you refresh.
 - **Accessibility & Responsive Design**
   Fully keyboard-accessible with layouts optimised for mobile and desktop.
+- **Sample Plan**
+  Explore a pre-built 4 day Rome itinerary from the home page.
 
 You can deploy the same app to Vercel or Netlify.
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -144,6 +144,18 @@ This document summarizes each React component in the repository. It follows the 
   - **Interactions:** choose suggestion via click or Tab key; both return `{ name, latitude, longitude }`
   - **Performance notes:** none
 
+### InspirationLink
+
+- **Location:** `src/components/home/InspirationLink.tsx`
+- **Responsibility:** Link to view the sample Rome itinerary.
+- **Props:** none
+- **State:** none
+- **External Hooks:** none
+- **Side-effects:** none
+- **Accessibility:** semantic heading and link
+- **Interactions:** navigates to `/inspiration/rome`
+- **Performance notes:** none
+
 ---
 
 ## Onboarding Components

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -12,6 +12,7 @@ The application lets users create and organize trip itineraries, persisting data
 - **Geoapify Catalog** – Activities are fetched from Geoapify using your `GEOAPIFY_KEY`.
 - **Persistent Storage** – Planner data and budget stay saved in the browser.
 - **Map Mode** – View itinerary on an interactive map built with Leaflet.
+- **Rome Inspiration** – Browse a pre-built example itinerary for Rome.
 
 ## Tech Stack
 

--- a/src/app/inspiration/rome/page.tsx
+++ b/src/app/inspiration/rome/page.tsx
@@ -1,0 +1,29 @@
+// src/app/inspiration/rome/page.tsx
+import rome from '@/data/rome.json';
+
+export const metadata = {
+  title: 'Rome Inspiration',
+};
+
+export default function RomeInspiration() {
+  return (
+    <main id="main-content" className="space-y-8 p-8">
+      <h1 className="font-title text-4xl font-semibold">{rome.title_inspiration}</h1>
+      {rome.itinerary.map((day) => (
+        <section key={day.day} className="space-y-2">
+          <h2 className="text-2xl font-medium">Day {day.day}</h2>
+          <ul className="space-y-2">
+            {day.activities.map((act, idx) => (
+              <li key={idx} className="rounded border p-2">
+                <p className="font-semibold">{act.title}</p>
+                {act.startTime && <p>Start: {act.startTime}</p>}
+                {act.duration != null && <p>Duration: {act.duration}h</p>}
+                {act.address && <p>{act.address}</p>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 // src/app/page.tsx
 
-import { FeaturePreview, WelcomeForm } from '@/components';
+import { FeaturePreview, WelcomeForm, InspirationLink } from '@/components';
 
 export default function Home() {
   return (
     <main id="main-content" className="space-y-16">
       <WelcomeForm />
       <FeaturePreview />
+      <InspirationLink />
     </main>
   );
 }

--- a/src/components/home/InspirationLink.tsx
+++ b/src/components/home/InspirationLink.tsx
@@ -1,0 +1,18 @@
+// src/components/home/InspirationLink.tsx
+'use client';
+
+import Link from 'next/link';
+
+export default function InspirationLink() {
+  return (
+    <section className="container p-8">
+      <h2 className="font-title text-2xl mb-4">Trip Inspiration</h2>
+      <Link
+        href="/inspiration/rome"
+        className="text-primary underline hover:text-primary/80"
+      >
+        A 4 day trip to Rome
+      </Link>
+    </section>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -3,3 +3,4 @@
 export { default as WelcomeForm } from './WelcomeForm';
 export { default as FeaturePreview } from './FeaturePreview';
 export { default as DestinationInput } from './DestinationInput';
+export { default as InspirationLink } from './InspirationLink';

--- a/src/data/rome.json
+++ b/src/data/rome.json
@@ -9,35 +9,35 @@
       "activities": [
         {
           "title": "Rome City Walking Tour",
-          "start_time": "08:00",
-          "duration": "3 h",
+          "startTime": "08:00",
+          "duration": 3,
           "address": "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/5/53/Colosseum_in_Rome%2C_Italy_-_April_2007.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/53/Colosseum_in_Rome%2C_Italy_-_April_2007.jpg"
         },
         {
           "title": "Skip-the-Line Group Tour of the Vatican, Sistine Chapel & St. Peter's Basilica",
-          "start_time": "11:30",
-          "duration": "3 h",
+          "startTime": "11:30",
+          "duration": 3,
           "address": "Cortile della Pigna, 00120 Vatican City",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/f/f5/Basilica_di_San_Pietro_in_Vaticano_September_2015-1a.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/f5/Basilica_di_San_Pietro_in_Vaticano_September_2015-1a.jpg"
         },
         {
           "title": "Break",
-          "start_time": "14:30",
-          "duration": "1 h",
+          "startTime": "14:30",
+          "duration": 1,
           "address": "Via dei Condotti, 86, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-0)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Via_dei_Condotti_in_Rome.jpg"
+          "color": "bg-[var(--color-0)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Via_dei_Condotti_in_Rome.jpg"
         },
         {
           "title": "Dinner at Trattoria da Enzo al 29",
-          "start_time": "18:00",
-          "duration": "2 h",
+          "startTime": "18:00",
+          "duration": 2,
           "address": "Via dei Vascellari, 29, 00153 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://i0.wp.com/planejandoaviagem.com/wp-content/uploads/2015/07/da-enzo-700x466.jpg?ssl=1"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://i0.wp.com/planejandoaviagem.com/wp-content/uploads/2015/07/da-enzo-700x466.jpg?ssl=1"
         }
       ]
     },
@@ -46,59 +46,59 @@
       "activities": [
         {
           "title": "Explore the Roman Forum",
-          "start_time": "09:00",
-          "duration": "2 h",
+          "startTime": "09:00",
+          "duration": 2,
           "address": "Via della Salara Vecchia, 5/6, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/6/6e/Forum_Romanum_%28Rome%29_03.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6e/Forum_Romanum_%28Rome%29_03.jpg"
         },
         {
           "title": "Break",
-          "start_time": "11:00",
-          "duration": "1 h",
+          "startTime": "11:00",
+          "duration": 1,
           "address": "Via dei Fori Imperiali, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-0)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Fori_Imperiali_Rome.jpg"
+          "color": "bg-[var(--color-0)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Fori_Imperiali_Rome.jpg"
         },
         {
           "title": "Lunch at Ristorante Aroma",
-          "start_time": "12:00",
-          "duration": "1 h",
+          "startTime": "12:00",
+          "duration": 1,
           "address": "Via Labicana, 125, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://res.cloudinary.com/tf-lab/image/upload/restaurant/abdb2f83-6064-4d86-a43c-618f82024713/478b5ce2-f3d8-4a7b-9c41-ae30217c1811.jpg"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://res.cloudinary.com/tf-lab/image/upload/restaurant/abdb2f83-6064-4d86-a43c-618f82024713/478b5ce2-f3d8-4a7b-9c41-ae30217c1811.jpg"
         },
         {
           "title": "Transportation to the Colosseum",
-          "start_time": "13:00",
-          "duration": "1 h",
+          "startTime": "13:00",
+          "duration": 1,
           "address": "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-1)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/5/5a/Colosseum-Entrance_LII.jpg"
+          "color": "bg-[var(--color-1)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/5a/Colosseum-Entrance_LII.jpg"
         },
         {
           "title": "Colosseum, Roman Forum & Palatine Hill Guided Tour",
-          "start_time": "14:00",
-          "duration": "3 h",
+          "startTime": "14:00",
+          "duration": 3,
           "address": "Piazza del Colosseo, 1, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/1/1e/Palatine_Hill_%287940391062%29.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/1e/Palatine_Hill_%287940391062%29.jpg"
         },
         {
           "title": "Break",
-          "start_time": "17:00",
-          "duration": "1 h",
+          "startTime": "17:00",
+          "duration": 1,
           "address": "Via del Teatro di Marcello, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-0)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/a/a4/Marcello_Theatre_Rome.jpg"
+          "color": "bg-[var(--color-0)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/a/a4/Marcello_Theatre_Rome.jpg"
         },
         {
           "title": "Dinner at Spaghetteria L'Archeologia",
-          "start_time": "18:00",
-          "duration": "2 h",
+          "startTime": "18:00",
+          "duration": 2,
           "address": "Via delle Coppelle, 16/17, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/18/45/b2/d8/locale.jpg?w=800&h=500&s=1"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/18/45/b2/d8/locale.jpg?w=800&h=500&s=1"
         }
       ]
     },
@@ -107,67 +107,67 @@
       "activities": [
         {
           "title": "Visit the Pantheon",
-          "start_time": "09:00",
-          "duration": "1.5 h",
+          "startTime": "09:00",
+          "duration": 1.5,
           "address": "Piazza della Rotonda, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/6/6a/Pantheon_front_Rome.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6a/Pantheon_front_Rome.jpg"
         },
         {
           "title": "Transportation to Piazza Navona",
-          "start_time": "10:30",
-          "duration": "0.5 h",
+          "startTime": "10:30",
+          "duration": 0.5,
           "address": "Piazza Navona, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-1)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/5/5d/Piazza_Navona_3.jpg"
+          "color": "bg-[var(--color-1)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/5d/Piazza_Navona_3.jpg"
         },
         {
           "title": "Explore Piazza Navona",
-          "start_time": "11:00",
-          "duration": "1.5 h",
+          "startTime": "11:00",
+          "duration": 1.5,
           "address": "Piazza Navona, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/9/99/Piazza_Navona_Feb_2008.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/9/99/Piazza_Navona_Feb_2008.jpg"
         },
         {
           "title": "Lunch at Ristorante Tre Scalini",
-          "start_time": "12:30",
-          "duration": "1 h",
+          "startTime": "12:30",
+          "duration": 1,
           "address": "Piazza Navona, 28, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Restaurant_Tre_Scalini_at_Piazza_Navona_in_Rome.jpg/960px-Restaurant_Tre_Scalini_at_Piazza_Navona_in_Rome.jpg?20201114145033"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Restaurant_Tre_Scalini_at_Piazza_Navona_in_Rome.jpg/960px-Restaurant_Tre_Scalini_at_Piazza_Navona_in_Rome.jpg?20201114145033"
         },
         {
           "title": "Visit the Trevi Fountain",
-          "start_time": "14:00",
-          "duration": "1 h",
+          "startTime": "14:00",
+          "duration": 1,
           "address": "Piazza di Trevi, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/1/16/Trevi_Fountain_Rome.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/16/Trevi_Fountain_Rome.jpg"
         },
         {
           "title": "Break",
-          "start_time": "15:00",
-          "duration": "1 h",
+          "startTime": "15:00",
+          "duration": 1,
           "address": "Via della Panetteria, 42, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-0)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/2/24/Gelateria_del_Pantheon.jpg"
+          "color": "bg-[var(--color-0)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/24/Gelateria_del_Pantheon.jpg"
         },
         {
           "title": "Shopping on Via del Corso",
-          "start_time": "16:00",
-          "duration": "2 h",
+          "startTime": "16:00",
+          "duration": 2,
           "address": "Via del Corso, 00186 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/a/aa/Via_del_Corso_Rome.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/a/aa/Via_del_Corso_Rome.jpg"
         },
         {
           "title": "Dinner at Hostaria Romana",
-          "start_time": "19:00",
-          "duration": "2 h",
+          "startTime": "19:00",
+          "duration": 2,
           "address": "Via del Boschetto, 73, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://media-cdn.tripadvisor.com/media/photo-s/12/b3/3f/14/hosteria-romana-roma.jpg"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://media-cdn.tripadvisor.com/media/photo-s/12/b3/3f/14/hosteria-romana-roma.jpg"
         }
       ]
     },
@@ -176,67 +176,67 @@
       "activities": [
         {
           "title": "Visit Villa Borghese Gardens",
-          "start_time": "09:00",
-          "duration": "2 h",
+          "startTime": "09:00",
+          "duration": 2,
           "address": "Piazzale Napoleone I, 00197 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Villa_Borghese_%28Rome%29_01.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Villa_Borghese_%28Rome%29_01.jpg"
         },
         {
           "title": "Transportation to Spanish Steps",
-          "start_time": "11:00",
-          "duration": "0.5 h",
+          "startTime": "11:00",
+          "duration": 0.5,
           "address": "Piazza di Spagna, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-1)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/e/ed/Spanish_Steps_Rome.jpg"
+          "color": "bg-[var(--color-1)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ed/Spanish_Steps_Rome.jpg"
         },
         {
           "title": "Explore the Spanish Steps",
-          "start_time": "11:30",
-          "duration": "1 h",
+          "startTime": "11:30",
+          "duration": 1,
           "address": "Piazza di Spagna, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/3/3b/Spanish_Steps-top_view.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3b/Spanish_Steps-top_view.jpg"
         },
         {
           "title": "Lunch at Caffè Greco",
-          "start_time": "13:00",
-          "duration": "1.5 h",
+          "startTime": "13:00",
+          "duration": 1.5,
           "address": "Via dei Condotti, 86, 00187 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://www.vamosparaitalia.com.br/wp-content/uploads/2018/05/greco.jpg"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://www.vamosparaitalia.com.br/wp-content/uploads/2018/05/greco.jpg"
         },
         {
           "title": "Transportation to Borghese Gallery",
-          "start_time": "14:30",
-          "duration": "0.5 h",
+          "startTime": "14:30",
+          "duration": 0.5,
           "address": "Piazzale Scipione Borghese, 5, 00197 Roma RM, Italy",
-          "card_color": "bg-[var(--color-1)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/2/28/Galleria_Borghese_Facade.jpg"
+          "color": "bg-[var(--color-1)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/28/Galleria_Borghese_Facade.jpg"
         },
         {
           "title": "Tour of the Borghese Gallery",
-          "start_time": "15:00",
-          "duration": "2 h",
+          "startTime": "15:00",
+          "duration": 2,
           "address": "Piazzale Scipione Borghese, 5, 00197 Roma RM, Italy",
-          "card_color": "bg-[var(--color-3)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Galleria_Borghese_interior.jpg"
+          "color": "bg-[var(--color-3)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Galleria_Borghese_interior.jpg"
         },
         {
           "title": "Break",
-          "start_time": "17:00",
-          "duration": "1 h",
+          "startTime": "17:00",
+          "duration": 1,
           "address": "Terrazza del Pincio, 00197 Roma RM, Italy",
-          "card_color": "bg-[var(--color-0)]",
-          "image_url": "https://upload.wikimedia.org/wikipedia/commons/2/24/Terrazza_del_Pincio.jpg"
+          "color": "bg-[var(--color-0)]",
+          "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/24/Terrazza_del_Pincio.jpg"
         },
         {
           "title": "Farewell Dinner at Osteria Antica",
-          "start_time": "19:00",
-          "duration": "2 h",
+          "startTime": "19:00",
+          "duration": 2,
           "address": "Via Garibaldi, 5, 00184 Roma RM, Italy",
-          "card_color": "bg-[var(--color-4)]",
-          "image_url": "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/1b/7c/2c/dc/tramonto-in-riva-all.jpg?w=900&h=500&s=1"
+          "color": "bg-[var(--color-4)]",
+          "imageUrl": "https://dynamic-media-cdn.tripadvisor.com/media/photo-o/1b/7c/2c/dc/tramonto-in-riva-all.jpg?w=900&h=500&s=1"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add link to example itinerary on home page
- expose new `InspirationLink` component
- create `/inspiration/rome` page rendering the Rome plan
- normalize fields in `rome.json`
- document `InspirationLink` component and Rome example

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c26104208322912054801ba77af6