### PR TITLE
fix: resolve test lint issues

### DIFF
--- a/src/components/home/DestinationInput.test.tsx
+++ b/src/components/home/DestinationInput.test.tsx
@@ -5,19 +5,26 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import DestinationInput from './DestinationInput';
 
-const mockUseDestinationAutocomplete = vi.fn();
+const { mockUseDestinationAutocomplete, mockUseDebounce } = vi.hoisted(() => {
+  return {
+    mockUseDestinationAutocomplete: vi.fn(),
+    mockUseDebounce: vi.fn(),
+  };
+});
 
 vi.mock('@/hooks', async () => {
   const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
   return {
     ...actual,
     useDestinationAutocomplete: mockUseDestinationAutocomplete,
+    useDebounce: mockUseDebounce,
   };
 });
 
 describe('DestinationInput', () => {
   beforeEach(() => {
     mockUseDestinationAutocomplete.mockReset();
+    mockUseDebounce.mockImplementation((v: unknown) => v);
   });
 
   it('passes the selected place object when clicking a suggestion', () => {
@@ -27,11 +34,8 @@ describe('DestinationInput', () => {
         { name: 'London, UK', latitude: 1, longitude: 1 },
       ],
       loading: false,
-       error: false,
-    }),
-    useDebounce: (v: unknown) => v,
-  };
-});
+      error: false,
+    });
 
     const handleChange = vi.fn();
     render(<DestinationInput value="" onChange={handleChange} />);

--- a/src/hooks/catalog/fetchAutocomplete.test.ts
+++ b/src/hooks/catalog/fetchAutocomplete.test.ts
@@ -14,7 +14,7 @@ describe('fetchAutocomplete', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ results: mockResults }),
-    } as any);
+    } as unknown as Response);
 
     const result = await fetchAutocomplete('paris');
 
@@ -26,7 +26,7 @@ describe('fetchAutocomplete', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-    } as any);
+    } as unknown as Response);
 
     await expect(fetchAutocomplete('paris')).rejects.toThrow(
       'Failed to fetch suggestions: HTTP 500'

--- a/src/hooks/catalog/fetchCatalog.test.ts
+++ b/src/hooks/catalog/fetchCatalog.test.ts
@@ -14,7 +14,7 @@ describe('fetchCatalog', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => mockData,
-    } as any);
+    } as unknown as Response);
 
     const result = await fetchCatalog('paris', ['museum']);
 
@@ -26,7 +26,7 @@ describe('fetchCatalog', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,
-    } as any);
+    } as unknown as Response);
 
     await expect(fetchCatalog('paris', [])).rejects.toThrow('Failed to fetch catalog: HTTP 404');
   });

--- a/src/hooks/catalog/fetchSearch.test.ts
+++ b/src/hooks/catalog/fetchSearch.test.ts
@@ -14,7 +14,7 @@ describe('fetchSearch', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ activities: mockActivities }),
-    } as any);
+    } as unknown as Response);
 
     const result = await fetchSearch('muse');
 
@@ -26,7 +26,7 @@ describe('fetchSearch', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-    } as any);
+    } as unknown as Response);
 
     await expect(fetchSearch('muse')).rejects.toThrow('Failed to search: HTTP 500');
   });


### PR DESCRIPTION
## Summary
- fix DestinationInput unit tests and mock hooks safely
- replace explicit any casts in catalog fetch tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b7a74613483229ba3adfe97128fcc