### PR TITLE
refactor: remove address prop from activity card

### DIFF
--- a/src/components/planner/dnd/ActivityCard.tsx
+++ b/src/components/planner/dnd/ActivityCard.tsx
@@ -93,7 +93,6 @@ export default function ActivityCard({
             onSave={save}
             inputRef={inputRef}
             imageUrl={imageUrl}
-            address={activity.address}
             duration={duration}
             twBg={twBg}
             budget={budget}
@@ -130,7 +129,6 @@ export default function ActivityCard({
           }}
           inputRef={inputRef}
           imageUrl={editedImageUrl}
-          address={activity.address}
           duration={duration}
           twBg={twBg}
           budget={budget}

--- a/src/components/planner/dnd/ActivityCardBase.tsx
+++ b/src/components/planner/dnd/ActivityCardBase.tsx
@@ -8,7 +8,6 @@ import { EMPTY_ACTIVITY_TITLE } from '@/constants';
 
 interface ActivityCardBaseProps {
   title: string;
-  address?: string;
   draftTitle?: string;
   onDraftTitleChange?: (value: string) => void;
   onSave?: () => void;

--- a/src/components/planner/dnd/ActivityCardEditing.test.tsx
+++ b/src/components/planner/dnd/ActivityCardEditing.test.tsx
@@ -13,7 +13,6 @@ vi.mock('@/components', async () => {
     name: 'Stub Place',
     description: 'info',
     imageUrl: 'photo.jpg',
-    address: 'Street',
     category: '',
   };
   function CatalogSearchPopup({
@@ -107,7 +106,6 @@ describe('ActivityCardEditing', () => {
       name: 'Stub Place',
       description: 'info',
       imageUrl: 'photo.jpg',
-      address: 'Street',
       category: '',
     });
     expect(setEditedImageUrl).toHaveBeenCalledWith('photo.jpg');


### PR DESCRIPTION
## Summary
- remove unused address prop from ActivityCardBase
- stop ActivityCard from passing address
- drop address fields from ActivityCardEditing test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b706f7ae4832293a95f2b345d82da