### PR TITLE
Introduce PlannerContext and update components

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -241,7 +241,7 @@ This document summarizes each React component in the repository. It follows the 
 
 - **Location:** `src/components/planner/catalog/DestinationFilterPanel.tsx`
 - **Responsibility:** Full catalog modal with search and filters.
-- **Props:** `{ isOpen, onClose, onAdd, onRemove, dest, addedIds? }`
+- **Props:** `{ isOpen, onClose }`
 - **State:** handled in `useDestinationFilter`
 - **External Hooks:** `useDestinationFilter`, `useEscapeKey`
 - **Side-effects:** portal rendering
@@ -323,7 +323,7 @@ This document summarizes each React component in the repository. It follows the 
 
 - **Location:** `src/components/planner/modal`
 - **Responsibility:** Modal for editing an activity (header tools and form).
-- **Props:** various: open state, activity data, callbacks for delete/save/etc.
+- **Props:** none (reads selected activity from context)
 - **State:** `draft` state in modal
 - **External Hooks:** `useEscapeKey`
 - **Side-effects:** portal rendering, updates draft when activity changes
@@ -437,11 +437,11 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** numerous callbacks: `handleDragStart`, `handleDragEnd`, etc.
 - **Performance notes:** `useMemo` for totals and added ID set
 
-### PlannerBoard
+-### PlannerBoard
 
 - **Location:** `src/app/planner/PlannerBoard.tsx`
 - **Responsibility:** Renders droppable board of days using DnD Kit.
-- **Props:** days array, DnD sensors, callbacks
+- **Props:** none (reads data from `PlannerContext`)
 - **State:** none
 - **External Hooks:** `useActivitiesById`
 - **Side-effects:** none
@@ -449,11 +449,11 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** drag start/over/end events
 - **Performance notes:** memoizes activity lookups
 
-### PlannerControls
+-### PlannerControls
 
 - **Location:** `src/components/planner/PlannerControls.tsx`
 - **Responsibility:** Wrapper for the view mode switch and trip date range picker.
-- **Props:** `{ mode, onModeChange, range, onRangeChange }`
+- **Props:** `{ mode, onModeChange }`
 - **State:** none
 - **External Hooks:** none
 - **Side-effects:** none
@@ -461,11 +461,11 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** toggles modes, selects date ranges
 - **Performance notes:** none
 
-### BudgetPanel
+-### BudgetPanel
 
 - **Location:** `src/app/planner/BudgetPanel.tsx`
 - **Responsibility:** Panel displaying and editing trip budget.
-- **Props:** `{ planId, activitiesTotal, days, onUpdateBudget }`
+- **Props:** none (uses `PlannerContext`)
 - **State:** `editActivities` toggle
 - **External Hooks:** `useBudget`
 - **Side-effects:** none
@@ -473,10 +473,10 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** open activities popup, update entries
 - **Performance notes:** none
 
-### MapView
+-### MapView
 
 - **Location:** `src/app/planner/MapView.tsx`
 - **Responsibility:** Interactive itinerary map using Leaflet to display markers and paths.
-- **Props:** `{ days: DayPlan[], onSelectActivity: (activity) => void, centerCoords?: { lat: number; lng: number } }`
+- **Props:** none (uses `PlannerContext`)
 - **Accessibility:** `<MapContainer>` labeled with `aria-label="Itinerary map"`.
 - **Performance notes:** Fits bounds to markers when coordinates change.

--- a/src/app/planner/BudgetPanel.test.tsx
+++ b/src/app/planner/BudgetPanel.test.tsx
@@ -3,12 +3,62 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import BudgetPanel from '@/app/planner/BudgetPanel';
+import { PlannerProvider } from '@/contexts/PlannerContext';
+import { vi } from 'vitest';
+import type { DayPlan } from '@/types';
+
+let mockDays: DayPlan[] = [];
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    usePlanner: () => ({
+      planId: 'test',
+      dest: 'rome',
+      days: mockDays,
+      destCoords: null,
+      setDays: vi.fn(),
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      activeId: null,
+      sensors: [],
+      collisionDetection: vi.fn(),
+      handleDragStart: vi.fn(),
+      handleDragOver: vi.fn(),
+      handleDragEnd: vi.fn(),
+      addActivity: vi.fn(),
+      removeActivity: vi.fn(),
+      updateActivity: vi.fn(),
+      addBlankActivity: vi.fn(),
+    }),
+    useSelectedActivity: () => ({
+      selectedActivity: null,
+      setSelectedActivity: vi.fn(),
+      changeDay: vi.fn(),
+      changePosition: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+      closeModal: vi.fn(),
+      save: vi.fn(),
+      deleteActivity: vi.fn(),
+      changeColor: vi.fn(),
+    }),
+  };
+});
 
 describe('BudgetPanel', () => {
   it('adds expenses and updates totals', () => {
-    const days = [{ id: 'd1', label: 'Day 1', activities: [] }];
+    mockDays = [
+      {
+        id: 'd1',
+        label: 'Day 1',
+        activities: [{ id: 'a1', title: 'Act', color: 'red', budget: 25 }],
+      },
+    ];
     render(
-      <BudgetPanel planId="test" activitiesTotal={25} days={days} onUpdateBudget={() => {}} />
+      <PlannerProvider>
+        <BudgetPanel />
+      </PlannerProvider>
     );
     fireEvent.change(screen.getByPlaceholderText('Description'), {
       target: { value: 'Taxi' },

--- a/src/app/planner/BudgetPanel.tsx
+++ b/src/app/planner/BudgetPanel.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { Info } from 'lucide-react';
 import { useBudget } from '@/hooks/budget/useBudget';
 import { BUDGET_INFO } from '@/constants';
-import type { DayPlan } from '@/types';
+import { usePlannerContext } from '@/contexts/PlannerContext';
 import {
   BudgetPanelHeader,
   InfoPopup,
@@ -14,14 +14,12 @@ import {
   ActivitiesBudgetPopup,
 } from '@/components';
 
-interface Props {
-  planId: string;
-  activitiesTotal: number;
-  days: DayPlan[];
-  onUpdateBudget: (id: string, amount: number) => void;
-}
-
-export default function BudgetPanel({ planId, activitiesTotal, days, onUpdateBudget }: Props) {
+export default function BudgetPanel() {
+  const { planId, days, updateActivity } = usePlannerContext();
+  const activitiesTotal = days.reduce(
+    (sum, day) => sum + day.activities.reduce((acc, act) => acc + (act.budget ?? 0), 0),
+    0
+  );
   const {
     budget,
     setBudget,
@@ -92,7 +90,7 @@ export default function BudgetPanel({ planId, activitiesTotal, days, onUpdateBud
       <ActivitiesBudgetPopup
         open={editActivities}
         days={days}
-        onUpdate={onUpdateBudget}
+        onUpdate={(id, amount) => updateActivity(id, { budget: amount })}
         onClose={() => setEditActivities(false)}
       />
     </div>

--- a/src/app/planner/MapView.test.tsx
+++ b/src/app/planner/MapView.test.tsx
@@ -4,12 +4,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
 import MapView from './MapView';
+import { PlannerProvider } from '@/contexts/PlannerContext';
 import type { DayPlan } from '@/types';
 
 // Reuse the same mocks across tests
 const map = { fitBounds: vi.fn() };
 const markers: Array<{ title?: string }> = [];
 let containerProps: { center?: unknown } | undefined;
+
+let mockDays: DayPlan[] = [];
+let mockDestCoords: { lat: number; lng: number } | null = null;
 
 // Stub react-leaflet
 vi.mock('react-leaflet', () => {
@@ -29,6 +33,43 @@ vi.mock('react-leaflet', () => {
   };
 });
 
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    usePlanner: () => ({
+      planId: 'p1',
+      dest: 'rome',
+      days: mockDays,
+      destCoords: mockDestCoords,
+      setDays: vi.fn(),
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      activeId: null,
+      sensors: [],
+      collisionDetection: vi.fn(),
+      handleDragStart: vi.fn(),
+      handleDragOver: vi.fn(),
+      handleDragEnd: vi.fn(),
+      addActivity: vi.fn(),
+      removeActivity: vi.fn(),
+      updateActivity: vi.fn(),
+      addBlankActivity: vi.fn(),
+    }),
+    useSelectedActivity: () => ({
+      selectedActivity: null,
+      setSelectedActivity: vi.fn(),
+      changeDay: vi.fn(),
+      changePosition: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+      closeModal: vi.fn(),
+      save: vi.fn(),
+      deleteActivity: vi.fn(),
+      changeColor: vi.fn(),
+    }),
+  };
+});
+
 // Simplify Leaflet utilities
 vi.mock('leaflet', () => ({
   __esModule: true,
@@ -43,6 +84,7 @@ describe('FitAllMarkers effect', () => {
     map.fitBounds.mockClear();
     markers.length = 0;
     containerProps = undefined;
+    mockDestCoords = null;
   });
 
   const baseActivity = { id: 'a1', title: 'A1', color: 'red' };
@@ -56,13 +98,27 @@ describe('FitAllMarkers effect', () => {
   ];
 
   it('runs when coordinates change', () => {
-    const { rerender } = render(<MapView days={buildDays([1, 1])} onSelectActivity={() => {}} />);
+    mockDays = buildDays([1, 1]);
+    const { rerender } = render(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
 
-    rerender(<MapView days={buildDays([1, 1])} onSelectActivity={() => {}} />);
+    rerender(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
 
-    rerender(<MapView days={buildDays([2, 2])} onSelectActivity={() => {}} />);
+    mockDays = buildDays([2, 2]);
+    rerender(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(map.fitBounds).toHaveBeenCalledTimes(2);
   });
 });
@@ -71,6 +127,7 @@ describe('Marker accessibility', () => {
   afterEach(() => {
     markers.length = 0;
     containerProps = undefined;
+    mockDestCoords = null;
   });
 
   it('sets each marker title', () => {
@@ -82,7 +139,12 @@ describe('Marker accessibility', () => {
       },
     ];
 
-    render(<MapView days={days} onSelectActivity={() => {}} />);
+    mockDays = days;
+    render(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(markers[0].title).toBe('Walk');
   });
 
@@ -94,8 +156,13 @@ describe('Marker accessibility', () => {
         activities: [],
       },
     ];
-
-    render(<MapView days={days} onSelectActivity={() => {}} centerCoords={{ lat: 5, lng: 6 }} />);
+    mockDays = days;
+    mockDestCoords = { lat: 5, lng: 6 };
+    render(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(containerProps!.center).toEqual([5, 6]);
   });
 });

--- a/src/app/planner/MapView.tsx
+++ b/src/app/planner/MapView.tsx
@@ -4,13 +4,9 @@
 import React, { useRef, useEffect, useMemo } from 'react';
 import { MapContainer, TileLayer, Marker, Polyline, useMap } from 'react-leaflet';
 import L, { LatLngExpression, LeafletMouseEvent } from 'leaflet';
-import type { DayPlan, Activity } from '@/types';
+import { usePlannerContext } from '@/contexts/PlannerContext';
 
-interface MapViewProps {
-  days: DayPlan[];
-  onSelectActivity: (activity: Activity & { dayId: string }) => void;
-  centerCoords?: { lat: number; lng: number };
-}
+interface MapViewProps {}
 
 // Extract the CSS color from a Tailwind class like "bg-[var(--color-X)]"
 const getCssColor = (cls: string): string => {
@@ -44,7 +40,9 @@ function FitAllMarkers({ coords }: { coords: LatLngExpression[] }) {
   return null;
 }
 
-export default function MapView({ days, onSelectActivity, centerCoords }: MapViewProps) {
+export default function MapView() {
+  const { days, setSelectedActivity, destCoords } = usePlannerContext();
+  const centerCoords = destCoords ?? undefined;
   const dayPaths = useMemo(
     () =>
       days
@@ -116,13 +114,13 @@ export default function MapView({ days, onSelectActivity, centerCoords }: MapVie
                   title={act.title}
                   eventHandlers={{
                     click: () =>
-                      onSelectActivity({
+                      setSelectedActivity({
                         ...act,
                         dayId: day.id,
                       }),
                     contextmenu: (e: LeafletMouseEvent) => {
                       e.originalEvent.preventDefault();
-                      onSelectActivity({
+                      setSelectedActivity({
                         ...act,
                         dayId: day.id,
                       });

--- a/src/app/planner/PlannerBoard.test.tsx
+++ b/src/app/planner/PlannerBoard.test.tsx
@@ -4,7 +4,9 @@ import { render, screen } from '@testing-library/react';
 import { within } from '@testing-library/react';
 import { closestCenter } from '@dnd-kit/core';
 import PlannerBoard from '@/app/planner/PlannerBoard';
+import { PlannerProvider } from '@/contexts/PlannerContext';
 import type { DayPlan, Activity } from '@/types';
+import { vi } from 'vitest';
 
 function buildActivities(prefix: string, count: number): Activity[] {
   return Array.from({ length: count }).map((_, i) => ({
@@ -14,29 +16,55 @@ function buildActivities(prefix: string, count: number): Activity[] {
   }));
 }
 
+let mockDays: DayPlan[] = [];
+
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    usePlanner: () => ({
+      planId: 'p1',
+      dest: 'rome',
+      days: mockDays,
+      destCoords: null,
+      setDays: vi.fn(),
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      activeId: null,
+      sensors: [],
+      collisionDetection: closestCenter,
+      handleDragStart: vi.fn(),
+      handleDragOver: vi.fn(),
+      handleDragEnd: vi.fn(),
+      addActivity: vi.fn(),
+      removeActivity: vi.fn(),
+      updateActivity: vi.fn(),
+      addBlankActivity: vi.fn(),
+    }),
+    useSelectedActivity: () => ({
+      selectedActivity: null,
+      setSelectedActivity: vi.fn(),
+      changeDay: vi.fn(),
+      changePosition: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+      closeModal: vi.fn(),
+      save: vi.fn(),
+      deleteActivity: vi.fn(),
+      changeColor: vi.fn(),
+    }),
+  };
+});
+
 function renderBoard() {
-  const days: DayPlan[] = [
+  mockDays = [
     { id: 'd1', label: 'Day 1', activities: buildActivities('a', 15) },
     { id: 'd2', label: 'Day 2', activities: buildActivities('b', 15) },
   ];
   render(
     <div style={{ height: '200px' }}>
-      <PlannerBoard
-        days={days}
-        activeId={null}
-        sensors={[]}
-        collisionDetection={closestCenter}
-        handleDragStart={() => {}}
-        handleDragOver={() => {}}
-        handleDragEnd={() => {}}
-        onSelectActivity={() => {}}
-        onAddActivity={() => {}}
-        onUpdateTitle={() => {}}
-        onChangeDay={() => {}}
-        onChangePosition={() => {}}
-        onChangeColor={() => {}}
-        onDelete={() => {}}
-      />
+      <PlannerProvider>
+        <PlannerBoard />
+      </PlannerProvider>
     </div>
   );
 }

--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -16,51 +16,45 @@ import { restrictToWindowEdges } from '@dnd-kit/modifiers';
 
 import { DayColumn, SortableItem, DragOverlayFallback } from '@/components';
 import { useActivitiesById } from '@/hooks';
-import type { Activity, DayPlan, CatalogActivity } from '@/types';
-
-export interface PlannerBoardProps {
-  days: DayPlan[];
-  activeId: string | null;
-  sensors: SensorDescriptor<SensorOptions>[];
-  collisionDetection: CollisionDetection;
-  handleDragStart: (e: DragStartEvent) => void;
-  handleDragOver: (e: DragOverEvent) => void;
-  handleDragEnd: (e: DragEndEvent) => void;
-  onSelectActivity: (activity: Activity & { dayId: string }) => void;
-  onAddActivity: (dayId: string, index?: number) => void;
-  onUpdateTitle: (id: string, title: string) => void;
-  onChangeDay: (activityId: string, dayId: string) => void;
-  onChangePosition: (activityId: string, index: number) => void;
-  onChangeColor: (activityId: string, color: string) => void;
-  onDelete: (activityId: string) => void;
-  onUpdateImage?: (activityId: string, url: string) => void;
-  onApplyCatalogItem?: (activityId: string, item: CatalogActivity) => void;
-}
+import { usePlannerContext } from '@/contexts/PlannerContext';
+import type { CatalogActivity } from '@/types';
 
 /**
  * Presentation component to render the DnD board.
  * Receives state and handlers from parent via props.
  */
-export default function PlannerBoard({
-  days,
-  activeId,
-  sensors,
-  collisionDetection,
-  handleDragStart,
-  handleDragOver,
-  handleDragEnd,
-  onSelectActivity,
-  onAddActivity,
-  onUpdateTitle,
-  onChangeDay,
-  onChangePosition,
-  onChangeColor,
-  onDelete,
-  onUpdateImage,
-  onApplyCatalogItem,
-}: PlannerBoardProps) {
+export default function PlannerBoard() {
+  const {
+    days,
+    activeId,
+    sensors,
+    collisionDetection,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    setSelectedActivity,
+    addBlankAndSelect,
+    changeDay,
+    changePosition,
+    changeColor,
+    removeActivity,
+    updateActivity,
+    selectedActivity,
+  } = usePlannerContext();
+
   const byId = useActivitiesById(days);
   const active = activeId ? byId[activeId] : null;
+
+  const handleUpdateImage = (id: string, url: string) => {
+    updateActivity(id, { imageUrl: url });
+    if (selectedActivity && selectedActivity.id === id) {
+      setSelectedActivity({ ...selectedActivity, imageUrl: url });
+    }
+  };
+
+  const handleApplyCatalogItem = (id: string, item: CatalogActivity) => {
+    handleUpdateImage(id, item.imageUrl || '');
+  };
 
   return (
     <DndContext
@@ -82,15 +76,15 @@ export default function PlannerBoard({
             <DayColumn
               day={d}
               days={days}
-              onAddActivity={onAddActivity}
-              onSelectActivity={onSelectActivity}
-              onUpdateTitle={onUpdateTitle}
-              onChangeDay={(activityId, dayId) => onChangeDay(activityId, dayId)}
-              onChangePosition={(activityId, idx) => onChangePosition(activityId, idx)}
-              onChangeColor={(activityId, color) => onChangeColor(activityId, color)}
-              onDelete={onDelete}
-              onUpdateImage={onUpdateImage}
-              onApplyCatalogItem={onApplyCatalogItem}
+              onAddActivity={(dayId, idx) => addBlankAndSelect(dayId, idx)}
+              onSelectActivity={(a) => setSelectedActivity(a)}
+              onUpdateTitle={(id, title) => updateActivity(id, { title })}
+              onChangeDay={(activityId, dayId) => changeDay(activityId, dayId)}
+              onChangePosition={(activityId, idx) => changePosition(activityId, idx)}
+              onChangeColor={(activityId, color) => changeColor(activityId, color)}
+              onDelete={removeActivity}
+              onUpdateImage={handleUpdateImage}
+              onApplyCatalogItem={(activityId, item) => handleApplyCatalogItem(activityId, item)}
             />
           </div>
         ))}
@@ -102,13 +96,13 @@ export default function PlannerBoard({
             id={active.id}
             activity={active}
             availableDays={days}
-            onChangeDay={(newDayId) => onChangeDay(active.id, newDayId)}
-            onChangePosition={(idx) => onChangePosition(active.id, idx)}
-            onChangeColor={(newColor) => onChangeColor(active.id, newColor)}
+            onChangeDay={(newDayId) => changeDay(active.id, newDayId)}
+            onChangePosition={(idx) => changePosition(active.id, idx)}
+            onChangeColor={(newColor) => changeColor(active.id, newColor)}
             bgColor={active.color}
-            onDelete={() => onDelete(active.id)}
-            onUpdateImage={(url) => onUpdateImage?.(active.id, url)}
-            onApplyCatalogItem={(item) => onApplyCatalogItem?.(active.id, item)}
+            onDelete={() => removeActivity(active.id)}
+            onUpdateImage={(url) => handleUpdateImage(active.id, url)}
+            onApplyCatalogItem={(item) => handleApplyCatalogItem(active.id, item)}
             aria-grabbed="true"
             aria-label={`Dragging ${active.title}`}
           />

--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -16,17 +16,10 @@ import {
   OnboardingModal,
   PlannerControls,
 } from '@/components';
-import {
-  usePlanner,
-  useActivitiesById,
-  useSelectedActivity,
-  usePlanTitle,
-  useInputWidth,
-  useKeyBinds,
-} from '@/hooks';
+import { usePlanTitle, useInputWidth, useKeyBinds } from '@/hooks';
 import { OnboardingProvider } from '@/contexts/OnboardingContext';
+import { PlannerProvider, usePlannerContext } from '@/contexts/PlannerContext';
 import type { CatalogActivity, DayPlan } from '@/types';
-import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 import { motion } from 'framer-motion';
 
 /**
@@ -47,13 +40,13 @@ interface PlannerClientProps {
   hideCatalog?: boolean;
 }
 
-export default function PlannerClient({
-  initialDays,
-  planId: planIdProp,
-  dest: destProp,
-  hideOnboarding = false,
-  hideCatalog = false,
-}: PlannerClientProps) {
+function PlannerClientInner({
+  hideOnboarding,
+  hideCatalog,
+}: {
+  hideOnboarding: boolean;
+  hideCatalog: boolean;
+}) {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [mode, setMode] = useState<Mode>('planner');
 
@@ -62,7 +55,6 @@ export default function PlannerClient({
     dest,
     days,
     destCoords,
-    setDays,
     currentRange,
     handleRangeChange,
     activeId,
@@ -74,28 +66,19 @@ export default function PlannerClient({
     addActivity,
     removeActivity,
     updateActivity,
-    addBlankActivity,
-  } = usePlanner({ initialDays, planId: planIdProp, dest: destProp });
-
-  const { title, setTitle } = usePlanTitle(planId, dest);
-  const { ref: titleRef, width: titleWidth } = useInputWidth(title);
-
-  const {
+    addBlankAndSelect,
     selectedActivity,
     setSelectedActivity,
     changeDay,
     changePosition,
-    addBlankAndSelect,
     closeModal,
     save,
     deleteActivity,
     changeColor,
-  } = useSelectedActivity(days, setDays, {
-    addActivity,
-    removeActivity,
-    updateActivity,
-    addBlankActivity,
-  });
+  } = usePlannerContext();
+
+  const { title, setTitle } = usePlanTitle(planId, dest);
+  const { ref: titleRef, width: titleWidth } = useInputWidth(title);
 
   const handleUpdateImage = (id: string, url: string) => {
     updateActivity(id, { imageUrl: url });
@@ -105,18 +88,6 @@ export default function PlannerClient({
   const handleApplyCatalogItem = (id: string, item: CatalogActivity) => {
     handleUpdateImage(id, item.imageUrl || '');
   };
-
-  // Build a Set of activity IDs already placed on the board
-  const activitiesById = useActivitiesById(days);
-  const addedIds = useMemo(() => new Set(Object.keys(activitiesById)), [activitiesById]);
-  const activitiesTotal = useMemo(
-    () =>
-      days.reduce(
-        (sum, day) => sum + day.activities.reduce((acc, act) => acc + (act.budget ?? 0), 0),
-        0
-      ),
-    [days]
-  );
 
   useKeyBinds({
     onPlanner: () => setMode('planner'),
@@ -170,12 +141,7 @@ export default function PlannerClient({
           )}
         </div>
 
-        <PlannerControls
-          mode={mode}
-          onModeChange={setMode}
-          range={currentRange}
-          onRangeChange={handleRangeChange}
-        />
+        <PlannerControls mode={mode} onModeChange={setMode} />
 
         {/* BOARD / MAP / BUDGET */}
         <div className="relative order-2 container flex-1 overflow-visible md:order-3">
@@ -205,83 +171,46 @@ export default function PlannerClient({
                 <div style={{ pointerEvents: isActive ? 'auto' : 'none' }} className="h-full">
                   {m === 'planner' && (
                     <PlannerBoard
-                      days={days}
                       activeId={stringActiveId}
                       sensors={sensors}
                       collisionDetection={collisionDetection}
                       handleDragStart={handleDragStart}
                       handleDragOver={handleDragOver}
                       handleDragEnd={handleDragEnd}
-                      onSelectActivity={setSelectedActivity}
                       onUpdateTitle={(id, title) => updateActivity(id, { title })}
-                      onAddActivity={(dayId, insertIdx) => addBlankAndSelect(dayId, insertIdx)}
-                      onChangeDay={changeDay}
-                      onChangePosition={changePosition}
-                      onChangeColor={(id, color) => changeColor(id, color)}
                       onUpdateImage={handleUpdateImage}
                       onApplyCatalogItem={handleApplyCatalogItem}
-                      onDelete={removeActivity}
                     />
                   )}
-                  {m === 'budget' && (
-                    <BudgetPanel
-                      planId={planId}
-                      activitiesTotal={activitiesTotal}
-                      days={days}
-                      onUpdateBudget={(id, amount) => updateActivity(id, { budget: amount })}
-                    />
-                  )}
-                  {m === 'map' && (
-                    <MapView
-                      days={days}
-                      onSelectActivity={setSelectedActivity}
-                      centerCoords={destCoords ?? undefined}
-                    />
-                  )}
+                  {m === 'budget' && <BudgetPanel />}
+                  {m === 'map' && <MapView />}
                 </div>
               </motion.div>
             );
           })}
         </div>
 
-        {selectedActivity && (
-          <ActivityModal
-            open
-            activity={selectedActivity}
-            onClose={closeModal}
-            onSave={save}
-            onDelete={deleteActivity}
-            color={selectedActivity.color}
-            onColorChange={(newColor) => changeColor(selectedActivity.id, newColor)}
-            days={days}
-            onChangeDay={(dayId) => changeDay(selectedActivity.id, dayId)}
-            onChangePosition={(idx) => changePosition(selectedActivity.id, idx)}
-          />
-        )}
+        <ActivityModal />
 
         {!hideOnboarding && <OnboardingModal />}
         {!hideCatalog && (
-          <DestinationFilterPanel
-            isOpen={isPanelOpen}
-            onClose={() => setIsPanelOpen(false)}
-            dest={dest}
-            onAdd={(item: CatalogActivity) =>
-              addActivity({
-                id: item.id,
-                title: item.name,
-                imageUrl: item.imageUrl,
-                address: item.address,
-                latitude: item.latitude,
-                longitude: item.longitude,
-                color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
-                startTime: '',
-              })
-            }
-            onRemove={removeActivity}
-            addedIds={addedIds}
-          />
+          <DestinationFilterPanel isOpen={isPanelOpen} onClose={() => setIsPanelOpen(false)} />
         )}
       </main>
     </OnboardingProvider>
+  );
+}
+
+export default function PlannerClient({
+  initialDays,
+  planId,
+  dest,
+  hideOnboarding = false,
+  hideCatalog = false,
+}: PlannerClientProps) {
+  return (
+    <PlannerProvider initialDays={initialDays} planId={planId} dest={dest}>
+      <PlannerClientInner hideOnboarding={hideOnboarding} hideCatalog={hideCatalog} />
+    </PlannerProvider>
   );
 }

--- a/src/components/planner/PlannerControls.tsx
+++ b/src/components/planner/PlannerControls.tsx
@@ -2,28 +2,26 @@
 'use client';
 
 import React from 'react';
-import { DateRange } from 'react-day-picker';
 import { ModeToggleButton, DateRangePicker } from '@/components';
+import { usePlannerContext } from '@/contexts/PlannerContext';
 
 type Mode = 'planner' | 'map' | 'budget';
 
 interface PlannerControlsProps {
   mode: Mode;
   onModeChange: (m: Mode) => void;
-  range: DateRange | undefined;
-  onRangeChange: (r: DateRange | undefined) => void;
 }
 
-export default function PlannerControls({
-  mode,
-  onModeChange,
-  range,
-  onRangeChange,
-}: PlannerControlsProps) {
+export default function PlannerControls({ mode, onModeChange }: PlannerControlsProps) {
+  const { currentRange, handleRangeChange } = usePlannerContext();
   return (
     <div className="order-3 container flex items-center justify-center gap-4 py-2 md:order-2 md:justify-between md:pt-0 md:pb-4">
       <ModeToggleButton value={mode} onChange={onModeChange} />
-      <DateRangePicker value={range} onChange={onRangeChange} className="hidden md:flex" />
+      <DateRangePicker
+        value={currentRange}
+        onChange={handleRangeChange}
+        className="hidden md:flex"
+      />
     </div>
   );
 }

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -1,7 +1,7 @@
 // src/components/planner/catalog/DestinationFilterPanel.tsx
 'use client';
 
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
 import {
   DestinationHeader,
   DestinationCardGrid,
@@ -11,15 +11,13 @@ import {
 } from '@/components';
 import { GEOAPIFY_CATEGORIES } from '@/lib';
 import type { CatalogActivity } from '@/types';
-import { useDestinationCatalog, useEscapeKey } from '@/hooks';
+import { useDestinationCatalog, useEscapeKey, useActivitiesById } from '@/hooks';
+import { usePlannerContext } from '@/contexts/PlannerContext';
+import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 
 interface DestinationFilterPanelProps {
   isOpen: boolean;
-  dest: string;
   onClose: () => void;
-  onAdd: (a: CatalogActivity) => void; // Catalog items only
-  onRemove: (id: string) => void;
-  addedIds?: Set<string>;
 }
 
 /**
@@ -27,14 +25,10 @@ interface DestinationFilterPanelProps {
  * - Displays catalog items to add to the planner.
  * - Works exclusively with CatalogActivity data.
  */
-export default function DestinationFilterPanel({
-  isOpen,
-  onClose,
-  onAdd,
-  onRemove,
-  dest,
-  addedIds = new Set<string>(),
-}: DestinationFilterPanelProps) {
+export default function DestinationFilterPanel({ isOpen, onClose }: DestinationFilterPanelProps) {
+  const { dest, days, addActivity, removeActivity } = usePlannerContext();
+  const activitiesById = useActivitiesById(days);
+  const addedIds = useMemo(() => new Set<string>(Object.keys(activitiesById)), [activitiesById]);
   const [selectedCats, setSelectedCats] = useState<Set<string>>(new Set());
   const [submitted, setSubmitted] = useState(false);
 
@@ -59,12 +53,21 @@ export default function DestinationFilterPanel({
 
   const handleAdd = (a: CatalogActivity) => {
     scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
-    onAdd(a);
+    addActivity({
+      id: a.id,
+      title: a.name,
+      imageUrl: a.imageUrl,
+      address: a.address,
+      latitude: a.latitude,
+      longitude: a.longitude,
+      color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
+      startTime: '',
+    });
   };
 
   const handleRemove = (id: string) => {
     scrollPosRef.current = scrollRef.current?.scrollTop ?? 0;
-    onRemove(id);
+    removeActivity(id);
   };
 
   useEffect(() => {

--- a/src/components/planner/modal/ActivityModal.tsx
+++ b/src/components/planner/modal/ActivityModal.tsx
@@ -3,41 +3,31 @@
 
 import React, { useEffect, useState } from 'react';
 import { ActivityModalHeader, ActivityModalForm, Modal } from '@/components';
-import type { Activity, DayPlan, CatalogActivity } from '@/types';
+import type { Activity, CatalogActivity } from '@/types';
 import { useEscapeKey } from '@/hooks';
+import { usePlannerContext } from '@/contexts/PlannerContext';
 
-interface ActivityModalProps {
-  open: boolean;
-  activity: Activity & { dayId?: string };
-  onClose: () => void;
-  onDelete: () => void;
-  onSave: (draft: Partial<Activity>) => void;
-  color: string;
-  onColorChange: (color: string) => void;
-  days: DayPlan[];
-  onChangeDay: (dayId: string) => void;
-  onChangePosition: (index: number) => void;
-}
+export default function ActivityModal() {
+  const {
+    selectedActivity: activity,
+    closeModal,
+    save,
+    deleteActivity,
+    changeColor,
+    days,
+    changeDay,
+    changePosition,
+  } = usePlannerContext();
+  const open = Boolean(activity);
+  useEscapeKey({ onClose: closeModal, isActive: open });
 
-export default function ActivityModal({
-  open,
-  activity,
-  onClose,
-  onDelete,
-  onSave,
-  color,
-  onColorChange,
-  days,
-  onChangeDay,
-  onChangePosition,
-}: ActivityModalProps) {
-  useEscapeKey({ onClose, isActive: open });
-
-  const [draft, setDraft] = useState(activity);
+  const [draft, setDraft] = useState(activity ?? ({} as Activity));
 
   useEffect(() => {
-    setDraft(activity);
+    if (activity) setDraft(activity);
   }, [activity]);
+
+  if (!activity) return null;
 
   function handleCatalogSelect(item: CatalogActivity) {
     setDraft((prev) => ({
@@ -57,7 +47,7 @@ export default function ActivityModal({
   return (
     <Modal
       open={open}
-      onClose={onClose}
+      onClose={closeModal}
       overlayClassName="backdrop-overlay"
       aria-labelledby="activity-modal-title"
       className="bg-background focus:ring-primary flex w-[95%] max-w-[452px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
@@ -67,17 +57,17 @@ export default function ActivityModal({
       </h2>
       <ActivityModalHeader
         activity={draft}
-        bgColor={color}
-        onDelete={onDelete}
-        onClose={onClose}
-        onColorChange={onColorChange}
+        bgColor={activity.color}
+        onDelete={deleteActivity}
+        onClose={closeModal}
+        onColorChange={(color) => changeColor(activity.id, color)}
         availableDays={days}
-        onChangeDay={onChangeDay}
-        onChangePosition={onChangePosition}
+        onChangeDay={(dayId) => changeDay(activity.id, dayId)}
+        onChangePosition={(idx) => changePosition(activity.id, idx)}
         onCatalogSelect={handleCatalogSelect}
         onImageChange={handleImageChange}
       />
-      <ActivityModalForm activity={draft} onSave={onSave} color={color} />
+      <ActivityModalForm activity={draft} onSave={save} color={activity.color} />
     </Modal>
   );
 }

--- a/src/contexts/PlannerContext.tsx
+++ b/src/contexts/PlannerContext.tsx
@@ -1,0 +1,39 @@
+// src/contexts/PlannerContext.tsx
+import React, { createContext, useContext, ReactNode } from 'react';
+import { usePlanner, useSelectedActivity } from '@/hooks';
+import type { DayPlan } from '@/types';
+
+type PlannerCtx = ReturnType<typeof usePlanner> & ReturnType<typeof useSelectedActivity>;
+
+export const PlannerContext = createContext<PlannerCtx | null>(null);
+
+export function PlannerProvider({
+  children,
+  initialDays,
+  planId,
+  dest,
+}: {
+  children: ReactNode;
+  initialDays?: DayPlan[];
+  planId?: string;
+  dest?: string;
+}) {
+  const planner = usePlanner({ initialDays, planId, dest });
+  const selected = useSelectedActivity(planner.days, planner.setDays, {
+    addActivity: planner.addActivity,
+    removeActivity: planner.removeActivity,
+    updateActivity: planner.updateActivity,
+    addBlankActivity: planner.addBlankActivity,
+  });
+  return (
+    <PlannerContext.Provider value={{ ...planner, ...selected }}>
+      {children}
+    </PlannerContext.Provider>
+  );
+}
+
+export function usePlannerContext() {
+  const ctx = useContext(PlannerContext);
+  if (!ctx) throw new Error('usePlannerContext must be inside PlannerProvider');
+  return ctx;
+}

--- a/src/hooks/ui/useInputWidth.ts
+++ b/src/hooks/ui/useInputWidth.ts
@@ -1,8 +1,8 @@
 // src/hooks/useInputWidth.ts
-"use client";
+'use client';
 
-import { useRef, useLayoutEffect, useState } from "react";
-import { measureTextWidth } from "@/lib";
+import { useRef, useLayoutEffect, useState } from 'react';
+import { measureTextWidth } from '@/lib';
 
 /**
  * Calculates the pixel width needed to display an input's value
@@ -18,15 +18,13 @@ export function useInputWidth(value: string) {
 
     const style = window.getComputedStyle(el);
     const font = style.font;
-    const paddingLeft = parseFloat(style.paddingLeft || "0");
-    const paddingRight = parseFloat(style.paddingRight || "0");
-    const borderLeft = parseFloat(style.borderLeftWidth || "0");
-    const borderRight = parseFloat(style.borderRightWidth || "0");
+    const paddingLeft = parseFloat(style.paddingLeft || '0');
+    const paddingRight = parseFloat(style.paddingRight || '0');
+    const borderLeft = parseFloat(style.borderLeftWidth || '0');
+    const borderRight = parseFloat(style.borderRightWidth || '0');
 
-    const textWidth = measureTextWidth(value || " ", font);
-    const newWidth = Math.ceil(
-      textWidth + paddingLeft + paddingRight + borderLeft + borderRight
-    );
+    const textWidth = measureTextWidth(value || ' ', font);
+    const newWidth = Math.ceil(textWidth + paddingLeft + paddingRight + borderLeft + borderRight);
     setWidth(newWidth);
   }, [value]);
 

--- a/src/tests/integration/mapRender.spec.tsx
+++ b/src/tests/integration/mapRender.spec.tsx
@@ -4,11 +4,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
 import MapView from '@/app/planner/MapView';
+import { PlannerProvider } from '@/contexts/PlannerContext';
 import type { DayPlan } from '@/types';
 
 const map = { fitBounds: vi.fn() };
 const markers: Array<{ title?: string }> = [];
 let containerProps: { center?: unknown } | undefined;
+let mockDays: DayPlan[] = [];
+let mockDestCoords: { lat: number; lng: number } | null = null;
 
 vi.mock('react-leaflet', () => {
   const React = require('react');
@@ -35,10 +38,49 @@ vi.mock('leaflet', () => ({
   },
 }));
 
+vi.mock('@/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
+  return {
+    ...actual,
+    usePlanner: () => ({
+      planId: 'p1',
+      dest: 'rome',
+      days: mockDays,
+      destCoords: mockDestCoords,
+      setDays: vi.fn(),
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      activeId: null,
+      sensors: [],
+      collisionDetection: vi.fn(),
+      handleDragStart: vi.fn(),
+      handleDragOver: vi.fn(),
+      handleDragEnd: vi.fn(),
+      addActivity: vi.fn(),
+      removeActivity: vi.fn(),
+      updateActivity: vi.fn(),
+      addBlankActivity: vi.fn(),
+    }),
+    useSelectedActivity: () => ({
+      selectedActivity: null,
+      setSelectedActivity: vi.fn(),
+      changeDay: vi.fn(),
+      changePosition: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+      closeModal: vi.fn(),
+      save: vi.fn(),
+      deleteActivity: vi.fn(),
+      changeColor: vi.fn(),
+    }),
+  };
+});
+
 afterEach(() => {
   map.fitBounds.mockClear();
   markers.length = 0;
   containerProps = undefined;
+  mockDays = [];
+  mockDestCoords = null;
 });
 
 describe('map render integration', () => {
@@ -50,14 +92,24 @@ describe('map render integration', () => {
         activities: [{ id: 'a1', title: 'Walk', color: 'red', latitude: 1, longitude: 1 }],
       },
     ];
-
-    render(<MapView days={days} onSelectActivity={() => {}} />);
+    mockDays = days;
+    render(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(markers[0].title).toBe('Walk');
   });
 
   it('centers map using provided coordinates', () => {
     const days: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
-    render(<MapView days={days} onSelectActivity={() => {}} centerCoords={{ lat: 3, lng: 4 }} />);
+    mockDays = days;
+    mockDestCoords = { lat: 3, lng: 4 };
+    render(
+      <PlannerProvider>
+        <MapView />
+      </PlannerProvider>
+    );
     expect(containerProps!.center).toEqual([3, 4]);
   });
 });


### PR DESCRIPTION
## Summary
- add `PlannerProvider` to centralize planner state
- wrap planner client with the new context
- refactor planner components to read from context
- update tests for context usage
- document new props in `COMPONENTS.md`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897077902483228fbd8eb65c51b24b