### PR TITLE
Modularize catalog filter panel

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -249,9 +249,9 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** filter changes, add/remove actions, **Back** button resets the category step
 - **Performance notes:** none
 
-### DestinationHeader
+### CatalogHeader
 
-- **Location:** `src/components/planner/catalog/DestinationHeader.tsx`
+- **Location:** `src/components/planner/catalog/CatalogHeader.tsx`
 - **Responsibility:** Header controls for catalog search.
 - **Props:** search string, change handler, close callback
 - **State:** none
@@ -259,6 +259,30 @@ This document summarizes each React component in the repository. It follows the 
 - **Side-effects:** none
 - **Accessibility:** labeled search input
 - **Interactions:** updates search text
+- **Performance notes:** none
+
+### CategorySelector
+
+- **Location:** `src/components/planner/catalog/CategorySelector.tsx`
+- **Responsibility:** Category selection UI with search/back buttons.
+- **Props:** active set, toggle handler, submit/back callbacks, submitted flag
+- **State:** none
+- **External Hooks:** none
+- **Side-effects:** none
+- **Accessibility:** buttons and horizontal scroll
+- **Interactions:** choose categories, trigger search or back
+- **Performance notes:** none
+
+### ResultsList
+
+- **Location:** `src/components/planner/catalog/ResultsList.tsx`
+- **Responsibility:** Displays catalog results with loading and error states.
+- **Props:** list items, add/remove callbacks, added ID set
+- **State:** scroll position only
+- **External Hooks:** none
+- **Side-effects:** preserves scroll on add/remove
+- **Accessibility:** status messages, list semantics
+- **Interactions:** add or remove items
 - **Performance notes:** none
 
 ---

--- a/src/components/planner/catalog/CatalogHeader.tsx
+++ b/src/components/planner/catalog/CatalogHeader.tsx
@@ -1,20 +1,16 @@
-// src/components/planner/catalog/DestinationHeader.tsx
+// src/components/planner/catalog/CatalogHeader.tsx
 'use client';
 
 import React from 'react';
 import { CloseButton } from '@/components';
 
-interface DestinationHeaderProps {
+interface CatalogHeaderProps {
   search: string;
   onSearchChange: (s: string) => void;
   onClose: () => void;
 }
 
-export default function DestinationHeader({
-  search,
-  onSearchChange,
-  onClose,
-}: DestinationHeaderProps) {
+export default function CatalogHeader({ search, onSearchChange, onClose }: CatalogHeaderProps) {
   return (
     <>
       <div className="flex items-center justify-between border-b px-4 py-2">

--- a/src/components/planner/catalog/CategorySelector.tsx
+++ b/src/components/planner/catalog/CategorySelector.tsx
@@ -1,0 +1,48 @@
+// src/components/planner/catalog/CategorySelector.tsx
+'use client';
+
+import React from 'react';
+import { CategoryFilterBar } from '@/components';
+import { GEOAPIFY_CATEGORIES } from '@/lib';
+
+interface CategorySelectorProps {
+  active: Set<string>;
+  onToggle: (cat: string) => void;
+  submitted: boolean;
+  onSubmit: () => void;
+  onBack: () => void;
+}
+
+export default function CategorySelector({
+  active,
+  onToggle,
+  submitted,
+  onSubmit,
+  onBack,
+}: CategorySelectorProps) {
+  if (submitted) {
+    return (
+      <div className="flex items-center gap-2 border-b px-4 py-2">
+        <button type="button" onClick={onBack} className="rounded border px-3 py-1 text-sm">
+          Back
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+      <div className="flex-1 overflow-x-auto">
+        <CategoryFilterBar categories={GEOAPIFY_CATEGORIES} active={active} onToggle={onToggle} />
+      </div>
+      <button
+        type="button"
+        disabled={active.size === 0}
+        onClick={onSubmit}
+        className="rounded border px-3 py-1 text-sm"
+      >
+        Search
+      </button>
+    </div>
+  );
+}

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -1,11 +1,10 @@
 // src/components/planner/catalog/DestinationFilterPanel.tsx
 'use client';
 
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import FocusTrap from 'focus-trap-react';
-import { DestinationHeader, DestinationCardGrid, CategoryFilterBar, Spinner } from '@/components';
-import { GEOAPIFY_CATEGORIES } from '@/lib';
+import { CatalogHeader, CategorySelector, ResultsList } from '@/components';
 import type { CatalogActivity } from '@/types';
 import { useDestinationCatalog, useEscapeKey } from '@/hooks';
 
@@ -51,25 +50,6 @@ export default function DestinationFilterPanel({
   useEscapeKey({ onClose, isActive: isOpen });
 
   const containerRef = useRef<HTMLDivElement>(null);
-  // Preserve scroll position so the list doesn't jump after adding/removing
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const scrollPosRef = useRef(0);
-
-  const handleAdd = (a: CatalogActivity) => {
-    scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
-    onAdd(a);
-  };
-
-  const handleRemove = (id: string) => {
-    scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
-    onRemove(id);
-  };
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollPosRef.current;
-    }
-  }, [addedIds]);
 
   if (!isOpen) return null;
 
@@ -96,59 +76,25 @@ export default function DestinationFilterPanel({
           onClick={(e) => e.stopPropagation()}
         >
           {/* header */}
-          <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
+          <CatalogHeader search={search} onSearchChange={setSearch} onClose={onClose} />
 
-          {!submitted && (
-            <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
-              <div className="flex-1 overflow-x-auto">
-                <CategoryFilterBar
-                  categories={GEOAPIFY_CATEGORIES}
-                  active={selectedCats}
-                  onToggle={toggleCat}
-                />
-              </div>
-              <button
-                type="button"
-                disabled={selectedCats.size === 0}
-                onClick={() => setSubmitted(true)}
-                className="rounded border px-3 py-1 text-sm"
-              >
-                Search
-              </button>
-            </div>
-          )}
-          {submitted && (
-            <div className="flex items-center gap-2 border-b px-4 py-2">
-              <button
-                type="button"
-                onClick={() => setSubmitted(false)}
-                className="rounded border px-3 py-1 text-sm"
-              >
-                Back
-              </button>
-            </div>
-          )}
+          <CategorySelector
+            active={selectedCats}
+            onToggle={toggleCat}
+            submitted={submitted}
+            onSubmit={() => setSubmitted(true)}
+            onBack={() => setSubmitted(false)}
+          />
 
           {submitted && (
-            <div className="flex flex-1 overflow-auto" ref={scrollRef}>
-              <div className="flex-1 p-4">
-                {loading && (
-                  <div className="flex items-center gap-2">
-                    <Spinner />
-                    <span>Loading catalog...</span>
-                  </div>
-                )}
-                {error && <p className="text-red-500">{error}</p>}
-                {!loading && !error && (
-                  <DestinationCardGrid
-                    items={visibleItems}
-                    addedIds={addedIds}
-                    onAdd={handleAdd}
-                    onRemove={handleRemove}
-                  />
-                )}
-              </div>
-            </div>
+            <ResultsList
+              items={visibleItems}
+              addedIds={addedIds}
+              loading={loading}
+              error={error}
+              onAdd={onAdd}
+              onRemove={onRemove}
+            />
           )}
         </div>
       </FocusTrap>

--- a/src/components/planner/catalog/ResultsList.tsx
+++ b/src/components/planner/catalog/ResultsList.tsx
@@ -1,0 +1,65 @@
+// src/components/planner/catalog/ResultsList.tsx
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { DestinationCardGrid, Spinner } from '@/components';
+import type { CatalogActivity } from '@/types';
+
+interface ResultsListProps {
+  items: CatalogActivity[];
+  addedIds: Set<string>;
+  loading: boolean;
+  error?: string;
+  onAdd: (a: CatalogActivity) => void;
+  onRemove: (id: string) => void;
+}
+
+export default function ResultsList({
+  items,
+  addedIds,
+  loading,
+  error,
+  onAdd,
+  onRemove,
+}: ResultsListProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const scrollPosRef = useRef(0);
+
+  const handleAdd = (a: CatalogActivity) => {
+    scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
+    onAdd(a);
+  };
+
+  const handleRemove = (id: string) => {
+    scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
+    onRemove(id);
+  };
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollPosRef.current;
+    }
+  }, [addedIds]);
+
+  return (
+    <div className="flex flex-1 overflow-auto" ref={scrollRef}>
+      <div className="flex-1 p-4">
+        {loading && (
+          <div className="flex items-center gap-2">
+            <Spinner />
+            <span>Loading catalog...</span>
+          </div>
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+        {!loading && !error && (
+          <DestinationCardGrid
+            items={items}
+            addedIds={addedIds}
+            onAdd={handleAdd}
+            onRemove={handleRemove}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/catalog/index.ts
+++ b/src/components/planner/catalog/index.ts
@@ -4,4 +4,6 @@ export { default as CategoryFilterBar } from './CategoryFilterBar';
 export { default as DestinationCard } from './DestinationCard';
 export { default as DestinationCardGrid } from './DestinationCardGrid';
 export { default as DestinationFilterPanel } from './DestinationFilterPanel';
-export { default as DestinationHeader } from './DestinationHeader';
+export { default as CatalogHeader } from './CatalogHeader';
+export { default as CategorySelector } from './CategorySelector';
+export { default as ResultsList } from './ResultsList';

--- a/src/hooks/ui/useInputWidth.ts
+++ b/src/hooks/ui/useInputWidth.ts
@@ -1,8 +1,8 @@
 // src/hooks/useInputWidth.ts
-"use client";
+'use client';
 
-import { useRef, useLayoutEffect, useState } from "react";
-import { measureTextWidth } from "@/lib";
+import { useRef, useLayoutEffect, useState } from 'react';
+import { measureTextWidth } from '@/lib';
 
 /**
  * Calculates the pixel width needed to display an input's value
@@ -18,15 +18,13 @@ export function useInputWidth(value: string) {
 
     const style = window.getComputedStyle(el);
     const font = style.font;
-    const paddingLeft = parseFloat(style.paddingLeft || "0");
-    const paddingRight = parseFloat(style.paddingRight || "0");
-    const borderLeft = parseFloat(style.borderLeftWidth || "0");
-    const borderRight = parseFloat(style.borderRightWidth || "0");
+    const paddingLeft = parseFloat(style.paddingLeft || '0');
+    const paddingRight = parseFloat(style.paddingRight || '0');
+    const borderLeft = parseFloat(style.borderLeftWidth || '0');
+    const borderRight = parseFloat(style.borderRightWidth || '0');
 
-    const textWidth = measureTextWidth(value || " ", font);
-    const newWidth = Math.ceil(
-      textWidth + paddingLeft + paddingRight + borderLeft + borderRight
-    );
+    const textWidth = measureTextWidth(value || ' ', font);
+    const newWidth = Math.ceil(textWidth + paddingLeft + paddingRight + borderLeft + borderRight);
     setWidth(newWidth);
   }, [value]);
 


### PR DESCRIPTION
## Summary
- split destination filter panel into smaller components
- document catalog header, category selector and results list

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68896774fc688322bd23b149808b188d