### PR TITLE
Add Rome inspiration planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ While editing an activity, you can search the catalog directly from the modal or
 - **Accessibility & Responsive Design**
   Fully keyboard-accessible with layouts optimised for mobile and desktop.
 - **Sample Plan**
-  Explore a pre-built 4 day Rome itinerary from the home page.
+  Try the interactive 4 day Rome itinerary from the home page link.
 
 You can deploy the same app to Vercel or Netlify.
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -155,6 +155,18 @@ This document summarizes each React component in the repository. It follows the 
 - **Accessibility:** semantic heading and link
 - **Interactions:** navigates to `/inspiration/rome`
 - **Performance notes:** none
+### RomeInspirationPage
+
+- **Location:** `src/app/inspiration/rome/page.tsx`
+- **Responsibility:** Interactive demo planner with a four day Rome itinerary.
+- **Props:** none
+- **State:** planner days, selected activity, mode
+- **External Hooks:** `useDnDPlanner`, `useSelectedActivity`, `usePlanTitle`, `useKeyBinds`
+- **Side-effects:** saves title and budget in `localStorage`
+- **Accessibility:** keyboard shortcuts via key binds
+- **Interactions:** drag cards, edit details, switch between planner, map and budget
+- **Performance notes:** memoized activity lookup
+
 
 ---
 

--- a/src/app/inspiration/rome/InspirationPlanner.tsx
+++ b/src/app/inspiration/rome/InspirationPlanner.tsx
@@ -1,0 +1,199 @@
+// src/app/inspiration/rome/InspirationPlanner.tsx
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import dynamic from 'next/dynamic';
+import { closestCenter } from '@dnd-kit/core';
+
+import PlannerBoard from '@/app/planner/PlannerBoard';
+import BudgetPanel from '@/app/planner/BudgetPanel';
+const MapView = dynamic(() => import('@/app/planner/MapView'), { ssr: false });
+
+import { ActivityModal, PlannerControls } from '@/components';
+import { useDnDPlanner, useSelectedActivity, usePlanTitle, useKeyBinds } from '@/hooks';
+import type { DayPlan, CatalogActivity } from '@/types';
+import { motion } from 'framer-motion';
+
+/**
+ * Interactive planner preloaded with sample days.
+ * Used by the Rome inspiration page.
+ */
+
+type Mode = 'planner' | 'map' | 'budget';
+const modeOrder: Mode[] = ['planner', 'map', 'budget'];
+
+interface Props {
+  initialDays: DayPlan[];
+  dest: string;
+  planId: string;
+}
+
+export default function InspirationPlanner({ initialDays, dest, planId }: Props) {
+  const [mode, setMode] = useState<Mode>('planner');
+
+  const {
+    days,
+    setDays,
+    activeId,
+    sensors,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    addActivity,
+    removeActivity,
+    updateActivity,
+    addBlankActivity,
+  } = useDnDPlanner(initialDays);
+
+  const { title, setTitle } = usePlanTitle(planId, dest);
+
+  const {
+    selectedActivity,
+    setSelectedActivity,
+    changeDay,
+    changePosition,
+    addBlankAndSelect,
+    closeModal,
+    save,
+    deleteActivity,
+    changeColor,
+  } = useSelectedActivity(days, setDays, {
+    addActivity,
+    removeActivity,
+    updateActivity,
+    addBlankActivity,
+  });
+
+  const activitiesTotal = useMemo(
+    () =>
+      days.reduce(
+        (sum, day) => sum + day.activities.reduce((acc, act) => acc + (act.budget ?? 0), 0),
+        0
+      ),
+    [days]
+  );
+
+  useKeyBinds({
+    onPlanner: () => setMode('planner'),
+    onMap: () => setMode('map'),
+    onBudget: () => setMode('budget'),
+    onNewCard: () => addBlankAndSelect(days[0].id),
+    onCatalog: () => {},
+  });
+
+  const stringActiveId = activeId != null ? String(activeId) : null;
+  const activeIdx = modeOrder.indexOf(mode);
+
+  return (
+    <main
+      id="main-content"
+      className="bg-card flex h-screen flex-col overflow-hidden p-4 md:pb-12 lg:px-12"
+    >
+      {/* HEADER */}
+      <div className="container flex items-center justify-between gap-4 pb-4">
+        <h1 className="bg-card inline-flex flex-none cursor-pointer rounded-md text-3xl font-semibold whitespace-nowrap capitalize hover:bg-[color-mix(in_oklch,var(--card)_75%,var(--card-foreground)_5%)] md:text-5xl">
+          <input
+            id="planner-title"
+            name="title"
+            role="heading"
+            aria-level={1}
+            aria-label="Planner title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            style={{ width: `${Math.max(title.length, 1)}ch` }}
+            onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
+            className="focus:border-border focus:bg-background cursor-pointer rounded-md border-2 border-transparent bg-transparent px-4 py-2 transition-colors outline-none focus:cursor-text"
+          />
+        </h1>
+      </div>
+
+      <PlannerControls
+        mode={mode}
+        onModeChange={setMode}
+        range={undefined}
+        onRangeChange={() => {}}
+      />
+
+      {/* BOARD / MAP / BUDGET */}
+      <div className="relative order-2 container flex-1 overflow-visible md:order-3">
+        {modeOrder.map((m, idx) => {
+          const isActive = idx === activeIdx;
+          const rel = idx - activeIdx;
+          const abs = Math.abs(rel);
+          const z = 3 - abs;
+          const offsetMap = [0, 6, 10];
+          const offset = offsetMap[abs] * Math.sign(rel);
+          const scaleMap = [1, 0.92, 0.87];
+          const scale = scaleMap[abs] ?? 0.7;
+          const opacityMap = [1, 0.92, 0.8];
+          const opacity = opacityMap[abs] ?? 0.6;
+          const rotate = rel * 2;
+
+          return (
+            <motion.div
+              key={m}
+              className={`absolute inset-0 ${!isActive ? 'cursor-pointer' : ''}`}
+              style={{ zIndex: z }}
+              initial={false}
+              animate={{ x: `${offset}%`, scale, opacity, rotateZ: rotate }}
+              transition={{ type: 'spring', stiffness: 200, damping: 25 }}
+              onClick={() => !isActive && setMode(m)}
+            >
+              <div style={{ pointerEvents: isActive ? 'auto' : 'none' }} className="h-full">
+                {m === 'planner' && (
+                  <PlannerBoard
+                    days={days}
+                    dest={dest}
+                    activeId={stringActiveId}
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    handleDragStart={handleDragStart}
+                    handleDragOver={handleDragOver}
+                    handleDragEnd={handleDragEnd}
+                    onSelectActivity={setSelectedActivity}
+                    onUpdateTitle={(id, title) => updateActivity(id, { title })}
+                    onAddActivity={(dayId, insertIdx) => addBlankAndSelect(dayId, insertIdx)}
+                    onChangeDay={changeDay}
+                    onChangePosition={changePosition}
+                    onChangeColor={(id, color) => changeColor(id, color)}
+                    onUpdateImage={(id, url) => updateActivity(id, { imageUrl: url })}
+                    onApplyCatalogItem={(id, item: CatalogActivity) =>
+                      updateActivity(id, { imageUrl: item.imageUrl || '' })
+                    }
+                    onDelete={removeActivity}
+                  />
+                )}
+                {m === 'budget' && (
+                  <BudgetPanel
+                    planId={planId}
+                    activitiesTotal={activitiesTotal}
+                    days={days}
+                    onUpdateBudget={(id, amount) => updateActivity(id, { budget: amount })}
+                  />
+                )}
+                {m === 'map' && <MapView days={days} onSelectActivity={setSelectedActivity} />}
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {selectedActivity && (
+        <ActivityModal
+          open
+          activity={selectedActivity}
+          onClose={closeModal}
+          onSave={save}
+          onDelete={deleteActivity}
+          color={selectedActivity.color}
+          onColorChange={(newColor) => changeColor(selectedActivity.id, newColor)}
+          days={days}
+          dest={dest}
+          onChangeDay={(dayId) => changeDay(selectedActivity.id, dayId)}
+          onChangePosition={(idx) => changePosition(selectedActivity.id, idx)}
+        />
+      )}
+    </main>
+  );
+}

--- a/src/app/inspiration/rome/page.tsx
+++ b/src/app/inspiration/rome/page.tsx
@@ -1,29 +1,35 @@
 // src/app/inspiration/rome/page.tsx
+'use client';
+
+import React, { useMemo } from 'react';
 import rome from '@/data/rome.json';
+import InspirationPlanner from './InspirationPlanner';
+import { formatDayPlan } from '@/utils';
+import type { DayPlan, Activity } from '@/types';
+import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 
 export const metadata = {
   title: 'Rome Inspiration',
 };
 
-export default function RomeInspiration() {
-  return (
-    <main id="main-content" className="space-y-8 p-8">
-      <h1 className="font-title text-4xl font-semibold">{rome.title_inspiration}</h1>
-      {rome.itinerary.map((day) => (
-        <section key={day.day} className="space-y-2">
-          <h2 className="text-2xl font-medium">Day {day.day}</h2>
-          <ul className="space-y-2">
-            {day.activities.map((act, idx) => (
-              <li key={idx} className="rounded border p-2">
-                <p className="font-semibold">{act.title}</p>
-                {act.startTime && <p>Start: {act.startTime}</p>}
-                {act.duration != null && <p>Duration: {act.duration}h</p>}
-                {act.address && <p>{act.address}</p>}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
-    </main>
-  );
+function buildInitialDays(): DayPlan[] {
+  const start = new Date();
+  return rome.itinerary.map((d, i) => {
+    const { id, label } = formatDayPlan(new Date(start.getTime() + i * 86400000));
+    const activities: Activity[] = d.activities.map((a, idx) => ({
+      id: `r${i}-${idx}`,
+      title: a.title,
+      startTime: a.startTime,
+      duration: a.duration,
+      address: a.address,
+      imageUrl: a.imageUrl,
+      color: a.color ?? DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
+    }));
+    return { id, label, activities };
+  });
+}
+
+export default function RomeInspirationPage() {
+  const initialDays = useMemo(buildInitialDays, []);
+  return <InspirationPlanner initialDays={initialDays} dest="rome" planId="rome-inspiration" />;
 }

--- a/src/components/home/InspirationLink.tsx
+++ b/src/components/home/InspirationLink.tsx
@@ -6,11 +6,8 @@ import Link from 'next/link';
 export default function InspirationLink() {
   return (
     <section className="container p-8">
-      <h2 className="font-title text-2xl mb-4">Trip Inspiration</h2>
-      <Link
-        href="/inspiration/rome"
-        className="text-primary underline hover:text-primary/80"
-      >
+      <h2 className="font-title mb-4 text-2xl">Trip Inspiration</h2>
+      <Link href="/inspiration/rome" className="text-primary hover:text-primary/80 underline">
         A 4 day trip to Rome
       </Link>
     </section>


### PR DESCRIPTION
## Summary
- implement a client-side inspiration planner for Rome
- expose new `InspirationPlanner` component with drag-and-drop UI
- document the page in COMPONENTS.md and update README

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6888d5b3708883229bcc0fb73eb4f6df