### PR TITLE
Fix useCatalogActivities categories argument

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -54,11 +54,15 @@ const { tripDays, handleRangeChange } = useTripRange(dest, planId);
 _File: `src/hooks/fetchCatalog.ts`_
 
 ```ts
-export async function fetchCatalog(dest: string): Promise<CatalogApiResponse>;
+export async function fetchCatalog(
+  dest: string,
+  categories: string[],
+): Promise<CatalogApiResponse>;
 ```
 
 - **Inputs**
   - `dest`: destination name.
+  - `categories`: list of active category filters.
 - **Outputs**
   Catalog activities from the API.
 - **Lifecycle**
@@ -69,11 +73,16 @@ export async function fetchCatalog(dest: string): Promise<CatalogApiResponse>;
 _File: `src/hooks/useCatalogActivities.ts`_
 
 ```ts
-export function useCatalogActivities(dest: string | null, options: { enabled: boolean });
+export function useCatalogActivities(
+  dest: string | null,
+  categories: string[],
+  options: { enabled: boolean },
+);
 ```
 
 - **Inputs**
   - `dest`: destination name.
+  - `categories`: active category filters.
   - `options.enabled`: whether the query should execute.
 - **Outputs**
   Raw catalog `activities` plus React Query props.

--- a/src/hooks/fetchCatalog.ts
+++ b/src/hooks/fetchCatalog.ts
@@ -10,8 +10,15 @@ export interface CatalogApiResponse {
  * Fetches the catalog activities for a destination.
  * Throws if the request fails.
  */
-export async function fetchCatalog(dest: string): Promise<CatalogApiResponse> {
-  const res = await fetch(`/api/catalog?dest=${encodeURIComponent(dest)}`);
+export async function fetchCatalog(
+  dest: string,
+  categories: string[],
+): Promise<CatalogApiResponse> {
+  const params = new URLSearchParams({ dest });
+  if (categories.length > 0) {
+    params.set('categories', categories.join(','));
+  }
+  const res = await fetch(`/api/catalog?${params.toString()}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch catalog: HTTP ${res.status}`);
   }

--- a/src/hooks/useCatalog.ts
+++ b/src/hooks/useCatalog.ts
@@ -16,7 +16,7 @@ import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 
 export function useCatalog(dest: string | null, options: { enabled: boolean }) {
   // 1) Load catalog activities using the shared hook
-  const { activities, ...query } = useCatalogActivities(dest, options);
+  const { activities, ...query } = useCatalogActivities(dest, [], options);
 
   // 2) Memoize transforming raw activities into day-based buckets
   const days: DayPlan[] | undefined = useMemo(() => {

--- a/src/hooks/useCatalogActivities.ts
+++ b/src/hooks/useCatalogActivities.ts
@@ -1,4 +1,4 @@
-// src/hooks/useDestinationCatalog.ts
+// src/hooks/useCatalogActivities.ts
 
 import { useQuery } from '@tanstack/react-query';
 import { fetchCatalog } from '@/hooks';
@@ -8,10 +8,14 @@ import type { CatalogActivity } from '@/types';
  * Hook to load catalog activities for a destination.
  * Provides raw activity data along with React Query state.
  */
-export function useCatalogActivities(dest: string | null, options: { enabled: boolean }) {
+export function useCatalogActivities(
+  dest: string | null,
+  categories: string[],
+  options: { enabled: boolean },
+) {
   const query = useQuery({
-    queryKey: ['catalog', dest],
-    queryFn: () => fetchCatalog(dest || ''),
+    queryKey: ['catalog', dest, categories],
+    queryFn: () => fetchCatalog(dest || '', categories),
     enabled: options.enabled && !!dest,
   });
 

--- a/src/hooks/useDestinationCatalog.ts
+++ b/src/hooks/useDestinationCatalog.ts
@@ -16,7 +16,7 @@ export function useDestinationCatalog(isOpen: boolean, city = 'salvador') {
   // Catalog activities list (raw from API)
   const { data, isLoading, isError } = useQuery({
     queryKey: ['catalog', city],
-    queryFn: () => fetchCatalog(city),
+    queryFn: () => fetchCatalog(city, []),
     enabled: isOpen,
   });
   const loading = isLoading;


### PR DESCRIPTION
## Summary
- extend `fetchCatalog` to accept category filters
- forward categories through `useCatalogActivities`
- update hooks calling `fetchCatalog`
- document new hook signatures

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file)*
- `npm run format` *(fails: missing prettier plugin)*
- `npm run lint` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6889549699708322a040aff7b7d57389