### PR TITLE
Add onboarding context

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -201,7 +201,7 @@ This document summarizes each React component in the repository. It follows the 
 
 - **Location:** `src/components/planner/onboarding/OnboardingModal.tsx`
 - **Responsibility:** Modal wrapper showing the carousel.
-- **Props:** `{ open, onClose }`
+- **Props:** none (uses `OnboardingContext`)
 - **State:** none
 - **External Hooks:** `useEscapeKey`
 - **Side-effects:** none

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -23,8 +23,8 @@ import {
   usePlanTitle,
   useInputWidth,
   useKeyBinds,
-  useOnboardingCheck,
 } from '@/hooks';
+import { OnboardingProvider } from '@/contexts/OnboardingContext';
 import type { CatalogActivity, DayPlan } from '@/types';
 import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 import { motion } from 'framer-motion';
@@ -87,9 +87,6 @@ export default function PlannerClient({
 
   const { title, setTitle } = usePlanTitle(planId, dest);
   const { ref: titleRef, width: titleWidth } = useInputWidth(title);
-  const onboarding = useOnboardingCheck(planId);
-  const showOnboarding = hideOnboarding ? false : onboarding.showOnboarding;
-  const setShowOnboarding = hideOnboarding ? () => {} : onboarding.setShowOnboarding;
 
   const {
     selectedActivity,
@@ -145,154 +142,154 @@ export default function PlannerClient({
   const activeIdx = modeOrder.indexOf(mode);
 
   return (
-    <main
-      id="main-content"
-      className="bg-card flex h-screen flex-col overflow-hidden p-4 md:pb-12 lg:px-12"
-    >
-      {/* HEADER */}
-      <div className="container flex items-center justify-between gap-4 pb-4">
-        <h1 className="bg-card inline-flex flex-none cursor-pointer rounded-md text-3xl font-semibold whitespace-nowrap capitalize hover:bg-[color-mix(in_oklch,var(--card)_75%,var(--card-foreground)_5%)] md:text-5xl">
-          <input
-            id="planner-title"
-            name="title"
-            role="heading"
-            aria-level={1}
-            aria-label="Planner title"
-            type="text"
-            ref={titleRef}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            style={{ width: `${titleWidth}px` }}
-            onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
-            className="focus:border-border focus:bg-background cursor-pointer rounded-md border-2 border-transparent bg-transparent px-4 py-2 transition-colors outline-none focus:cursor-text"
-          />
-        </h1>
-        {!hideCatalog && (
-          <>
-            <div className="flex gap-2 md:hidden">
-              <DateRangePickerIcon value={currentRange} onChange={handleRangeChange} />
-              <OpenPanelIcon onClick={() => setIsPanelOpen(true)} />
-            </div>
-            <div className="hidden md:flex">
-              <OpenPanelButton days={days} onClick={() => setIsPanelOpen(true)} />
-            </div>
-          </>
-        )}
-      </div>
-
-      <PlannerControls
-        mode={mode}
-        onModeChange={setMode}
-        range={currentRange}
-        onRangeChange={handleRangeChange}
-      />
-
-      {/* BOARD / MAP / BUDGET */}
-      <div className="relative order-2 container flex-1 overflow-visible md:order-3">
-        {modeOrder.map((m, idx) => {
-          const isActive = idx === activeIdx;
-          const rel = idx - activeIdx;
-          const abs = Math.abs(idx - activeIdx);
-          const z = 3 - abs;
-          const offsetMap = [0, 6, 10];
-          const offset = offsetMap[abs] * Math.sign(rel);
-          const scaleMap = [1, 0.92, 0.87];
-          const scale = scaleMap[abs] ?? 0.7;
-          const opacityMap = [1, 0.92, 0.8];
-          const opacity = opacityMap[abs] ?? 0.6;
-          const rotate = rel * 2;
-
-          return (
-            <motion.div
-              key={m}
-              className={`absolute inset-0 ${!isActive ? 'cursor-pointer' : ''}`}
-              style={{ zIndex: z }}
-              initial={false}
-              animate={{ x: `${offset}%`, scale, opacity, rotateZ: rotate }}
-              transition={{ type: 'spring', stiffness: 200, damping: 25 }}
-              onClick={() => !isActive && setMode(m)}
-            >
-              <div style={{ pointerEvents: isActive ? 'auto' : 'none' }} className="h-full">
-                {m === 'planner' && (
-                  <PlannerBoard
-                    days={days}
-                    activeId={stringActiveId}
-                    sensors={sensors}
-                    collisionDetection={collisionDetection}
-                    handleDragStart={handleDragStart}
-                    handleDragOver={handleDragOver}
-                    handleDragEnd={handleDragEnd}
-                    onSelectActivity={setSelectedActivity}
-                    onUpdateTitle={(id, title) => updateActivity(id, { title })}
-                    onAddActivity={(dayId, insertIdx) => addBlankAndSelect(dayId, insertIdx)}
-                    onChangeDay={changeDay}
-                    onChangePosition={changePosition}
-                    onChangeColor={(id, color) => changeColor(id, color)}
-                    onUpdateImage={handleUpdateImage}
-                    onApplyCatalogItem={handleApplyCatalogItem}
-                    onDelete={removeActivity}
-                  />
-                )}
-                {m === 'budget' && (
-                  <BudgetPanel
-                    planId={planId}
-                    activitiesTotal={activitiesTotal}
-                    days={days}
-                    onUpdateBudget={(id, amount) => updateActivity(id, { budget: amount })}
-                  />
-                )}
-                {m === 'map' && (
-                  <MapView
-                    days={days}
-                    onSelectActivity={setSelectedActivity}
-                    centerCoords={destCoords ?? undefined}
-                  />
-                )}
+    <OnboardingProvider planId={planId}>
+      <main
+        id="main-content"
+        className="bg-card flex h-screen flex-col overflow-hidden p-4 md:pb-12 lg:px-12"
+      >
+        {/* HEADER */}
+        <div className="container flex items-center justify-between gap-4 pb-4">
+          <h1 className="bg-card inline-flex flex-none cursor-pointer rounded-md text-3xl font-semibold whitespace-nowrap capitalize hover:bg-[color-mix(in_oklch,var(--card)_75%,var(--card-foreground)_5%)] md:text-5xl">
+            <input
+              id="planner-title"
+              name="title"
+              role="heading"
+              aria-level={1}
+              aria-label="Planner title"
+              type="text"
+              ref={titleRef}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              style={{ width: `${titleWidth}px` }}
+              onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
+              className="focus:border-border focus:bg-background cursor-pointer rounded-md border-2 border-transparent bg-transparent px-4 py-2 transition-colors outline-none focus:cursor-text"
+            />
+          </h1>
+          {!hideCatalog && (
+            <>
+              <div className="flex gap-2 md:hidden">
+                <DateRangePickerIcon value={currentRange} onChange={handleRangeChange} />
+                <OpenPanelIcon onClick={() => setIsPanelOpen(true)} />
               </div>
-            </motion.div>
-          );
-        })}
-      </div>
+              <div className="hidden md:flex">
+                <OpenPanelButton days={days} onClick={() => setIsPanelOpen(true)} />
+              </div>
+            </>
+          )}
+        </div>
 
-      {selectedActivity && (
-        <ActivityModal
-          open
-          activity={selectedActivity}
-          onClose={closeModal}
-          onSave={save}
-          onDelete={deleteActivity}
-          color={selectedActivity.color}
-          onColorChange={(newColor) => changeColor(selectedActivity.id, newColor)}
-          days={days}
-          onChangeDay={(dayId) => changeDay(selectedActivity.id, dayId)}
-          onChangePosition={(idx) => changePosition(selectedActivity.id, idx)}
+        <PlannerControls
+          mode={mode}
+          onModeChange={setMode}
+          range={currentRange}
+          onRangeChange={handleRangeChange}
         />
-      )}
 
-      {!hideOnboarding && (
-        <OnboardingModal open={showOnboarding} onClose={() => setShowOnboarding(false)} />
-      )}
-      {!hideCatalog && (
-        <DestinationFilterPanel
-          isOpen={isPanelOpen}
-          onClose={() => setIsPanelOpen(false)}
-          dest={dest}
-          onAdd={(item: CatalogActivity) =>
-            addActivity({
-              id: item.id,
-              title: item.name,
-              imageUrl: item.imageUrl,
-              address: item.address,
-              latitude: item.latitude,
-              longitude: item.longitude,
-              color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
-              startTime: '',
-            })
-          }
-          onRemove={removeActivity}
-          addedIds={addedIds}
-        />
-      )}
-    </main>
+        {/* BOARD / MAP / BUDGET */}
+        <div className="relative order-2 container flex-1 overflow-visible md:order-3">
+          {modeOrder.map((m, idx) => {
+            const isActive = idx === activeIdx;
+            const rel = idx - activeIdx;
+            const abs = Math.abs(idx - activeIdx);
+            const z = 3 - abs;
+            const offsetMap = [0, 6, 10];
+            const offset = offsetMap[abs] * Math.sign(rel);
+            const scaleMap = [1, 0.92, 0.87];
+            const scale = scaleMap[abs] ?? 0.7;
+            const opacityMap = [1, 0.92, 0.8];
+            const opacity = opacityMap[abs] ?? 0.6;
+            const rotate = rel * 2;
+
+            return (
+              <motion.div
+                key={m}
+                className={`absolute inset-0 ${!isActive ? 'cursor-pointer' : ''}`}
+                style={{ zIndex: z }}
+                initial={false}
+                animate={{ x: `${offset}%`, scale, opacity, rotateZ: rotate }}
+                transition={{ type: 'spring', stiffness: 200, damping: 25 }}
+                onClick={() => !isActive && setMode(m)}
+              >
+                <div style={{ pointerEvents: isActive ? 'auto' : 'none' }} className="h-full">
+                  {m === 'planner' && (
+                    <PlannerBoard
+                      days={days}
+                      activeId={stringActiveId}
+                      sensors={sensors}
+                      collisionDetection={collisionDetection}
+                      handleDragStart={handleDragStart}
+                      handleDragOver={handleDragOver}
+                      handleDragEnd={handleDragEnd}
+                      onSelectActivity={setSelectedActivity}
+                      onUpdateTitle={(id, title) => updateActivity(id, { title })}
+                      onAddActivity={(dayId, insertIdx) => addBlankAndSelect(dayId, insertIdx)}
+                      onChangeDay={changeDay}
+                      onChangePosition={changePosition}
+                      onChangeColor={(id, color) => changeColor(id, color)}
+                      onUpdateImage={handleUpdateImage}
+                      onApplyCatalogItem={handleApplyCatalogItem}
+                      onDelete={removeActivity}
+                    />
+                  )}
+                  {m === 'budget' && (
+                    <BudgetPanel
+                      planId={planId}
+                      activitiesTotal={activitiesTotal}
+                      days={days}
+                      onUpdateBudget={(id, amount) => updateActivity(id, { budget: amount })}
+                    />
+                  )}
+                  {m === 'map' && (
+                    <MapView
+                      days={days}
+                      onSelectActivity={setSelectedActivity}
+                      centerCoords={destCoords ?? undefined}
+                    />
+                  )}
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        {selectedActivity && (
+          <ActivityModal
+            open
+            activity={selectedActivity}
+            onClose={closeModal}
+            onSave={save}
+            onDelete={deleteActivity}
+            color={selectedActivity.color}
+            onColorChange={(newColor) => changeColor(selectedActivity.id, newColor)}
+            days={days}
+            onChangeDay={(dayId) => changeDay(selectedActivity.id, dayId)}
+            onChangePosition={(idx) => changePosition(selectedActivity.id, idx)}
+          />
+        )}
+
+        {!hideOnboarding && <OnboardingModal />}
+        {!hideCatalog && (
+          <DestinationFilterPanel
+            isOpen={isPanelOpen}
+            onClose={() => setIsPanelOpen(false)}
+            dest={dest}
+            onAdd={(item: CatalogActivity) =>
+              addActivity({
+                id: item.id,
+                title: item.name,
+                imageUrl: item.imageUrl,
+                address: item.address,
+                latitude: item.latitude,
+                longitude: item.longitude,
+                color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
+                startTime: '',
+              })
+            }
+            onRemove={removeActivity}
+            addedIds={addedIds}
+          />
+        )}
+      </main>
+    </OnboardingProvider>
   );
 }

--- a/src/components/planner/onboarding/OnboardingModal.test.tsx
+++ b/src/components/planner/onboarding/OnboardingModal.test.tsx
@@ -5,10 +5,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import OnboardingModal from './OnboardingModal';
 import { ONBOARDING_STEPS } from '@/constants';
 import { vi } from 'vitest';
+import { OnboardingContext } from '@/contexts/OnboardingContext';
 
 describe('OnboardingModal', () => {
   it('renders all onboarding steps when open', () => {
-    render(<OnboardingModal open onClose={() => {}} />);
+    render(
+      <OnboardingContext.Provider value={{ showOnboarding: true, setShowOnboarding: vi.fn() }}>
+        <OnboardingModal />
+      </OnboardingContext.Provider>
+    );
     ONBOARDING_STEPS.forEach((step) => {
       expect(screen.getAllByText(step.title).length).toBeGreaterThan(0);
     });
@@ -16,7 +21,11 @@ describe('OnboardingModal', () => {
 
   it('calls onClose when close button clicked', () => {
     const handleClose = vi.fn();
-    render(<OnboardingModal open onClose={handleClose} />);
+    render(
+      <OnboardingContext.Provider value={{ showOnboarding: true, setShowOnboarding: handleClose }}>
+        <OnboardingModal />
+      </OnboardingContext.Provider>
+    );
     fireEvent.click(screen.getByLabelText('Close'));
     expect(handleClose).toHaveBeenCalled();
   });

--- a/src/components/planner/onboarding/OnboardingModal.tsx
+++ b/src/components/planner/onboarding/OnboardingModal.tsx
@@ -6,13 +6,11 @@ import FocusTrap from 'focus-trap-react';
 import ReactDOM from 'react-dom';
 import { OnboardingCarousel, CloseButton } from '@/components';
 import { useEscapeKey } from '@/hooks';
+import { useOnboardingContext } from '@/contexts/OnboardingContext';
 
-interface OnboardingModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-export default function OnboardingModal({ open, onClose }: OnboardingModalProps) {
+export default function OnboardingModal() {
+  const { showOnboarding: open, setShowOnboarding } = useOnboardingContext();
+  const onClose = () => setShowOnboarding(false);
   useEscapeKey({ onClose, isActive: open });
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/contexts/OnboardingContext.tsx
+++ b/src/contexts/OnboardingContext.tsx
@@ -1,0 +1,16 @@
+// src/contexts/OnboardingContext.tsx
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useOnboardingCheck } from '@/hooks';
+
+export const OnboardingContext = createContext<ReturnType<typeof useOnboardingCheck> | null>(null);
+
+export function OnboardingProvider({ planId, children }: { planId: string; children: ReactNode }) {
+  const value = useOnboardingCheck(planId);
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}
+
+export function useOnboardingContext() {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) throw new Error('useOnboardingContext must be inside OnboardingProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `OnboardingContext` to manage onboarding state
- wrap `PlannerClient` tree in `OnboardingProvider`
- simplify `OnboardingModal` to read context instead of props
- adjust tests and docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688969520ae08322a62af54d9df727aa