### PR TITLE
Update inspiration page props typing

### DIFF
--- a/src/app/inspiration/[city]/$types.ts
+++ b/src/app/inspiration/[city]/$types.ts
@@ -1,0 +1,4 @@
+// src/app/inspiration/[city]/$types.ts
+export interface PageProps {
+  params: { city: string };
+}

--- a/src/app/inspiration/[city]/page.tsx
+++ b/src/app/inspiration/[city]/page.tsx
@@ -4,18 +4,17 @@ export const dynamic = 'force-dynamic'; // disable SSG and ISR
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import type { Metadata } from 'next';
+import type { PageProps } from './$types';
 import InspirationPlanner from '../InspirationPlanner';
 import { buildDaysFromInspirationData } from '@/utils';
 
-interface PageProps {
-  params: { city: string };
-}
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export interface InspirationPageProps extends PageProps {}
+export async function generateMetadata({ params }: InspirationPageProps): Promise<Metadata> {
   const { city } = params;
   return { title: `${city} Inspiration` };
 }
 
-export default function InspirationPage({ params }: PageProps) {
+export default function InspirationPage({ params }: InspirationPageProps) {
   const { city } = params;
   const filePath = join(process.cwd(), 'src', 'data', `${city}.json`);
   const raw = readFileSync(filePath, 'utf-8');


### PR DESCRIPTION
## Summary
- add local `$types.ts` defining the `PageProps` interface
- use the new `PageProps` for the inspiration page props

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck` *(fails: containerProps undefined in tests)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688944d78034832290d106bc4a696457