### PR TITLE
feat: improve destination input accessibility

### DIFF
--- a/src/components/home/DestinationInput.test.tsx
+++ b/src/components/home/DestinationInput.test.tsx
@@ -5,29 +5,38 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import DestinationInput from './DestinationInput';
 
+const mockUseDestinationAutocomplete = vi.fn();
+
 vi.mock('@/hooks', async () => {
   const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
   return {
     ...actual,
-    useDestinationAutocomplete: () => ({
+    useDestinationAutocomplete: mockUseDestinationAutocomplete,
+  };
+});
+
+describe('DestinationInput', () => {
+  beforeEach(() => {
+    mockUseDestinationAutocomplete.mockReset();
+  });
+
+  it('passes the selected place object when clicking a suggestion', () => {
+    mockUseDestinationAutocomplete.mockReturnValue({
       results: [
         { name: 'Rome, Italy', latitude: 0, longitude: 0 },
         { name: 'London, UK', latitude: 1, longitude: 1 },
       ],
       loading: false,
-    }),
-  };
-});
+      error: false,
+    });
 
-describe('DestinationInput', () => {
-  it('passes the selected place object when clicking a suggestion', () => {
     const handleChange = vi.fn();
     render(<DestinationInput value="" onChange={handleChange} />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('combobox');
     fireEvent.change(input, { target: { value: 'Rome' } });
 
-    const option = screen.getByRole('button', { name: 'Rome, Italy' });
+    const option = screen.getByRole('option', { name: 'Rome, Italy' });
     fireEvent.mouseDown(option);
 
     expect(handleChange).toHaveBeenCalledWith({
@@ -35,5 +44,44 @@ describe('DestinationInput', () => {
       latitude: 0,
       longitude: 0,
     });
+  });
+
+  it('allows selecting a suggestion with keyboard navigation', () => {
+    mockUseDestinationAutocomplete.mockReturnValue({
+      results: [
+        { name: 'Rome, Italy', latitude: 0, longitude: 0 },
+        { name: 'London, UK', latitude: 1, longitude: 1 },
+      ],
+      loading: false,
+      error: false,
+    });
+
+    const handleChange = vi.fn();
+    render(<DestinationInput value="" onChange={handleChange} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'Ro' } });
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(handleChange).toHaveBeenCalledWith({
+      name: 'London, UK',
+      latitude: 1,
+      longitude: 1,
+    });
+  });
+
+  it('renders an error message when the hook returns an error', () => {
+    mockUseDestinationAutocomplete.mockReturnValue({
+      results: [],
+      loading: false,
+      error: true,
+    });
+
+    render(<DestinationInput value="Paris" onChange={() => {}} />);
+
+    expect(screen.getByText('Failed to load suggestions.')).toBeInTheDocument();
   });
 });

--- a/src/components/home/DestinationInput.tsx
+++ b/src/components/home/DestinationInput.tsx
@@ -17,10 +17,17 @@ interface Props {
 }
 
 export default function DestinationInput({ value, onChange }: Props) {
-  const { results, loading } = useDestinationAutocomplete(value);
+  const { results, loading, error } = useDestinationAutocomplete(value);
 
-  // Track whether the suggestion list is visible
   const [open, setOpen] = React.useState(false);
+  const [active, setActive] = React.useState(-1);
+
+  const handleSelect = (r: PlaceSelection) => {
+    onChange({ name: r.name, latitude: r.latitude, longitude: r.longitude });
+    setOpen(false);
+    setActive(-1);
+  };
+
   return (
     <div className="relative">
       <label htmlFor="dest-input" className="sr-only">
@@ -28,46 +35,65 @@ export default function DestinationInput({ value, onChange }: Props) {
       </label>
       <input
         id="dest-input"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls="dest-suggestions"
+        aria-activedescendant={active >= 0 ? `dest-option-${active}` : undefined}
         type="text"
         value={value}
         onChange={(e) => {
           setOpen(true);
+          setActive(-1);
           onChange(e.target.value);
         }}
         onKeyDown={(e) => {
-          if (e.key === 'Tab' && open) {
-            const first = results[0];
-            if (first) {
-              onChange({
-                name: first.name,
-                latitude: first.latitude,
-                longitude: first.longitude,
-              });
+          if (e.key === 'ArrowDown' && results.length > 0) {
+            e.preventDefault();
+            setOpen(true);
+            setActive((i) => (i + 1) % results.length);
+          } else if (e.key === 'ArrowUp' && results.length > 0) {
+            e.preventDefault();
+            setOpen(true);
+            setActive((i) => (i - 1 + results.length) % results.length);
+          } else if ((e.key === 'Enter' || e.key === 'Tab') && open) {
+            const idx = active >= 0 ? active : 0;
+            const r = results[idx];
+            if (r) {
+              e.preventDefault();
+              handleSelect(r);
+            } else {
+              setOpen(false);
             }
-            setOpen(false);
           }
         }}
-        onBlur={() => setOpen(false)}
+        onBlur={() => {
+          setOpen(false);
+          setActive(-1);
+        }}
         placeholder="City"
         className="w-full rounded border px-2 py-1 text-sm"
         autoComplete="off"
       />
       {loading && <Spinner className="absolute top-2 right-2 size-4" />}
-      {open && results.length > 0 && (
-        <ul className="bg-background absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded border text-sm shadow">
-          {results.map((r) => (
+      {error && <p className="mt-1 text-sm text-red-500">Failed to load suggestions.</p>}
+      {open && results.length > 0 && !error && (
+        <ul
+          id="dest-suggestions"
+          role="listbox"
+          className="bg-background absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded border text-sm shadow"
+        >
+          {results.map((r, idx) => (
             <li key={`${r.latitude}-${r.longitude}`}>
               <button
+                id={`dest-option-${idx}`}
+                role="option"
+                aria-selected={active === idx}
+                tabIndex={-1}
                 type="button"
-                className="hover:bg-accent w-full px-2 py-1 text-left"
-                onMouseDown={() => {
-                  onChange({
-                    name: r.name,
-                    latitude: r.latitude,
-                    longitude: r.longitude,
-                  });
-                  setOpen(false);
-                }}
+                className={`w-full px-2 py-1 text-left ${
+                  active === idx ? 'bg-accent' : 'hover:bg-accent'
+                }`}
+                onMouseDown={() => handleSelect(r)}
               >
                 {r.name}
               </button>


### PR DESCRIPTION
## Summary
- show autocomplete errors inline in DestinationInput
- add combobox ARIA attributes and arrow-key navigation for suggestions
- cover selection, keyboard navigation, and error cases with tests

## Testing
- `npm run lint`
- `npm test` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*

------
https://chatgpt.com/codex/tasks/task_e_688b709e12808322aa929d9e7ed5a46f