### PR TITLE
test: add catalog hook tests

### DIFF
--- a/src/hooks/catalog/fetchAutocomplete.test.ts
+++ b/src/hooks/catalog/fetchAutocomplete.test.ts
@@ -1,0 +1,35 @@
+// src/hooks/catalog/fetchAutocomplete.test.ts
+
+import { fetchAutocomplete } from './fetchAutocomplete';
+
+describe('fetchAutocomplete', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test('returns suggestions on success', async () => {
+    const mockResults = [{ name: 'Paris', latitude: 1, longitude: 2 }];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: mockResults }),
+    } as any);
+
+    const result = await fetchAutocomplete('paris');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/autocomplete?text=paris');
+    expect(result).toEqual(mockResults);
+  });
+
+  test('throws on failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as any);
+
+    await expect(fetchAutocomplete('paris')).rejects.toThrow(
+      'Failed to fetch suggestions: HTTP 500'
+    );
+  });
+});

--- a/src/hooks/catalog/fetchCatalog.test.ts
+++ b/src/hooks/catalog/fetchCatalog.test.ts
@@ -1,0 +1,33 @@
+// src/hooks/catalog/fetchCatalog.test.ts
+
+import { fetchCatalog } from './fetchCatalog';
+
+describe('fetchCatalog', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test('returns activities on success', async () => {
+    const mockData = { activities: [{ id: '1', name: 'Louvre', category: 'museum' }] };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as any);
+
+    const result = await fetchCatalog('paris', ['museum']);
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/catalog?dest=paris&cats=museum');
+    expect(result).toEqual(mockData);
+  });
+
+  test('throws on failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as any);
+
+    await expect(fetchCatalog('paris', [])).rejects.toThrow('Failed to fetch catalog: HTTP 404');
+  });
+});

--- a/src/hooks/catalog/fetchSearch.test.ts
+++ b/src/hooks/catalog/fetchSearch.test.ts
@@ -1,0 +1,33 @@
+// src/hooks/catalog/fetchSearch.test.ts
+
+import { fetchSearch } from './fetchSearch';
+
+describe('fetchSearch', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test('returns search results on success', async () => {
+    const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ activities: mockActivities }),
+    } as any);
+
+    const result = await fetchSearch('muse');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/search?q=muse');
+    expect(result).toEqual(mockActivities);
+  });
+
+  test('throws on failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as any);
+
+    await expect(fetchSearch('muse')).rejects.toThrow('Failed to search: HTTP 500');
+  });
+});

--- a/src/hooks/catalog/useCatalog.test.ts
+++ b/src/hooks/catalog/useCatalog.test.ts
@@ -1,0 +1,52 @@
+// src/hooks/catalog/useCatalog.test.ts
+
+import { renderHook } from '@testing-library/react';
+
+vi.mock('@/hooks', () => ({
+  useCatalogActivities: vi.fn(),
+}));
+
+import { useCatalogActivities } from '@/hooks';
+import { useCatalog } from './useCatalog';
+
+const mockUseCatalogActivities = vi.mocked(useCatalogActivities);
+
+describe('useCatalog', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('splits activities into day buckets', () => {
+    const activities = [
+      { id: '1', name: 'A', category: 'c1', imageUrl: 'img1' },
+      { id: '2', name: 'B', category: 'c1', imageUrl: 'img2' },
+      { id: '3', name: 'C', category: 'c1', imageUrl: 'img3' },
+      { id: '4', name: 'D', category: 'c1', imageUrl: 'img4' },
+    ];
+    mockUseCatalogActivities.mockReturnValue({
+      activities,
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useCatalog('Paris', { enabled: true }));
+
+    expect(result.current.days).toHaveLength(2);
+    expect(result.current.days?.[0].activities).toHaveLength(3);
+    expect(result.current.days?.[1].activities).toHaveLength(1);
+    expect(result.current.isError).toBe(false);
+  });
+
+  test('propagates error state', () => {
+    mockUseCatalogActivities.mockReturnValue({
+      activities: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const { result } = renderHook(() => useCatalog('Paris', { enabled: true }));
+
+    expect(result.current.days).toBeUndefined();
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/src/hooks/catalog/useCatalogActivities.test.ts
+++ b/src/hooks/catalog/useCatalogActivities.test.ts
@@ -1,0 +1,55 @@
+// src/hooks/catalog/useCatalogActivities.test.ts
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/hooks', () => ({
+  fetchCatalog: vi.fn(),
+}));
+
+import { fetchCatalog } from '@/hooks';
+import { useCatalogActivities } from './useCatalogActivities';
+
+const mockFetchCatalog = vi.mocked(fetchCatalog);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+describe('useCatalogActivities', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns activities on success', async () => {
+    const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
+    mockFetchCatalog.mockResolvedValue({ activities: mockActivities });
+
+    const { result } = renderHook(() => useCatalogActivities('Paris', { enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.activities).toEqual(mockActivities);
+    expect(result.current.isError).toBe(false);
+  });
+
+  test('handles errors', async () => {
+    mockFetchCatalog.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useCatalogActivities('Paris', { enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.activities).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/hooks/catalog/useDestinationAutocomplete.test.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.test.ts
@@ -1,0 +1,55 @@
+// src/hooks/catalog/useDestinationAutocomplete.test.ts
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/hooks', () => ({
+  fetchAutocomplete: vi.fn(),
+}));
+
+import { fetchAutocomplete } from '@/hooks';
+import { useDestinationAutocomplete } from './useDestinationAutocomplete';
+
+const mockFetchAutocomplete = vi.mocked(fetchAutocomplete);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+describe('useDestinationAutocomplete', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('provides results on success', async () => {
+    const mockResults = [{ name: 'Paris', latitude: 1, longitude: 2 }];
+    mockFetchAutocomplete.mockResolvedValue(mockResults);
+
+    const { result } = renderHook(() => useDestinationAutocomplete('par'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.results).toEqual(mockResults);
+    expect(result.current.error).toBe(false);
+  });
+
+  test('handles errors', async () => {
+    mockFetchAutocomplete.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useDestinationAutocomplete('par'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/hooks/catalog/useDestinationCatalog.test.ts
+++ b/src/hooks/catalog/useDestinationCatalog.test.ts
@@ -1,0 +1,55 @@
+// src/hooks/catalog/useDestinationCatalog.test.ts
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/hooks', () => ({
+  fetchCatalog: vi.fn(),
+}));
+
+import { fetchCatalog } from '@/hooks';
+import { useDestinationCatalog } from './useDestinationCatalog';
+
+const mockFetchCatalog = vi.mocked(fetchCatalog);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+describe('useDestinationCatalog', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns visibleItems on success', async () => {
+    const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
+    mockFetchCatalog.mockResolvedValue({ activities: mockActivities });
+
+    const { result } = renderHook(() => useDestinationCatalog(true, ['museum'], 'Paris'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.visibleItems).toEqual(mockActivities);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('handles errors', async () => {
+    mockFetchCatalog.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useDestinationCatalog(true, ['museum'], 'Paris'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('Failed to load catalog.'));
+
+    expect(result.current.visibleItems).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/hooks/catalog/useGeoapifySearch.test.ts
+++ b/src/hooks/catalog/useGeoapifySearch.test.ts
@@ -1,0 +1,55 @@
+// src/hooks/catalog/useGeoapifySearch.test.ts
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/hooks/catalog/fetchSearch', () => ({
+  fetchSearch: vi.fn(),
+}));
+
+import { fetchSearch } from '@/hooks/catalog/fetchSearch';
+import { useGeoapifySearch } from './useGeoapifySearch';
+
+const mockFetchSearch = vi.mocked(fetchSearch);
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return Wrapper;
+}
+
+describe('useGeoapifySearch', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('provides results on success', async () => {
+    const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
+    mockFetchSearch.mockResolvedValue(mockActivities);
+
+    const { result } = renderHook(() => useGeoapifySearch('par'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.results).toEqual(mockActivities);
+    expect(result.current.error).toBe(false);
+  });
+
+  test('handles errors', async () => {
+    mockFetchSearch.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useGeoapifySearch('par'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for fetchAutocomplete, fetchCatalog, and fetchSearch utilities
- cover destination and catalog hooks for success and error states

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b709627ac832284f797f7b5d7ba76