### PR TITLE
Introduce budget context

### DIFF
--- a/src/app/planner/BudgetPanel.tsx
+++ b/src/app/planner/BudgetPanel.tsx
@@ -3,9 +3,9 @@
 
 import React, { useState } from 'react';
 import { Info } from 'lucide-react';
-import { useBudget } from '@/hooks/budget/useBudget';
 import { BUDGET_INFO } from '@/constants';
 import { usePlannerContext } from '@/contexts/PlannerContext';
+import { BudgetProvider } from '@/contexts/BudgetContext';
 import {
   BudgetPanelHeader,
   InfoPopup,
@@ -20,79 +20,47 @@ export default function BudgetPanel() {
     (sum, day) => sum + day.activities.reduce((acc, act) => acc + (act.budget ?? 0), 0),
     0
   );
-  const {
-    budget,
-    setBudget,
-    entries,
-    categoryTotals,
-    totalSpent,
-    difference,
-    desc,
-    setDesc,
-    cat,
-    setCat,
-    amount,
-    setAmount,
-    handleAdd,
-    handleUpdateEntry,
-    handleDeleteEntry,
-  } = useBudget(planId, activitiesTotal);
 
   const [editActivities, setEditActivities] = useState(false);
 
   return (
-    <div
-      role="region"
-      aria-label="Budget panel"
-      className="bg-background flex h-full w-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl border p-4"
-      tabIndex={0}
-    >
-      <div className="flex justify-between pb-4">
-        <h2 className="text-3xl font-semibold">Traveling Budget</h2>
-        <Button variant="icon" size="sm" onClick={() => setEditActivities(true)}>
-          Budget Your Activities
-        </Button>
-      </div>
-      <BudgetPanelHeader
-        budget={budget}
-        setBudget={setBudget}
-        totalSpent={totalSpent}
-        difference={difference}
-        categoryTotals={categoryTotals}
-      />
+    <BudgetProvider planId={planId} activitiesTotal={activitiesTotal}>
+      <div
+        role="region"
+        aria-label="Budget panel"
+        className="bg-background flex h-full w-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl border p-4"
+        tabIndex={0}
+      >
+        <div className="flex justify-between pb-4">
+          <h2 className="text-3xl font-semibold">Traveling Budget</h2>
+          <Button variant="icon" size="sm" onClick={() => setEditActivities(true)}>
+            Budget Your Activities
+          </Button>
+        </div>
+        <BudgetPanelHeader />
 
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h3 id="expenses-heading" className="flex items-center gap-1 font-semibold">
-            Expenses
-            <InfoPopup content={BUDGET_INFO.expenses} aria-hidden="true">
-              <Info size={12} className="text-muted-foreground" aria-hidden="true" />
-            </InfoPopup>
-          </h3>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 id="expenses-heading" className="flex items-center gap-1 font-semibold">
+              Expenses
+              <InfoPopup content={BUDGET_INFO.expenses} aria-hidden="true">
+                <Info size={12} className="text-muted-foreground" aria-hidden="true" />
+              </InfoPopup>
+            </h3>
+          </div>
+
+          <div aria-labelledby="expenses-heading">
+            <ExpenseTable />
+          </div>
         </div>
 
-        <div aria-labelledby="expenses-heading">
-          <ExpenseTable
-            entries={entries}
-            desc={desc}
-            cat={cat}
-            amount={amount}
-            setDesc={setDesc}
-            setCat={setCat}
-            setAmount={setAmount}
-            onAdd={handleAdd}
-            onUpdate={handleUpdateEntry}
-            onDelete={handleDeleteEntry}
-          />
-        </div>
+        <ActivitiesBudgetPopup
+          open={editActivities}
+          days={days}
+          onUpdate={(id, amount) => updateActivity(id, { budget: amount })}
+          onClose={() => setEditActivities(false)}
+        />
       </div>
-
-      <ActivitiesBudgetPopup
-        open={editActivities}
-        days={days}
-        onUpdate={(id, amount) => updateActivity(id, { budget: amount })}
-        onClose={() => setEditActivities(false)}
-      />
-    </div>
+    </BudgetProvider>
   );
 }

--- a/src/components/planner/budget/BudgetPanelHeader.tsx
+++ b/src/components/planner/budget/BudgetPanelHeader.tsx
@@ -7,22 +7,10 @@ import { InfoPopup } from '@/components';
 import { CATEGORIES, BUDGET_INFO } from '@/constants';
 import { CategoryProgressBar, Input } from '@/components';
 import { normalizeAmount } from '@/utils';
+import { useBudgetContext } from '@/contexts/BudgetContext';
 
-interface Props {
-  budget: number;
-  setBudget: (val: number) => void;
-  totalSpent: number;
-  difference: number;
-  categoryTotals: Record<string, number>;
-}
-
-export default function BudgetPanelHeader({
-  budget,
-  setBudget,
-  totalSpent,
-  difference,
-  categoryTotals,
-}: Props) {
+export default function BudgetPanelHeader() {
+  const { budget, setBudget, totalSpent, difference, categoryTotals } = useBudgetContext();
   const [budgetInput, setBudgetInput] = useState(budget ? String(budget) : '');
 
   return (

--- a/src/components/planner/budget/ExpenseTable.tsx
+++ b/src/components/planner/budget/ExpenseTable.tsx
@@ -4,34 +4,23 @@
 import React, { useState, useEffect } from 'react';
 import { Info } from 'lucide-react';
 import { InfoPopup, TableRowEdit, TableRowEntry, TableRowNew } from '@/components';
-import { CategoryKey, BUDGET_INFO } from '@/constants';
+import { BUDGET_INFO } from '@/constants';
 import type { Entry } from '@/types';
+import { useBudgetContext } from '@/contexts/BudgetContext';
 
-interface ExpenseTableProps {
-  entries: Entry[];
-  desc: string;
-  cat: CategoryKey;
-  amount: number;
-  setDesc: (v: string) => void;
-  setCat: (v: CategoryKey) => void;
-  setAmount: (v: number) => void;
-  onAdd: () => void;
-  onUpdate?: (index: number, updated: Entry) => void;
-  onDelete?: (index: number) => void;
-}
-
-export default function ExpenseTable({
-  entries,
-  desc,
-  cat,
-  amount,
-  setDesc,
-  setCat,
-  setAmount,
-  onAdd,
-  onUpdate,
-  onDelete,
-}: ExpenseTableProps) {
+export default function ExpenseTable() {
+  const {
+    entries,
+    desc,
+    cat,
+    amount,
+    setDesc,
+    setCat,
+    setAmount,
+    handleAdd,
+    handleUpdateEntry,
+    handleDeleteEntry,
+  } = useBudgetContext();
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [editEntry, setEditEntry] = useState<Entry | null>(null);
   const [amountInput, setAmountInput] = useState(amount ? String(amount) : '');
@@ -50,13 +39,6 @@ export default function ExpenseTable({
   const cancelEdit = () => {
     setEditIndex(null);
     setEditEntry(null);
-  };
-
-  const confirmEdit = () => {
-    if (editIndex !== null && editEntry && onUpdate) {
-      onUpdate(editIndex, editEntry);
-      cancelEdit();
-    }
   };
 
   return (
@@ -109,27 +91,24 @@ export default function ExpenseTable({
           editIndex === idx && editEntry ? (
             <TableRowEdit
               key={idx}
+              index={idx}
               editEntry={editEntry}
               setEditEntry={setEditEntry}
               editAmountInput={editAmountInput}
               setEditAmountInput={setEditAmountInput}
-              onConfirm={confirmEdit}
               onCancel={cancelEdit}
             />
           ) : (
-            <TableRowEntry key={idx} index={idx} entry={e} onEdit={startEdit} onDelete={onDelete} />
+            <TableRowEntry
+              key={idx}
+              index={idx}
+              entry={e}
+              onEdit={startEdit}
+              onDelete={handleDeleteEntry}
+            />
           )
         )}
-        <TableRowNew
-          desc={desc}
-          cat={cat}
-          amountInput={amountInput}
-          setDesc={setDesc}
-          setCat={setCat}
-          setAmount={setAmount}
-          setAmountInput={setAmountInput}
-          onAdd={onAdd}
-        />
+        <TableRowNew amountInput={amountInput} setAmountInput={setAmountInput} onAdd={handleAdd} />
       </tbody>
     </table>
   );

--- a/src/components/planner/budget/TableRowEdit.tsx
+++ b/src/components/planner/budget/TableRowEdit.tsx
@@ -7,22 +7,29 @@ import { Button, Input } from '@/components';
 import { CATEGORIES, CategoryKey } from '@/constants';
 import type { Entry } from '@/types';
 import { normalizeAmount } from '@/utils';
+import { useBudgetContext } from '@/contexts/BudgetContext';
 
 export default function TableRowEdit({
   editEntry,
   setEditEntry,
   editAmountInput,
   setEditAmountInput,
-  onConfirm,
+  index,
   onCancel,
 }: {
   editEntry: Entry;
   setEditEntry: React.Dispatch<React.SetStateAction<Entry | null>>;
   editAmountInput: string;
   setEditAmountInput: (val: string) => void;
-  onConfirm: () => void;
+  index: number;
   onCancel: () => void;
 }) {
+  const { handleUpdateEntry } = useBudgetContext();
+
+  const confirm = () => {
+    handleUpdateEntry(index, editEntry);
+    onCancel();
+  };
   // useId generates a unique suffix for each instance
   const baseId = useId();
 
@@ -102,7 +109,7 @@ export default function TableRowEdit({
           size="icon"
           variant="ghost"
           type="button"
-          onClick={onConfirm}
+          onClick={confirm}
           aria-label="Save entry"
           className="focus:ring-primary focus:ring-2 focus:ring-offset-2 focus:outline-none"
         >

--- a/src/components/planner/budget/TableRowNew.tsx
+++ b/src/components/planner/budget/TableRowNew.tsx
@@ -6,26 +6,18 @@ import { Plus, DollarSign } from 'lucide-react';
 import { Button, Input } from '@/components';
 import { CATEGORIES, CategoryKey } from '@/constants';
 import { normalizeAmount } from '@/utils';
+import { useBudgetContext } from '@/contexts/BudgetContext';
 
 export default function TableRowNew({
-  desc,
-  setDesc,
-  cat,
-  setCat,
   amountInput,
   setAmountInput,
-  setAmount,
   onAdd,
 }: {
-  desc: string;
-  setDesc: (v: string) => void;
-  cat: CategoryKey;
-  setCat: (v: CategoryKey) => void;
   amountInput: string;
   setAmountInput: (val: string) => void;
-  setAmount: (v: number) => void;
   onAdd: () => void;
 }) {
+  const { desc, setDesc, cat, setCat, setAmount } = useBudgetContext();
   const baseId = useId();
 
   return (

--- a/src/contexts/BudgetContext.tsx
+++ b/src/contexts/BudgetContext.tsx
@@ -1,0 +1,25 @@
+// src/contexts/BudgetContext.tsx
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useBudget } from '@/hooks';
+import type { CategoryKey, Entry } from '@/types/budget';
+
+export const BudgetContext = createContext<ReturnType<typeof useBudget> | null>(null);
+
+export function BudgetProvider({
+  children,
+  planId,
+  activitiesTotal,
+}: {
+  children: ReactNode;
+  planId: string;
+  activitiesTotal: number;
+}) {
+  const value = useBudget(planId, activitiesTotal);
+  return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;
+}
+
+export function useBudgetContext() {
+  const ctx = useContext(BudgetContext);
+  if (!ctx) throw new Error('useBudgetContext must be inside BudgetProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- create `BudgetContext` for shared budget state
- use `BudgetProvider` in `BudgetPanel`
- refactor budget components to read from context

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68897db866ec8322bb4c55d0bea161c7