### PR TITLE
Refactor catalog panel layout

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -237,6 +237,30 @@ This document summarizes each React component in the repository. It follows the 
 - **Interactions:** add/remove actions
 - **Performance notes:** none
 
+### CategorySelection
+
+- **Location:** `src/components/planner/catalog/CategorySelection.tsx`
+- **Responsibility:** Category list and submit button for catalog search.
+- **Props:** `{ categories, active, onToggle, onSearch }`
+- **State:** none
+- **External Hooks:** none
+- **Side-effects:** none
+- **Accessibility:** buttons
+- **Interactions:** toggle categories, start search
+- **Performance notes:** none
+
+### DestinationResultsList
+
+- **Location:** `src/components/planner/catalog/DestinationResultsList.tsx`
+- **Responsibility:** Displays catalog results with loading and error states.
+- **Props:** `{ loading, error, items, addedIds, onAdd, onRemove }`
+- **State:** none
+- **External Hooks:** none
+- **Side-effects:** none
+- **Accessibility:** list semantics
+- **Interactions:** add/remove actions
+- **Performance notes:** none
+
 ### DestinationFilterPanel
 
 - **Location:** `src/components/planner/catalog/DestinationFilterPanel.tsx`

--- a/src/components/planner/catalog/CategorySelection.tsx
+++ b/src/components/planner/catalog/CategorySelection.tsx
@@ -1,0 +1,35 @@
+// src/components/planner/catalog/CategorySelection.tsx
+'use client';
+
+import React from 'react';
+import { CategoryFilterBar } from '@/components';
+
+interface CategorySelectionProps {
+  categories: string[];
+  active: Set<string>;
+  onToggle: (cat: string) => void;
+  onSearch: () => void;
+}
+
+export default function CategorySelection({
+  categories,
+  active,
+  onToggle,
+  onSearch,
+}: CategorySelectionProps) {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+      <div className="flex-1 overflow-x-auto">
+        <CategoryFilterBar categories={categories} active={active} onToggle={onToggle} />
+      </div>
+      <button
+        type="button"
+        disabled={active.size === 0}
+        onClick={onSearch}
+        className="rounded border px-3 py-1 text-sm"
+      >
+        Search
+      </button>
+    </div>
+  );
+}

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -2,13 +2,7 @@
 'use client';
 
 import React, { useRef, useEffect, useState, useMemo } from 'react';
-import {
-  DestinationHeader,
-  DestinationCardGrid,
-  CategoryFilterBar,
-  Spinner,
-  Modal,
-} from '@/components';
+import { DestinationHeader, CategorySelection, DestinationResultsList, Modal } from '@/components';
 import { GEOAPIFY_CATEGORIES } from '@/lib';
 import type { CatalogActivity } from '@/types';
 import { useDestinationCatalog, useEscapeKey, useActivitiesById } from '@/hooks';
@@ -90,23 +84,12 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
       <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
 
       {!submitted && (
-        <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
-          <div className="flex-1 overflow-x-auto">
-            <CategoryFilterBar
-              categories={GEOAPIFY_CATEGORIES}
-              active={selectedCats}
-              onToggle={toggleCat}
-            />
-          </div>
-          <button
-            type="button"
-            disabled={selectedCats.size === 0}
-            onClick={() => setSubmitted(true)}
-            className="rounded border px-3 py-1 text-sm"
-          >
-            Search
-          </button>
-        </div>
+        <CategorySelection
+          categories={GEOAPIFY_CATEGORIES}
+          active={selectedCats}
+          onToggle={toggleCat}
+          onSearch={() => setSubmitted(true)}
+        />
       )}
       {submitted && (
         <div className="flex items-center gap-2 border-b px-4 py-2">
@@ -121,24 +104,15 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
       )}
 
       {submitted && (
-        <div className="flex flex-1 overflow-auto" ref={scrollRef}>
-          <div className="flex-1 p-4">
-            {loading && (
-              <div className="flex items-center gap-2">
-                <Spinner />
-                <span>Loading catalog...</span>
-              </div>
-            )}
-            {error && <p className="text-red-500">{error}</p>}
-            {!loading && !error && (
-              <DestinationCardGrid
-                items={visibleItems}
-                addedIds={addedIds}
-                onAdd={handleAdd}
-                onRemove={handleRemove}
-              />
-            )}
-          </div>
+        <div ref={scrollRef} className="flex flex-1 overflow-auto">
+          <DestinationResultsList
+            loading={loading}
+            error={error}
+            items={visibleItems}
+            addedIds={addedIds}
+            onAdd={handleAdd}
+            onRemove={handleRemove}
+          />
         </div>
       )}
     </Modal>

--- a/src/components/planner/catalog/DestinationResultsList.tsx
+++ b/src/components/planner/catalog/DestinationResultsList.tsx
@@ -1,0 +1,46 @@
+// src/components/planner/catalog/DestinationResultsList.tsx
+'use client';
+
+import React from 'react';
+import { Spinner, DestinationCardGrid } from '@/components';
+import type { CatalogActivity } from '@/types';
+
+interface DestinationResultsListProps {
+  loading: boolean;
+  error: string | null;
+  items: CatalogActivity[];
+  addedIds: Set<string>;
+  onAdd: (a: CatalogActivity) => void;
+  onRemove: (id: string) => void;
+}
+
+export default function DestinationResultsList({
+  loading,
+  error,
+  items,
+  addedIds,
+  onAdd,
+  onRemove,
+}: DestinationResultsListProps) {
+  return (
+    <div className="flex flex-1 overflow-auto">
+      <div className="flex-1 p-4">
+        {loading && (
+          <div className="flex items-center gap-2">
+            <Spinner />
+            <span>Loading catalog...</span>
+          </div>
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+        {!loading && !error && (
+          <DestinationCardGrid
+            items={items}
+            addedIds={addedIds}
+            onAdd={onAdd}
+            onRemove={onRemove}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/planner/catalog/index.ts
+++ b/src/components/planner/catalog/index.ts
@@ -3,5 +3,7 @@
 export { default as CategoryFilterBar } from './CategoryFilterBar';
 export { default as DestinationCard } from './DestinationCard';
 export { default as DestinationCardGrid } from './DestinationCardGrid';
+export { default as DestinationResultsList } from './DestinationResultsList';
 export { default as DestinationFilterPanel } from './DestinationFilterPanel';
 export { default as DestinationHeader } from './DestinationHeader';
+export { default as CategorySelection } from './CategorySelection';


### PR DESCRIPTION
## Summary
- split category chooser and results list into dedicated components
- simplify DestinationFilterPanel composition
- document new components

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68897aef0f3483228b88c234bac1fff0