### PR TITLE
Simplify Geoapify catalog fetching

### DIFF
--- a/src/app/api/catalog/route.ts
+++ b/src/app/api/catalog/route.ts
@@ -8,15 +8,13 @@ import { fetchGeoapifyCatalog } from '@/lib/geoapify';
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const dest = searchParams.get('dest');
-  const cats = searchParams.get('cats');
 
   if (!dest) {
     return NextResponse.json({ error: 'Destination is required.' }, { status: 400 });
   }
 
   try {
-    const categories = cats ? cats.split(',') : undefined;
-    const data = await fetchGeoapifyCatalog(dest, categories);
+    const data = await fetchGeoapifyCatalog(dest);
     return NextResponse.json(data);
   } catch (err) {
     console.error(err);

--- a/src/lib/geoapify.ts
+++ b/src/lib/geoapify.ts
@@ -1,7 +1,6 @@
 // src/lib/geoapify.ts
 
-// Helpers for fetching POIs, place details, images and thumbnails from the
-// Geoapify API + Wikimedia.
+// Helpers for fetching POIs from the Geoapify API.
 
 import type { CatalogActivity, AutocompletePlace } from '@/types';
 
@@ -16,57 +15,17 @@ type GeoapifyFeature = {
     categories?: string[];
     rank?: { popularity?: number };
     distance?: number;
+    image?: string;
+    description?: string;
   };
 };
 type GeoapifyResponse = { features: GeoapifyFeature[] };
-type GeoapifyPlaceDetails = {
-  features: Array<{
-    properties: {
-      place_id?: string | number;
-      name?: string;
-      formatted?: string;
-      lat: number;
-      lon: number;
-      categories?: string[];
-      rank?: { popularity?: number };
-      distance?: number;
-      description?: string;
-      wikipedia_extracts?: { text: string };
-      datasource?: {
-        raw?: {
-          wikidata?: string;
-          wikipedia?: string;
-        };
-        wikidata?: string;
-        wikipedia?: string;
-      };
-    };
-  }>;
-};
 
 /* Static config */
 const DEFAULT_RADIUS_METERS = 20_000;
-const CATALOG_LIMIT = 30;
+const CATALOG_LIMIT = 120;
 
-export const GEOAPIFY_CATEGORIES = [
-  'entertainment.culture',
-  'entertainment.culture.theatre',
-  'entertainment.museum',
-  'entertainment.zoo',
-  'entertainment.aquarium',
-  'entertainment.planetarium',
-  'leisure.park',
-  'leisure.spa.public_bath',
-  'heritage',
-  'national_park',
-  'natural.forest',
-  'natural.water',
-  'natural.mountain',
-  'man_made.tower',
-  'man_made.bridge',
-  'man_made.lighthouse',
-];
-
+export const GEOAPIFY_CATEGORIES = ['tourism'];
 const DEFAULT_CATEGORIES = GEOAPIFY_CATEGORIES.join(',');
 
 /* Geoapify – Autocomplete */
@@ -88,122 +47,6 @@ export async function fetchGeoapifyAutocomplete(text: string): Promise<Autocompl
     latitude: f.properties.lat,
     longitude: f.properties.lon,
   }));
-}
-
-/* Geoapify – Place details (single call)  */
-async function fetchPlaceDetails(
-  placeId: string,
-  key: string
-): Promise<GeoapifyPlaceDetails | null> {
-  const url = `https://api.geoapify.com/v2/place-details?id=${encodeURIComponent(
-    placeId
-  )}&features=details&lang=pt&apiKey=${key}`;
-
-  const r = await fetch(url, { cache: 'no-store' });
-  if (!r.ok) return null;
-
-  return (await r.json()) as GeoapifyPlaceDetails;
-}
-
-/* Wikimedia helpers – extract QID / Wikipedia info */
-function extractWikiIds(details: GeoapifyPlaceDetails | null): {
-  qid?: string;
-  wikiTitle?: string;
-  wikiLang?: string;
-} {
-  // If no details, bail out
-  if (!details?.features?.length) {
-    return { qid: undefined, wikiTitle: undefined, wikiLang: undefined };
-  }
-
-  const props = details.features[0].properties;
-
-  // Geoapify sometimes nests datasource info under props.datasource.raw,
-  // other times it's directly under props.datasource.
-  const ds = props.datasource;
-  const rawSource = ds?.raw ?? ds ?? {};
-
-  // Attempt to read Wikidata QID
-  const qid = typeof rawSource.wikidata === 'string' ? rawSource.wikidata : undefined;
-
-  let wikiTitle: string | undefined;
-  let wikiLang: string | undefined;
-
-  // Attempt to read Wikipedia title (format "lang:Title" or just "Title")
-  if (typeof rawSource.wikipedia === 'string') {
-    const parts = rawSource.wikipedia.split(':', 2);
-    if (parts.length === 2) {
-      wikiLang = parts[0];
-      wikiTitle = parts[1];
-    } else {
-      wikiTitle = rawSource.wikipedia;
-    }
-  }
-
-  return { qid, wikiTitle, wikiLang };
-}
-
-async function wikidataImageFromP18(qid: string) {
-  const url =
-    'https://www.wikidata.org/w/api.php?action=wbgetclaims&property=P18&entity=' +
-    encodeURIComponent(qid) +
-    '&format=json&origin=*';
-
-  const r = await fetch(url, { cache: 'no-store' });
-  if (!r.ok) return null;
-
-  const j = await r.json();
-  const claim = j?.claims?.P18?.[0]?.mainsnak?.datavalue?.value as string | undefined;
-  if (!claim) return null;
-
-  const filename = claim.replace(/ /g, '_');
-  return {
-    url:
-      'https://commons.wikimedia.org/wiki/Special:FilePath/' +
-      encodeURIComponent(filename) +
-      '?width=960',
-    credit: `Imagem: ${filename} · Wikimedia Commons`,
-  };
-}
-
-async function wikipediaThumbnail(title: string, lang = 'pt', width = 960) {
-  const url = `https://${lang}.wikipedia.org/w/api.php?action=query&format=json&formatversion=2&prop=pageimages|pageterms&piprop=thumbnail&pithumbsize=${width}&titles=${encodeURIComponent(
-    title
-  )}&origin=*`;
-
-  const r = await fetch(url, { cache: 'no-store' });
-  if (!r.ok) return null;
-
-  const j = await r.json();
-  const page = j?.query?.pages?.[0];
-  const thumb = page?.thumbnail?.source as string | undefined;
-  if (!thumb) return null;
-
-  return {
-    url: thumb,
-    credit: `Imagem da Wikipédia (${lang}) — ${page?.title ?? title}`,
-  };
-}
-
-/* Image resolver (details -> best image) */
-
-async function resolveBestImage(
-  placeId: string,
-  key: string,
-  details?: Awaited<ReturnType<typeof fetchPlaceDetails>>
-) {
-  const det = details ?? (await fetchPlaceDetails(placeId, key));
-  const { qid, wikiTitle, wikiLang } = extractWikiIds(det);
-
-  if (qid) {
-    const img = await wikidataImageFromP18(qid);
-    if (img) return img;
-  }
-  if (wikiTitle) {
-    const img = await wikipediaThumbnail(wikiTitle, wikiLang ?? 'pt');
-    if (img) return img;
-  }
-  return null;
 }
 
 /* Static‑map thumbnail (fallback) */
@@ -247,59 +90,27 @@ export async function fetchGeoapifyCatalog(
 
   const data = (await res.json()) as GeoapifyResponse;
 
-  // 3) enrich each feature in parallel
-  const activities = await Promise.all(
-    data.features.map(async (f): Promise<CatalogActivity> => {
-      const p = f.properties;
-      const placeId = String(p.place_id);
+  const activities = data.features.map((f): CatalogActivity => {
+    const p = f.properties;
+    const placeId = String(p.place_id);
 
-      const details = await fetchPlaceDetails(placeId, key);
+    const description = p.description;
+    const imageUrl = p.image ?? staticMapThumbnail(p.lat, p.lon, key);
 
-      const description =
-        details?.features?.[0]?.properties?.wikipedia_extracts?.text ??
-        details?.features?.[0]?.properties?.description;
-
-      const img = (await resolveBestImage(placeId, key, details)) ?? {
-        url: staticMapThumbnail(p.lat, p.lon, key),
-      };
-
-      return {
-        id: placeId,
-        name: p.name ?? p.formatted ?? 'Tourist spot',
-        address: p.formatted,
-        description,
-        category: p.categories?.[0] ?? 'sight',
-        rating: p.rank?.popularity,
-        latitude: p.lat,
-        longitude: p.lon,
-        imageUrl: img.url,
-      };
-    })
-  );
+    return {
+      id: placeId,
+      name: p.name ?? p.formatted ?? 'Tourist spot',
+      address: p.formatted,
+      description,
+      category: p.categories?.[0] ?? 'sight',
+      rating: p.rank?.popularity,
+      latitude: p.lat,
+      longitude: p.lon,
+      imageUrl,
+    };
+  });
 
   return { activities };
-}
-
-/* Single place – quick lookup                       */
-
-export async function fetchGeoapifyPlaceDetails(placeId: string) {
-  const key = process.env.GEOAPIFY_KEY;
-  if (!key) throw new Error('GEOAPIFY_KEY not set');
-
-  const details = await fetchPlaceDetails(placeId, key);
-  if (!details) throw new Error('Place details not found');
-
-  const description =
-    details?.features?.[0]?.properties?.wikipedia_extracts?.text ??
-    details?.features?.[0]?.properties?.description;
-
-  const img = await resolveBestImage(placeId, key, details);
-
-  const lat = details.features[0]?.properties?.lat;
-  const lon = details.features[0]?.properties?.lon;
-  const fallback = lat != null && lon != null ? staticMapThumbnail(lat, lon, key) : undefined;
-
-  return { description, imageUrl: img?.url ?? fallback };
 }
 
 /* Text search – fallback “quick search” */
@@ -331,33 +142,25 @@ export async function fetchGeoapifySearch(
 
   const data = (await res.json()) as GeoapifyResponse;
 
-  const activities = await Promise.all(
-    data.features.map(async (f): Promise<CatalogActivity> => {
-      const p = f.properties;
-      const placeId = String(p.place_id);
+  const activities = data.features.map((f): CatalogActivity => {
+    const p = f.properties;
+    const placeId = String(p.place_id);
 
-      const details = await fetchPlaceDetails(placeId, key);
-      const description =
-        details?.features?.[0]?.properties?.wikipedia_extracts?.text ??
-        details?.features?.[0]?.properties?.description;
+    const description = p.description;
+    const imageUrl = p.image ?? staticMapThumbnail(p.lat, p.lon, key);
 
-      const img = (await resolveBestImage(placeId, key, details)) ?? {
-        url: staticMapThumbnail(p.lat, p.lon, key),
-      };
-
-      return {
-        id: placeId,
-        name: p.name ?? p.formatted ?? text,
-        address: p.formatted,
-        description,
-        category: p.categories?.[0] ?? 'sight',
-        rating: p.rank?.popularity,
-        latitude: p.lat,
-        longitude: p.lon,
-        imageUrl: img.url,
-      };
-    })
-  );
+    return {
+      id: placeId,
+      name: p.name ?? p.formatted ?? text,
+      address: p.formatted,
+      description,
+      category: p.categories?.[0] ?? 'sight',
+      rating: p.rank?.popularity,
+      latitude: p.lat,
+      longitude: p.lon,
+      imageUrl,
+    };
+  });
 
   return { activities };
 }


### PR DESCRIPTION
## Summary
- expand Geoapify catalog query with higher limit and tourism default category
- streamline catalog mapping using provided description and image fields
- ignore category query parameters in catalog API route

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bde14c0b883229485c964c81762c0