### PR TITLE
Fix missing CategoryKey export

### DIFF
--- a/src/types/budget.ts
+++ b/src/types/budget.ts
@@ -1,6 +1,7 @@
 // src/types/budget.ts
 
 import type { CategoryKey } from '@/constants';
+export type { CategoryKey } from '@/constants';
 
 export interface Entry {
   description: string;


### PR DESCRIPTION
## Summary
- re-export `CategoryKey` from budget types to resolve build errors

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6889814587788322ad7e36b80e332d6d