### PR TITLE
Debounce destination autocomplete requests

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -142,7 +142,7 @@ This document summarizes each React component in the repository. It follows the 
 - **Side-effects:** none
 - **Accessibility:** input label, list of suggestions
   - **Interactions:** choose suggestion via click or Tab key; both return `{ name, latitude, longitude }`
-  - **Performance notes:** none
+  - **Performance notes:** input is debounced before querying
 
 ### InspirationLink
 
@@ -349,12 +349,12 @@ This document summarizes each React component in the repository. It follows the 
 - **Responsibility:** Modal for editing an activity (header tools and form).
 - **Props:** none (reads selected activity from context)
 - **State:** `draft` state in modal
-- **External Hooks:** `useEscapeKey`
+- **External Hooks:** `useEscapeKey`, `useDestinationAutocomplete`
 - **Side-effects:** portal rendering, updates draft when activity changes
 - **Accessibility:** focus trap, ARIA labels, keyboard shortcuts
 - **Interactions:** edit fields (title, address, notes), change day/position, pick color
   - Address field provides Geoapify autocomplete suggestions while typing.
-- **Performance notes:** none
+- **Performance notes:** debounces address input before querying
 
 ---
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -143,11 +143,34 @@ export function useDestinationAutocomplete(query: string);
   Geoapify `results`, loading and error flags.
 - **Lifecycle**
   Fetches `/api/autocomplete?text=` when the query has at least 3 characters.
+  Results are cached for 1 minute and do not refetch on window focus.
 - **Exceptions**
   Sets an error state when the request fails.
 
 ```ts
-const { results } = useDestinationAutocomplete(search);
+const { results } = useDestinationAutocomplete(query);
+```
+
+### `useDebounce`
+
+_File: `src/hooks/useDebounce.ts`_
+
+```ts
+export function useDebounce<T>(value: T, delay?: number): T;
+```
+
+- **Inputs**
+  - `value`: value to debounce.
+  - `delay` (optional): wait time in milliseconds (defaults to `300`).
+- **Outputs**
+  Debounced value that updates after the delay passes.
+- **Lifecycle**
+  Updates the returned value only after the delay when inputs stop changing.
+- **Exceptions**
+  None.
+
+```ts
+const query = useDebounce(input);
 ```
 
 ### `useGeoapifySearch`

--- a/src/components/home/DestinationInput.test.tsx
+++ b/src/components/home/DestinationInput.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/hooks', async () => {
       ],
       loading: false,
     }),
+    useDebounce: (v: unknown) => v,
   };
 });
 

--- a/src/components/home/DestinationInput.tsx
+++ b/src/components/home/DestinationInput.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { Spinner } from '@/components';
-import { useDestinationAutocomplete } from '@/hooks';
+import { useDebounce, useDestinationAutocomplete } from '@/hooks';
 
 interface PlaceSelection {
   name: string;
@@ -17,7 +17,8 @@ interface Props {
 }
 
 export default function DestinationInput({ value, onChange }: Props) {
-  const { results, loading } = useDestinationAutocomplete(value);
+  const debounced = useDebounce(value);
+  const { results, loading } = useDestinationAutocomplete(debounced);
 
   // Track whether the suggestion list is visible
   const [open, setOpen] = React.useState(false);

--- a/src/components/planner/modal/ActivityModalForm.test.tsx
+++ b/src/components/planner/modal/ActivityModalForm.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/hooks', async () => {
       loading: false,
       error: false,
     }),
+    useDebounce: (v: unknown) => v,
   };
 });
 

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -8,7 +8,7 @@ import { DollarSign, Hourglass } from 'lucide-react';
 import type { Activity } from '@/types';
 import { EMPTY_ACTIVITY_TITLE } from '@/constants';
 import { UpdateButton, Input, Spinner } from '@/components';
-import { useDestinationAutocomplete } from '@/hooks';
+import { useDebounce, useDestinationAutocomplete } from '@/hooks';
 
 interface ActivityModalFormProps {
   activity: Activity;
@@ -23,8 +23,9 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
   const [duration, setDuration] = useState<number>(activity.duration || 0);
   const [budget, setBudget] = useState<number>(activity.budget || 0);
   const [editedImageUrl, setEditedImageUrl] = useState(activity.imageUrl ?? '');
+  const debouncedAddress = useDebounce(editedAddress);
   const { results: addressResults, loading: addressLoading } =
-    useDestinationAutocomplete(editedAddress);
+    useDestinationAutocomplete(debouncedAddress);
   const [addressOpen, setAddressOpen] = useState(false);
 
   // Update internal state when the activity prop changes

--- a/src/hooks/catalog/useDestinationAutocomplete.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.ts
@@ -7,12 +7,15 @@ import type { AutocompletePlace } from '@/types';
 
 /**
  * Provides Geoapify autocomplete suggestions when query length is >= 3.
+ * Results are cached for one minute and won't refetch on window focus.
  */
 export function useDestinationAutocomplete(query: string) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['autocomplete', query],
     queryFn: () => fetchAutocomplete(query),
     enabled: query.length >= 3,
+    staleTime: 1000 * 60,
+    refetchOnWindowFocus: false,
   });
 
   return {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,3 +39,6 @@ export * from './ui/usePopupOutsideHandler';
 export * from './ui/useElementRect';
 export * from './ui/useCardColors';
 export * from './ui/useInputWidth';
+
+// shared
+export * from './useDebounce';

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+// src/hooks/useDebounce.ts
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of a value that only updates after the delay passes.
+ */
+export function useDebounce<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- add generic `useDebounce` hook
- debounce address inputs before fetching suggestions
- cache destination autocomplete results for 1 minute

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b70a26e40832299d23a34024f1f53