### PR TITLE
Add day plan utility tests

### DIFF
--- a/src/utils/formatDayPlan.test.ts
+++ b/src/utils/formatDayPlan.test.ts
@@ -1,0 +1,13 @@
+// src/utils/formatDayPlan.test.ts
+
+import { formatDayPlan } from '@/utils/formatDayPlan';
+import { parseISO } from 'date-fns';
+
+describe('formatDayPlan', () => {
+  it('formats date into id and label', () => {
+    const date = parseISO('2024-07-05T00:00:00Z');
+    const result = formatDayPlan(date);
+
+    expect(result).toEqual({ id: '2024-07-05', label: 'Fri, 05 Jul' });
+  });
+});

--- a/src/utils/initialDays.test.ts
+++ b/src/utils/initialDays.test.ts
@@ -1,0 +1,17 @@
+// src/utils/initialDays.test.ts
+
+import { buildInitialDays } from '@/utils/initialDays';
+import { parseISO } from 'date-fns';
+
+describe('buildInitialDays', () => {
+  it('builds day plans with empty activities', () => {
+    const dates = [parseISO('2024-07-05T00:00:00Z'), parseISO('2024-07-06T00:00:00Z')];
+
+    const result = buildInitialDays(dates);
+
+    expect(result).toEqual([
+      { id: '2024-07-05', label: 'Fri, 05 Jul', activities: [] },
+      { id: '2024-07-06', label: 'Sat, 06 Jul', activities: [] },
+    ]);
+  });
+});

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -6,3 +6,13 @@ import React from 'react';
 vi.mock('focus-trap-react', () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+
+// Canvas isn't implemented in jsdom. Provide a minimal mock so tests using
+// measureText can run without installing additional packages.
+HTMLCanvasElement.prototype.getContext = vi.fn(
+  () =>
+    ({
+      font: '',
+      measureText: vi.fn(() => ({ width: 0 })),
+    }) as unknown as CanvasRenderingContext2D,
+);


### PR DESCRIPTION
## Summary
- test: add canvas mock for tests
- test: add unit tests for `formatDayPlan` and `buildInitialDays`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b708f163c83229cb98a09ed5cd131