### PR TITLE
Fix catalog hook

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -54,11 +54,12 @@ const { tripDays, handleRangeChange } = useTripRange(dest, planId);
 _File: `src/hooks/fetchCatalog.ts`_
 
 ```ts
-export async function fetchCatalog(dest: string): Promise<CatalogApiResponse>;
+export async function fetchCatalog(dest: string, categories: string[]): Promise<CatalogApiResponse>;
 ```
 
 - **Inputs**
   - `dest`: destination name.
+  - `categories`: list of category filters (empty for all).
 - **Outputs**
   Catalog activities from the API.
 - **Lifecycle**

--- a/src/hooks/catalog/useCatalogActivities.ts
+++ b/src/hooks/catalog/useCatalogActivities.ts
@@ -11,7 +11,7 @@ import type { CatalogActivity } from '@/types';
 export function useCatalogActivities(dest: string | null, options: { enabled: boolean }) {
   const query = useQuery({
     queryKey: ['catalog', dest],
-    queryFn: () => fetchCatalog(dest || ''),
+    queryFn: () => fetchCatalog(dest || '', []),
     enabled: options.enabled && !!dest,
   });
 


### PR DESCRIPTION
## Summary
- fetch catalog with empty categories
- document fetchCatalog signature with categories argument

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889507f7eb483228f2c71293dad124e