### PR TITLE
Fix planner title cropping

### DIFF
--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -21,6 +21,7 @@ import {
   useActivitiesById,
   useSelectedActivity,
   usePlanTitle,
+  useInputWidth,
   useKeyBinds,
   useOnboardingCheck,
 } from '@/hooks';
@@ -85,6 +86,7 @@ export default function PlannerClient({
   } = usePlanner({ initialDays, planId: planIdProp, dest: destProp });
 
   const { title, setTitle } = usePlanTitle(planId, dest);
+  const { ref: titleRef, width: titleWidth } = useInputWidth(title);
   const onboarding = useOnboardingCheck(planId);
   const showOnboarding = hideOnboarding ? false : onboarding.showOnboarding;
   const setShowOnboarding = hideOnboarding ? () => {} : onboarding.setShowOnboarding;
@@ -157,9 +159,10 @@ export default function PlannerClient({
             aria-level={1}
             aria-label="Planner title"
             type="text"
+            ref={titleRef}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            style={{ width: `${Math.max(title.length, 1)}ch` }}
+            style={{ width: `${titleWidth}px` }}
             onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
             className="focus:border-border focus:bg-background cursor-pointer rounded-md border-2 border-transparent bg-transparent px-4 py-2 transition-colors outline-none focus:cursor-text"
           />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -38,3 +38,4 @@ export * from './ui/useKeyBinds';
 export * from './ui/usePopupOutsideHandler';
 export * from './ui/useElementRect';
 export * from './ui/useCardColors';
+export * from './ui/useInputWidth';

--- a/src/hooks/ui/useInputWidth.ts
+++ b/src/hooks/ui/useInputWidth.ts
@@ -1,0 +1,34 @@
+// src/hooks/useInputWidth.ts
+"use client";
+
+import { useRef, useLayoutEffect, useState } from "react";
+import { measureTextWidth } from "@/lib";
+
+/**
+ * Calculates the pixel width needed to display an input's value
+ * using its computed font styles.
+ */
+export function useInputWidth(value: string) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [width, setWidth] = useState<number>(0);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const style = window.getComputedStyle(el);
+    const font = style.font;
+    const paddingLeft = parseFloat(style.paddingLeft || "0");
+    const paddingRight = parseFloat(style.paddingRight || "0");
+    const borderLeft = parseFloat(style.borderLeftWidth || "0");
+    const borderRight = parseFloat(style.borderRightWidth || "0");
+
+    const textWidth = measureTextWidth(value || " ", font);
+    const newWidth = Math.ceil(
+      textWidth + paddingLeft + paddingRight + borderLeft + borderRight
+    );
+    setWidth(newWidth);
+  }, [value]);
+
+  return { ref, width };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,3 +13,14 @@ export function cn(...inputs: ClassValue[]) {
 export function capitalize(str: string) {
   return str ? str.charAt(0).toUpperCase() + str.slice(1) : '';
 }
+
+/**
+ * Measures the width of a string using the provided font.
+ */
+export function measureTextWidth(text: string, font: string) {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  if (!context) return 0;
+  context.font = font;
+  return context.measureText(text).width;
+}


### PR DESCRIPTION
## Summary
- auto-size planner title based on the text width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68895655e90c8322801d6e257651fc03