### PR TITLE
Fix inspiration page props type

### DIFF
--- a/src/app/inspiration/[city]/page.tsx
+++ b/src/app/inspiration/[city]/page.tsx
@@ -7,15 +7,17 @@ import type { Metadata } from 'next';
 import InspirationPlanner from '../InspirationPlanner';
 import { buildDaysFromInspirationData } from '@/utils';
 
-interface PageProps {
+interface InspirationPageProps {
   params: { city: string };
 }
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: InspirationPageProps): Promise<Metadata> {
   const { city } = params;
   return { title: `${city} Inspiration` };
 }
 
-export default function InspirationPage({ params }: PageProps) {
+export default function InspirationPage({ params }: InspirationPageProps) {
   const { city } = params;
   const filePath = join(process.cwd(), 'src', 'data', `${city}.json`);
   const raw = readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
## Summary
- rename PageProps to InspirationPageProps to avoid Next.js type conflicts

## Testing
- `npm run format` *(fails: cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688940c5e4148322b3a26afea3ecc5c8