### PR TITLE
fix: stabilize planner client and modal

### DIFF
--- a/src/app/inspiration/InspirationPlanner.tsx
+++ b/src/app/inspiration/InspirationPlanner.tsx
@@ -1,19 +1,17 @@
 // src/app/inspiration/InspirationPlanner.tsx
-'use client';
+import dynamic from 'next/dynamic';
 
-import PlannerClient from '@/app/planner/PlannerClient';
 import type { DayPlan } from '@/types';
-
-/**
- * Interactive planner preloaded with sample days.
- * Used by the city inspiration pages.
- */
 
 interface Props {
   initialDays: DayPlan[];
   dest: string;
   planId: string;
 }
+
+const PlannerClient = dynamic(() => import('@/app/planner/PlannerClient'), {
+  ssr: false,
+});
 
 export default function InspirationPlanner({ initialDays, dest, planId }: Props) {
   return (

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -1,16 +1,17 @@
 // src/app/planner/page.tsx
 'use client';
 
-import { Suspense } from 'react';
-import PlannerClient from './PlannerClient';
+import dynamic from 'next/dynamic';
+
 import { LoadingScreen } from '@/components';
 
 export const dynamic = 'force-dynamic';
 
+const PlannerClient = dynamic(() => import('./PlannerClient'), {
+  ssr: false,
+  loading: () => <LoadingScreen text="Loading planner…" />,
+});
+
 export default function PlannerPage() {
-  return (
-    <Suspense fallback={<LoadingScreen text="Loading planner…" />}>
-      <PlannerClient />
-    </Suspense>
-  );
+  return <PlannerClient />;
 }

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -17,7 +17,7 @@ interface ActivityModalFormProps {
 }
 
 export default function ActivityModalForm({ activity, onSave, color }: ActivityModalFormProps) {
-  const [editedTitle, setEditedTitle] = useState(activity.title);
+  const [editedTitle, setEditedTitle] = useState(activity.title ?? '');
   const [editedDescription, setEditedDescription] = useState(activity.description ?? '');
   const [editedAddress, setEditedAddress] = useState(activity.address ?? '');
   const [duration, setDuration] = useState<number>(activity.duration || 0);
@@ -30,7 +30,7 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
 
   // Update internal state when the activity prop changes
   useEffect(() => {
-    setEditedTitle(activity.title);
+    setEditedTitle(activity.title ?? '');
     setEditedDescription(activity.description ?? '');
     setEditedAddress(activity.address ?? '');
     setDuration(activity.duration || 0);


### PR DESCRIPTION
## Summary
- handle missing activity titles to prevent modal crash
- load PlannerClient dynamically to avoid hydration errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bd67bceec8322b872df4148bd22d3