### PR TITLE
Fix build warnings

### DIFF
--- a/src/app/inspiration/[city]/page.tsx
+++ b/src/app/inspiration/[city]/page.tsx
@@ -1,5 +1,5 @@
 // src/app/inspiration/[city]/page.tsx
-export const dynamic = 'force-dynamic'; // desabilita SSG e ISR
+export const dynamic = 'force-dynamic'; // disable SSG and ISR
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -7,19 +7,20 @@ import type { Metadata } from 'next';
 import InspirationPlanner from '../InspirationPlanner';
 import { buildDaysFromInspirationData } from '@/utils';
 
-type Props = {
+interface PageProps {
   params: { city: string };
-};
-
-export async function generateMetadata({ params: { city } }: Props): Promise<Metadata> {
+}
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { city } = params;
   return { title: `${city} Inspiration` };
 }
 
-export default async function InspirationPage({ params: { city } }: Props) {
+export default function InspirationPage({ params }: PageProps) {
+  const { city } = params;
   const filePath = join(process.cwd(), 'src', 'data', `${city}.json`);
   const raw = readFileSync(filePath, 'utf-8');
   const data = JSON.parse(raw);
-  console.log('[InspirationPage] JSON carregado:', data);
+  console.log('[InspirationPage] Loaded JSON:', data);
 
   const initialDays = buildDaysFromInspirationData(data);
 

--- a/src/app/planner/MapView.test.tsx
+++ b/src/app/planner/MapView.test.tsx
@@ -6,12 +6,12 @@ import { vi } from 'vitest';
 import MapView from './MapView';
 import type { DayPlan } from '@/types';
 
-// Mover para fora do mock: escopo global para os testes
+// Reuse the same mocks across tests
 const map = { fitBounds: vi.fn() };
 const markers: Array<{ title?: string }> = [];
-let containerProps: any;
+let containerProps: { center?: unknown } | undefined;
 
-// Stub do react-leaflet
+// Stub react-leaflet
 vi.mock('react-leaflet', () => {
   const React = require('react');
   return {

--- a/src/hooks/planner/usePlanParams.ts
+++ b/src/hooks/planner/usePlanParams.ts
@@ -32,7 +32,7 @@ export function usePlanParams(options: { skipReplace?: boolean } = {}) {
       newSearch.set('plan', planId);
       router.replace(`/planner?${newSearch.toString()}`, { scroll: false });
     }
-  }, [planId, paramsString, router, options.skipReplace]);
+  }, [planId, paramsString, router, options.skipReplace, dest]);
 
   return { dest, planId, destCoords };
 }

--- a/src/tests/integration/mapRender.spec.tsx
+++ b/src/tests/integration/mapRender.spec.tsx
@@ -8,7 +8,7 @@ import type { DayPlan } from '@/types';
 
 const map = { fitBounds: vi.fn() };
 const markers: Array<{ title?: string }> = [];
-let containerProps: any;
+let containerProps: { center?: unknown } | undefined;
 
 vi.mock('react-leaflet', () => {
   const React = require('react');


### PR DESCRIPTION
## Summary
- clean up MapView tests
- update dest handling in `usePlanParams`
- clarify the inspiration page props

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893a1853008322b403b5887a51ac7f