### PR TITLE
Add reusable Modal component

### DIFF
--- a/src/components/planner/budget/activities/ActivitiesBudget.tsx
+++ b/src/components/planner/budget/activities/ActivitiesBudget.tsx
@@ -1,12 +1,10 @@
 // src/components/planner/budget/activities/ActivitiesBudget.tsx
 'use client';
 
-import React, { useMemo, useState, useEffect, useRef } from 'react';
-import ReactDOM from 'react-dom';
+import React, { useMemo, useState, useEffect } from 'react';
 import { DollarSign } from 'lucide-react';
-import FocusTrap from 'focus-trap-react';
 
-import { Input, CloseButton } from '@/components';
+import { Input, CloseButton, Modal } from '@/components';
 import { useEscapeKey } from '@/hooks';
 import { normalizeAmount } from '@/utils';
 import type { DayPlan } from '@/types';
@@ -20,8 +18,6 @@ interface ActivitiesBudgetProps {
 
 export default function ActivitiesBudget({ open, days, onUpdate, onClose }: ActivitiesBudgetProps) {
   useEscapeKey({ onClose, isActive: open });
-
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const activities = useMemo(
     () => days.flatMap((day) => day.activities.map((a) => ({ ...a, dayLabel: day.label }))),
@@ -51,63 +47,47 @@ export default function ActivitiesBudget({ open, days, onUpdate, onClose }: Acti
 
   if (!open) return null;
 
-  return ReactDOM.createPortal(
-    <div className="backdrop-overlay flex items-center justify-center" onClick={handleClose}>
-      <FocusTrap
-        active={open}
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          escapeDeactivates: false,
-          initialFocus: false,
-          fallbackFocus: () => containerRef.current ?? document.body,
-          tabbableOptions: { displayCheck: 'none' },
-        }}
-      >
-        <div
-          ref={containerRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="activities-budget-title"
-          tabIndex={-1}
-          className="focus:ring-primary w-[95%] max-w-md rounded-lg bg-white shadow-xl focus:ring-2 focus:outline-none"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className="flex items-center justify-between border-b px-4 py-2">
-            <h3 id="activities-budget-title" className="font-bold">
-              Budget Your Activities
-            </h3>
-            <CloseButton onClick={handleClose} aria-label="Close activities budget dialog" />
-          </div>
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      overlayClassName="backdrop-overlay"
+      aria-labelledby="activities-budget-title"
+      className="focus:ring-primary w-[95%] max-w-md rounded-lg bg-white shadow-xl focus:ring-2 focus:outline-none"
+    >
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <h3 id="activities-budget-title" className="font-bold">
+          Budget Your Activities
+        </h3>
+        <CloseButton onClick={handleClose} aria-label="Close activities budget dialog" />
+      </div>
 
-          <div
-            role="list"
-            aria-labelledby="activities-budget-title"
-            className="scrollbar-thin scrollbar-thumb-rounded scrollbar-track-transparent max-h-[70vh] space-y-2 overflow-y-auto p-4"
-          >
-            {activities.map((act, idx) => (
-              <div key={act.id} role="listitem" className="flex items-center justify-between gap-2">
-                <span className="flex-1 truncate text-sm">
-                  {act.title || 'Untitled'} – {act.dayLabel}
-                </span>
-                <Input
-                  autoFocus={idx === 0 && shouldAutoFocus}
-                  onFocus={idx === 0 ? () => setShouldAutoFocus(false) : undefined}
-                  autoComplete="off"
-                  labelId={`budget-${act.id}`}
-                  value={inputs[act.id] ?? ''}
-                  onValueChange={(v) => setInputs((prev) => ({ ...prev, [act.id]: v }))}
-                  inputSize="sm"
-                  background="default"
-                  placeholder="Budget"
-                  aria-label={`Budget for ${act.title || 'untitled'} – ${act.dayLabel}`}
-                  icon={<DollarSign aria-hidden="true" className="text-muted-foreground size-4" />}
-                />
-              </div>
-            ))}
+      <div
+        role="list"
+        aria-labelledby="activities-budget-title"
+        className="scrollbar-thin scrollbar-thumb-rounded scrollbar-track-transparent max-h-[70vh] space-y-2 overflow-y-auto p-4"
+      >
+        {activities.map((act, idx) => (
+          <div key={act.id} role="listitem" className="flex items-center justify-between gap-2">
+            <span className="flex-1 truncate text-sm">
+              {act.title || 'Untitled'} – {act.dayLabel}
+            </span>
+            <Input
+              autoFocus={idx === 0 && shouldAutoFocus}
+              onFocus={idx === 0 ? () => setShouldAutoFocus(false) : undefined}
+              autoComplete="off"
+              labelId={`budget-${act.id}`}
+              value={inputs[act.id] ?? ''}
+              onValueChange={(v) => setInputs((prev) => ({ ...prev, [act.id]: v }))}
+              inputSize="sm"
+              background="default"
+              placeholder="Budget"
+              aria-label={`Budget for ${act.title || 'untitled'} – ${act.dayLabel}`}
+              icon={<DollarSign aria-hidden="true" className="text-muted-foreground size-4" />}
+            />
           </div>
-        </div>
-      </FocusTrap>
-    </div>,
-    document.body
+        ))}
+      </div>
+    </Modal>
   );
 }

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -2,9 +2,13 @@
 'use client';
 
 import React, { useRef, useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
-import FocusTrap from 'focus-trap-react';
-import { DestinationHeader, DestinationCardGrid, CategoryFilterBar, Spinner } from '@/components';
+import {
+  DestinationHeader,
+  DestinationCardGrid,
+  CategoryFilterBar,
+  Spinner,
+  Modal,
+} from '@/components';
 import { GEOAPIFY_CATEGORIES } from '@/lib';
 import type { CatalogActivity } from '@/types';
 import { useDestinationCatalog, useEscapeKey } from '@/hooks';
@@ -49,8 +53,6 @@ export default function DestinationFilterPanel({
   );
 
   useEscapeKey({ onClose, isActive: isOpen });
-
-  const containerRef = useRef<HTMLDivElement>(null);
   // Preserve scroll position so the list doesn't jump after adding/removing
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const scrollPosRef = useRef(0);
@@ -73,86 +75,69 @@ export default function DestinationFilterPanel({
 
   if (!isOpen) return null;
 
-  return ReactDOM.createPortal(
-    <div className="backdrop-overlay flex items-center justify-center" onClick={onClose}>
-      <FocusTrap
-        active={isOpen}
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          escapeDeactivates: false,
-          initialFocus: false,
-          fallbackFocus: () => containerRef.current ?? document.body,
-          returnFocusOnDeactivate: false,
-          tabbableOptions: { displayCheck: 'none' },
-        }}
-      >
-        <div
-          ref={containerRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="destination-filter-title"
-          tabIndex={-1}
-          className="bg-background focus:ring-primary relative flex h-[90vh] w-[95vw] max-w-[1350px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {/* header */}
-          <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      overlayClassName="backdrop-overlay"
+      aria-labelledby="destination-filter-title"
+      className="bg-background focus:ring-primary relative flex h-[90vh] w-[95vw] max-w-[1350px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
+    >
+      {/* header */}
+      <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
 
-          {!submitted && (
-            <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
-              <div className="flex-1 overflow-x-auto">
-                <CategoryFilterBar
-                  categories={GEOAPIFY_CATEGORIES}
-                  active={selectedCats}
-                  onToggle={toggleCat}
-                />
-              </div>
-              <button
-                type="button"
-                disabled={selectedCats.size === 0}
-                onClick={() => setSubmitted(true)}
-                className="rounded border px-3 py-1 text-sm"
-              >
-                Search
-              </button>
-            </div>
-          )}
-          {submitted && (
-            <div className="flex items-center gap-2 border-b px-4 py-2">
-              <button
-                type="button"
-                onClick={() => setSubmitted(false)}
-                className="rounded border px-3 py-1 text-sm"
-              >
-                Back
-              </button>
-            </div>
-          )}
-
-          {submitted && (
-            <div className="flex flex-1 overflow-auto" ref={scrollRef}>
-              <div className="flex-1 p-4">
-                {loading && (
-                  <div className="flex items-center gap-2">
-                    <Spinner />
-                    <span>Loading catalog...</span>
-                  </div>
-                )}
-                {error && <p className="text-red-500">{error}</p>}
-                {!loading && !error && (
-                  <DestinationCardGrid
-                    items={visibleItems}
-                    addedIds={addedIds}
-                    onAdd={handleAdd}
-                    onRemove={handleRemove}
-                  />
-                )}
-              </div>
-            </div>
-          )}
+      {!submitted && (
+        <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+          <div className="flex-1 overflow-x-auto">
+            <CategoryFilterBar
+              categories={GEOAPIFY_CATEGORIES}
+              active={selectedCats}
+              onToggle={toggleCat}
+            />
+          </div>
+          <button
+            type="button"
+            disabled={selectedCats.size === 0}
+            onClick={() => setSubmitted(true)}
+            className="rounded border px-3 py-1 text-sm"
+          >
+            Search
+          </button>
         </div>
-      </FocusTrap>
-    </div>,
-    document.body
+      )}
+      {submitted && (
+        <div className="flex items-center gap-2 border-b px-4 py-2">
+          <button
+            type="button"
+            onClick={() => setSubmitted(false)}
+            className="rounded border px-3 py-1 text-sm"
+          >
+            Back
+          </button>
+        </div>
+      )}
+
+      {submitted && (
+        <div className="flex flex-1 overflow-auto" ref={scrollRef}>
+          <div className="flex-1 p-4">
+            {loading && (
+              <div className="flex items-center gap-2">
+                <Spinner />
+                <span>Loading catalog...</span>
+              </div>
+            )}
+            {error && <p className="text-red-500">{error}</p>}
+            {!loading && !error && (
+              <DestinationCardGrid
+                items={visibleItems}
+                addedIds={addedIds}
+                onAdd={handleAdd}
+                onRemove={handleRemove}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </Modal>
   );
 }

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -1,10 +1,8 @@
 // src/components/planner/modal/ActivityModal.tsx
 'use client';
 
-import React, { useEffect, useState, useRef } from 'react';
-import ReactDOM from 'react-dom';
-import FocusTrap from 'focus-trap-react';
-import { ActivityModalHeader, ActivityModalForm } from '@/components';
+import React, { useEffect, useState } from 'react';
+import { ActivityModalHeader, ActivityModalForm, Modal } from '@/components';
 import type { Activity, DayPlan, CatalogActivity } from '@/types';
 import { useEscapeKey } from '@/hooks';
 
@@ -35,8 +33,6 @@ export default function ActivityModal({
 }: ActivityModalProps) {
   useEscapeKey({ onClose, isActive: open });
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const [draft, setDraft] = useState(activity);
 
   useEffect(() => {
@@ -58,48 +54,30 @@ export default function ActivityModal({
     setDraft((prev) => ({ ...prev, imageUrl: url }));
   }
 
-  if (!open) return null;
-
-  return ReactDOM.createPortal(
-    <div className="backdrop-overlay flex items-center justify-center" onClick={onClose}>
-      <FocusTrap
-        active={open}
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          escapeDeactivates: false,
-          initialFocus: false,
-          fallbackFocus: () => containerRef.current ?? document.body,
-          tabbableOptions: { displayCheck: 'none' },
-        }}
-      >
-        <div
-          ref={containerRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="activity-modal-title"
-          tabIndex={-1}
-          className="bg-background focus:ring-primary flex w-[95%] max-w-[452px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <h2 id="activity-modal-title" className="sr-only">
-            Edit Activity
-          </h2>
-          <ActivityModalHeader
-            activity={draft}
-            bgColor={color}
-            onDelete={onDelete}
-            onClose={onClose}
-            onColorChange={onColorChange}
-            availableDays={days}
-            onChangeDay={onChangeDay}
-            onChangePosition={onChangePosition}
-            onCatalogSelect={handleCatalogSelect}
-            onImageChange={handleImageChange}
-          />
-          <ActivityModalForm activity={draft} onSave={onSave} color={color} />
-        </div>
-      </FocusTrap>
-    </div>,
-    document.body
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      overlayClassName="backdrop-overlay"
+      aria-labelledby="activity-modal-title"
+      className="bg-background focus:ring-primary flex w-[95%] max-w-[452px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
+    >
+      <h2 id="activity-modal-title" className="sr-only">
+        Edit Activity
+      </h2>
+      <ActivityModalHeader
+        activity={draft}
+        bgColor={color}
+        onDelete={onDelete}
+        onClose={onClose}
+        onColorChange={onColorChange}
+        availableDays={days}
+        onChangeDay={onChangeDay}
+        onChangePosition={onChangePosition}
+        onCatalogSelect={handleCatalogSelect}
+        onImageChange={handleImageChange}
+      />
+      <ActivityModalForm activity={draft} onSave={onSave} color={color} />
+    </Modal>
   );
 }

--- a/src/components/planner/onboarding/OnboardingModal.tsx
+++ b/src/components/planner/onboarding/OnboardingModal.tsx
@@ -1,10 +1,8 @@
 // src/components/planner/onboarding/OnboardingModal.tsx
 'use client';
 
-import React, { useRef } from 'react';
-import FocusTrap from 'focus-trap-react';
-import ReactDOM from 'react-dom';
-import { OnboardingCarousel, CloseButton } from '@/components';
+import React from 'react';
+import { OnboardingCarousel, CloseButton, Modal } from '@/components';
 import { useEscapeKey } from '@/hooks';
 
 interface OnboardingModalProps {
@@ -15,51 +13,27 @@ interface OnboardingModalProps {
 export default function OnboardingModal({ open, onClose }: OnboardingModalProps) {
   useEscapeKey({ onClose, isActive: open });
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  if (!open) return null;
-
-  return ReactDOM.createPortal(
-    <>
-      {/* Overlay */}
-      <div className="backdrop-overlay" onClick={onClose} />
-      <div className="fixed inset-0 z-50 flex items-center justify-center">
-        {/* Dialog */}
-        <FocusTrap
-          active={open}
-          focusTrapOptions={{
-            clickOutsideDeactivates: true,
-            escapeDeactivates: false,
-            initialFocus: false,
-            fallbackFocus: () => containerRef.current ?? document.body,
-            tabbableOptions: { displayCheck: 'none' },
-          }}
-        >
-          <div
-            ref={containerRef}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="onboarding-carousel-title"
-            tabIndex={-1}
-            className="bg-background focus:ring-primary relative max-w-sm rounded-lg p-4 shadow-xl focus:ring-2 focus:outline-none"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Heading */}
-            <h2 id="onboarding-carousel-title" className="sr-only">
-              Welcome
-            </h2>
-            {/* Close button */}
-            <div className="flex items-center justify-end pb-4">
-              <CloseButton onClick={onClose} />
-            </div>
-            {/* Carousel */}
-            <div className="flex items-center justify-center">
-              <OnboardingCarousel autoplay pauseOnHover baseWidth={384} onFinish={onClose} />
-            </div>
-          </div>
-        </FocusTrap>
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      overlayClassName="backdrop-overlay"
+      wrapperClassName="fixed inset-0 z-50 flex items-center justify-center"
+      aria-labelledby="onboarding-carousel-title"
+      className="focus:ring-primary bg-background relative max-w-sm rounded-lg p-4 shadow-xl focus:ring-2 focus:outline-none"
+    >
+      {/* Heading */}
+      <h2 id="onboarding-carousel-title" className="sr-only">
+        Welcome
+      </h2>
+      {/* Close button */}
+      <div className="flex items-center justify-end pb-4">
+        <CloseButton onClick={onClose} />
       </div>
-    </>,
-    document.body
+      {/* Carousel */}
+      <div className="flex items-center justify-center">
+        <OnboardingCarousel autoplay pauseOnHover baseWidth={384} onFinish={onClose} />
+      </div>
+    </Modal>
   );
 }

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,78 @@
+// src/components/ui/Modal.tsx
+'use client';
+
+import React, { useRef } from 'react';
+import ReactDOM from 'react-dom';
+import FocusTrap from 'focus-trap-react';
+import { cn } from '@/lib/utils';
+
+interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Control visibility and FocusTrap activation */
+  open?: boolean;
+  /** Render a backdrop element behind the modal */
+  withOverlay?: boolean;
+  /** Called when the user requests to close the modal */
+  onClose?: () => void;
+  /** Additional classes for the backdrop element */
+  overlayClassName?: string;
+  /** Classes for the wrapper that centers the modal */
+  wrapperClassName?: string;
+}
+
+export default function Modal({
+  open = true,
+  withOverlay = true,
+  onClose,
+  overlayClassName,
+  wrapperClassName,
+  className,
+  children,
+  ...props
+}: ModalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  if (!open) return null;
+
+  const dialog = (
+    <FocusTrap
+      active={open}
+      focusTrapOptions={{
+        clickOutsideDeactivates: true,
+        escapeDeactivates: false,
+        initialFocus: false,
+        fallbackFocus: () => containerRef.current ?? document.body,
+        tabbableOptions: { displayCheck: 'none' },
+      }}
+    >
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className={cn(
+          'bg-background focus:ring-primary rounded-lg shadow-xl focus:ring-2 focus:outline-none',
+          className
+        )}
+        onClick={(e) => e.stopPropagation()}
+        {...props}
+      >
+        {children}
+      </div>
+    </FocusTrap>
+  );
+
+  return ReactDOM.createPortal(
+    <>
+      {withOverlay && (
+        <div className={cn('backdrop-overlay', overlayClassName)} onClick={onClose} />
+      )}
+      <div
+        className={cn('fixed inset-0 z-50 flex items-center justify-center', wrapperClassName)}
+        onClick={onClose}
+      >
+        {dialog}
+      </div>
+    </>,
+    document.body
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from './popove
 export { default as Tooltip } from './Tooltip';
 export { default as TooltipKeyHint } from './TooltipKeyHint';
 export { default as Spinner } from './Spinner';
+export { default as Modal } from './Modal';
 
 // Icons components
 export * from './button-icons';


### PR DESCRIPTION
## Summary
- centralize FocusTrap/portal logic in a new `Modal` component
- update activity, onboarding, catalog, and budget views to use `Modal`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68896766b57483229f36c219a8518bdc