### PR TITLE
feat: improve catalog panel and query validation

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -70,39 +70,39 @@ export async function fetchCatalog(dest: string, categories: string[]): Promise<
 _File: `src/hooks/useCatalogActivities.ts`_
 
 ```ts
-export function useCatalogActivities(dest: string | null, options: { enabled: boolean });
+export function useCatalogActivities(planId: string | null, options: { enabled: boolean });
 ```
 
 - **Inputs**
-  - `dest`: destination name.
-  - `options.enabled`: whether the query should execute.
+  - `planId`: planner identifier for the storage key.
+  - `options.enabled`: whether the hook should read from storage.
 - **Outputs**
-  Raw catalog `activities` plus React Query props.
+  Raw catalog `activities` plus loading and error flags.
 - **Lifecycle**
-  Fetches catalog data via `useFetchCatalog` when enabled.
+  Loads `catalog-${planId}` from `localStorage` when enabled.
 
 ### `useCatalog`
 
 _File: `src/hooks/useCatalog.ts`_
 
 ```ts
-export function useCatalog(dest: string | null, options: { enabled: boolean });
+export function useCatalog(planId: string | null, options: { enabled: boolean });
 ```
 
 - **Inputs**
-  - `dest`: destination.
-  - `options.enabled`: whether the query should execute.
+  - `planId`: planner identifier for the storage key.
+  - `options.enabled`: whether the hook should load the cached data.
 - **Outputs**
-  React Query result props plus `days` (activities grouped by day).
+  Loading/error flags plus `days` (activities grouped by day).
 - **Lifecycle**
   - Uses `useCatalogActivities` internally to load activities.
   - Memoizes transformation of activities into `DayPlan[]`.
 - **Exceptions**
-  Throws an `Error` if the HTTP response is not OK.
+  None.
 - **Example**
 
 ```ts
-const { days, isLoading } = useCatalog(dest, { enabled: true });
+const { days, isLoading } = useCatalog(planId, { enabled: true });
 ```
 
 ### `useDestinationCatalog`
@@ -110,23 +110,22 @@ const { days, isLoading } = useCatalog(dest, { enabled: true });
 _File: `src/hooks/useDestinationCatalog.ts`_
 
 ```ts
-export function useDestinationCatalog(enabled: boolean, categories: string[], city: string);
+export function useDestinationCatalog(enabled: boolean, planId: string | null);
 ```
 
 - **Inputs**
-  - `enabled`: whether fetching is active.
-  - `categories`: list of selected categories.
-  - `city`: destination name.
+  - `enabled`: whether loading is active.
+  - `planId`: planner identifier for the storage key.
 - **Outputs**
-  Filtered `visibleItems`, loading and error flags, search helpers.
+  Catalog `activities`, derived `categories`, loading and error flags.
 - **Lifecycle**
-  Uses `useCatalogActivities` internally when the panel opens and memoizes the filtered list.
+  Loads activities from `useCatalogActivities` when enabled and memoizes category list.
 - **Exceptions**
-  Sets an error state when the fetch fails.
+  Sets an error state when cached data is missing.
 - **Example**
 
 ```ts
-const { visibleItems } = useDestinationCatalog(open, ['outdoors'], 'rome');
+const { activities } = useDestinationCatalog(open, planId);
 ```
 
 ### `useDestinationAutocomplete`
@@ -142,7 +141,7 @@ export function useDestinationAutocomplete(query: string);
 - **Outputs**
   Geoapify `results`, loading and error flags.
 - **Lifecycle**
-  Fetches `/api/autocomplete?text=` when the query has at least 3 characters.
+  Fetches `/api/autocomplete?text=` when the query has at least 4 characters.
   Results are cached for 1 minute and do not refetch on window focus.
 - **Exceptions**
   Sets an error state when the request fails.
@@ -186,7 +185,7 @@ export function useGeoapifySearch(query: string);
 - **Outputs**
   Catalog `results`, loading and error flags.
 - **Lifecycle**
-  Fetches `/api/search?q=` when the query has at least 3 characters.
+  Fetches `/api/search?q=` when the query has at least 4 characters.
   The backend geocodes the text and searches around that point using the default radius.
 - **Exceptions**
   Sets an error state when the request fails.

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -11,6 +11,9 @@ export async function GET(req: NextRequest) {
   if (!text) {
     return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
   }
+  if (text.length < 4) {
+    return NextResponse.json({ error: 'Query must be at least 4 characters.' }, { status: 400 });
+  }
 
   try {
     const results = await fetchGeoapifyAutocomplete(text);

--- a/src/app/api/catalog/route.ts
+++ b/src/app/api/catalog/route.ts
@@ -8,7 +8,6 @@ import { fetchGeoapifyCatalog } from '@/lib/geoapify';
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const dest = searchParams.get('dest');
-  const cats = searchParams.get('cats');
 
   if (!dest) {
     return NextResponse.json({ error: 'Destination is required.' }, { status: 400 });

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -11,6 +11,9 @@ export async function GET(req: NextRequest) {
   if (!q) {
     return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
   }
+  if (q.length < 4) {
+    return NextResponse.json({ error: 'Query must be at least 4 characters.' }, { status: 400 });
+  }
 
   try {
     const data = await fetchGeoapifySearch(q);

--- a/src/components/home/WelcomeForm.tsx
+++ b/src/components/home/WelcomeForm.tsx
@@ -59,7 +59,7 @@ export default function WelcomeForm() {
     setLoading(true);
     try {
       const planId = crypto.randomUUID();
-      const { activities } = await fetchCatalog(destParam, []);
+      const { activities } = await fetchCatalog(destParam);
       localStorage.setItem(`catalog-${planId}`, JSON.stringify(activities));
       const query = new URLSearchParams({
         dest: destParam,

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -19,14 +19,14 @@ interface DestinationFilterPanelProps {
  * - Works exclusively with CatalogActivity data.
  */
 export default function DestinationFilterPanel({ isOpen, onClose }: DestinationFilterPanelProps) {
-  const { dest, days, addActivity, removeActivity } = usePlannerContext();
+  const { planId, days, addActivity, removeActivity } = usePlannerContext();
   const activitiesById = useActivitiesById(days);
   const addedIds = useMemo(() => new Set<string>(Object.keys(activitiesById)), [activitiesById]);
   const [selectedCats, setSelectedCats] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<'name' | 'rating'>('name');
 
-  const { activities, categories, loading, error } = useDestinationCatalog(isOpen, dest);
+  const { activities, categories, loading, error } = useDestinationCatalog(isOpen, planId);
 
   const toggleCat = (cat: string) =>
     setSelectedCats((prev) => {

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -2,8 +2,7 @@
 'use client';
 
 import React, { useRef, useEffect, useState, useMemo } from 'react';
-import { DestinationHeader, CategorySelection, DestinationResultsList, Modal } from '@/components';
-import { GEOAPIFY_CATEGORIES } from '@/lib';
+import { DestinationHeader, DestinationResultsList, Modal, CategoryFilterBar } from '@/components';
 import type { CatalogActivity } from '@/types';
 import { useDestinationCatalog, useEscapeKey, useActivitiesById } from '@/hooks';
 import { usePlannerContext } from '@/contexts';
@@ -24,7 +23,10 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
   const activitiesById = useActivitiesById(days);
   const addedIds = useMemo(() => new Set<string>(Object.keys(activitiesById)), [activitiesById]);
   const [selectedCats, setSelectedCats] = useState<Set<string>>(new Set());
-  const [submitted, setSubmitted] = useState(false);
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<'name' | 'rating'>('name');
+
+  const { activities, categories, loading, error } = useDestinationCatalog(isOpen, dest);
 
   const toggleCat = (cat: string) =>
     setSelectedCats((prev) => {
@@ -34,11 +36,18 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
       return next;
     });
 
-  const { visibleItems, loading, error, search, setSearch } = useDestinationCatalog(
-    isOpen && submitted,
-    Array.from(selectedCats),
-    dest
-  );
+  const visibleItems = useMemo(() => {
+    const searchLower = search.toLowerCase();
+    let items = activities.filter(
+      (it) =>
+        (!selectedCats.size || selectedCats.has(it.category)) &&
+        it.name.toLowerCase().includes(searchLower)
+    );
+    items = items.sort((a, b) =>
+      sort === 'name' ? a.name.localeCompare(b.name) : (b.rating ?? 0) - (a.rating ?? 0)
+    );
+    return items;
+  }, [activities, search, selectedCats, sort]);
 
   useEscapeKey({ onClose, isActive: isOpen });
   // Preserve scroll position so the list doesn't jump after adding/removing
@@ -83,38 +92,30 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
       {/* header */}
       <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
 
-      {!submitted && (
-        <CategorySelection
-          categories={GEOAPIFY_CATEGORIES}
-          active={selectedCats}
-          onToggle={toggleCat}
-          onSearch={() => setSubmitted(true)}
-        />
-      )}
-      {submitted && (
-        <div className="flex items-center gap-2 border-b px-4 py-2">
-          <button
-            type="button"
-            onClick={() => setSubmitted(false)}
-            className="rounded border px-3 py-1 text-sm"
-          >
-            Back
-          </button>
+      <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+        <div className="flex-1 overflow-x-auto">
+          <CategoryFilterBar categories={categories} active={selectedCats} onToggle={toggleCat} />
         </div>
-      )}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as 'name' | 'rating')}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          <option value="name">Name</option>
+          <option value="rating">Rating</option>
+        </select>
+      </div>
 
-      {submitted && (
-        <div ref={scrollRef} className="flex flex-1 overflow-auto">
-          <DestinationResultsList
-            loading={loading}
-            error={error}
-            items={visibleItems}
-            addedIds={addedIds}
-            onAdd={handleAdd}
-            onRemove={handleRemove}
-          />
-        </div>
-      )}
+      <div ref={scrollRef} className="flex flex-1 overflow-auto">
+        <DestinationResultsList
+          loading={loading}
+          error={error}
+          items={visibleItems}
+          addedIds={addedIds}
+          onAdd={handleAdd}
+          onRemove={handleRemove}
+        />
+      </div>
     </Modal>
   );
 }

--- a/src/components/planner/modal/ActivityModalForm.test.tsx
+++ b/src/components/planner/modal/ActivityModalForm.test.tsx
@@ -25,7 +25,7 @@ describe('ActivityModalForm', () => {
     const onSave = vi.fn();
     render(<ActivityModalForm activity={activity} onSave={onSave} color="" />);
     const addressInput = screen.getByLabelText('Address');
-    fireEvent.change(addressInput, { target: { value: 'Ro' } });
+    fireEvent.change(addressInput, { target: { value: 'Rome' } });
     const option = screen.getByRole('button', { name: 'Rome, Italy' });
     fireEvent.mouseDown(option);
     fireEvent.click(screen.getByRole('button', { name: 'Update' }));

--- a/src/components/ui/popups/CatalogSearchPopup.test.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.test.tsx
@@ -3,25 +3,32 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import CatalogSearchPopup from './CatalogSearchPopup';
-import type { CatalogActivity } from '@/types';
+const { mockUseCatalogActivities } = vi.hoisted(() => ({
+  mockUseCatalogActivities: vi.fn(),
+}));
 
 vi.mock('@/hooks', async () => {
   const actual = await vi.importActual<typeof import('@/hooks')>('@/hooks');
   return {
     ...actual,
-    useGeoapifySearch: (query: string) => ({
-      results:
-        query && query !== 'err'
-          ? ([{ id: '1', name: 'Museum', category: 'sight' }] as CatalogActivity[])
-          : [],
-      loading: false,
-      error: query === 'err',
-    }),
+    useCatalogActivities: mockUseCatalogActivities,
   };
 });
 
+vi.mock('@/contexts', () => ({
+  usePlannerContext: () => ({ dest: 'Paris' }),
+}));
+
 describe('CatalogSearchPopup', () => {
+  beforeEach(() => {
+    mockUseCatalogActivities.mockReset();
+  });
   it('renders search results and handles selection', () => {
+    mockUseCatalogActivities.mockReturnValue({
+      activities: [{ id: '1', name: 'Museum', category: 'sight' }],
+      isLoading: false,
+      isError: false,
+    });
     const handleSelect = vi.fn();
     render(<CatalogSearchPopup open onSelect={handleSelect} onClose={() => {}} />);
 
@@ -35,10 +42,12 @@ describe('CatalogSearchPopup', () => {
   });
 
   it('shows an error message when loading fails', () => {
+    mockUseCatalogActivities.mockReturnValue({
+      activities: [],
+      isLoading: false,
+      isError: true,
+    });
     render(<CatalogSearchPopup open onSelect={() => {}} onClose={() => {}} />);
-
-    const input = screen.getByPlaceholderText('Search');
-    fireEvent.change(input, { target: { value: 'err' } });
 
     expect(screen.getByText('Failed to load results.')).toBeInTheDocument();
   });

--- a/src/components/ui/popups/CatalogSearchPopup.test.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/hooks', async () => {
 });
 
 vi.mock('@/contexts', () => ({
-  usePlannerContext: () => ({ dest: 'Paris' }),
+  usePlannerContext: () => ({ planId: 'p1' }),
 }));
 
 describe('CatalogSearchPopup', () => {

--- a/src/components/ui/popups/CatalogSearchPopup.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.tsx
@@ -3,7 +3,8 @@
 
 import React from 'react';
 import { CloseButton, Spinner, Popup } from '@/components';
-import { useGeoapifySearch } from '@/hooks';
+import { useCatalogActivities } from '@/hooks';
+import { usePlannerContext } from '@/contexts';
 import type { CatalogActivity } from '@/types';
 
 interface CatalogSearchPopupProps {
@@ -20,7 +21,12 @@ export default function CatalogSearchPopup({
   triggerRef,
 }: CatalogSearchPopupProps) {
   const [search, setSearch] = React.useState('');
-  const { results, loading, error } = useGeoapifySearch(search);
+  const { dest } = usePlannerContext();
+  const { activities = [], isLoading, isError } = useCatalogActivities(dest, { enabled: open });
+  const results = React.useMemo(
+    () => activities.filter((a) => a.name.toLowerCase().includes(search.toLowerCase())),
+    [activities, search]
+  );
 
   return (
     <Popup
@@ -49,14 +55,14 @@ export default function CatalogSearchPopup({
           placeholder="Search"
           className="w-full rounded border px-2 py-1 text-sm"
         />
-        {loading && (
+        {isLoading && (
           <div className="flex items-center gap-2 text-sm">
             <Spinner className="size-4" />
             <span>Loading...</span>
           </div>
         )}
-        {error && <p className="text-sm text-red-500">Failed to load results.</p>}
-        {!loading && !error && (
+        {isError && <p className="text-sm text-red-500">Failed to load results.</p>}
+        {!isLoading && !isError && (
           <ul className="max-h-60 space-y-1 overflow-y-auto">
             {results.map((item) => (
               <li key={item.id}>

--- a/src/components/ui/popups/CatalogSearchPopup.tsx
+++ b/src/components/ui/popups/CatalogSearchPopup.tsx
@@ -21,8 +21,8 @@ export default function CatalogSearchPopup({
   triggerRef,
 }: CatalogSearchPopupProps) {
   const [search, setSearch] = React.useState('');
-  const { dest } = usePlannerContext();
-  const { activities = [], isLoading, isError } = useCatalogActivities(dest, { enabled: open });
+  const { planId } = usePlannerContext();
+  const { activities = [], isLoading, isError } = useCatalogActivities(planId, { enabled: open });
   const results = React.useMemo(
     () => activities.filter((a) => a.name.toLowerCase().includes(search.toLowerCase())),
     [activities, search]

--- a/src/hooks/catalog/fetchCatalog.test.ts
+++ b/src/hooks/catalog/fetchCatalog.test.ts
@@ -16,9 +16,9 @@ describe('fetchCatalog', () => {
       json: async () => mockData,
     } as unknown as Response);
 
-    const result = await fetchCatalog('paris', ['museum']);
+    const result = await fetchCatalog('paris');
 
-    expect(global.fetch).toHaveBeenCalledWith('/api/catalog?dest=paris&cats=museum');
+    expect(global.fetch).toHaveBeenCalledWith('/api/catalog?dest=paris');
     expect(result).toEqual(mockData);
   });
 
@@ -28,6 +28,6 @@ describe('fetchCatalog', () => {
       status: 404,
     } as unknown as Response);
 
-    await expect(fetchCatalog('paris', [])).rejects.toThrow('Failed to fetch catalog: HTTP 404');
+    await expect(fetchCatalog('paris')).rejects.toThrow('Failed to fetch catalog: HTTP 404');
   });
 });

--- a/src/hooks/catalog/fetchCatalog.ts
+++ b/src/hooks/catalog/fetchCatalog.ts
@@ -10,12 +10,8 @@ export interface CatalogApiResponse {
  * Fetches the catalog activities for a destination.
  * Throws if the request fails.
  */
-export async function fetchCatalog(
-  dest: string,
-  categories: string[]
-): Promise<CatalogApiResponse> {
+export async function fetchCatalog(dest: string): Promise<CatalogApiResponse> {
   const params = new URLSearchParams({ dest });
-  if (categories.length > 0) params.set('cats', categories.join(','));
   const res = await fetch(`/api/catalog?${params.toString()}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch catalog: HTTP ${res.status}`);

--- a/src/hooks/catalog/useCatalog.test.ts
+++ b/src/hooks/catalog/useCatalog.test.ts
@@ -2,11 +2,11 @@
 
 import { renderHook } from '@testing-library/react';
 
-vi.mock('@/hooks', () => ({
+vi.mock('./useCatalogActivities', () => ({
   useCatalogActivities: vi.fn(),
 }));
 
-import { useCatalogActivities } from '@/hooks';
+import { useCatalogActivities } from './useCatalogActivities';
 import { useCatalog } from './useCatalog';
 
 const mockUseCatalogActivities = vi.mocked(useCatalogActivities);
@@ -29,7 +29,7 @@ describe('useCatalog', () => {
       isError: false,
     });
 
-    const { result } = renderHook(() => useCatalog('Paris', { enabled: true }));
+    const { result } = renderHook(() => useCatalog('p1', { enabled: true }));
 
     expect(result.current.days).toHaveLength(2);
     expect(result.current.days?.[0].activities).toHaveLength(3);
@@ -44,7 +44,7 @@ describe('useCatalog', () => {
       isError: true,
     });
 
-    const { result } = renderHook(() => useCatalog('Paris', { enabled: true }));
+    const { result } = renderHook(() => useCatalog('p1', { enabled: true }));
 
     expect(result.current.days).toBeUndefined();
     expect(result.current.isError).toBe(true);

--- a/src/hooks/catalog/useCatalog.ts
+++ b/src/hooks/catalog/useCatalog.ts
@@ -1,22 +1,22 @@
 // src/hooks/useCatalog.ts
+'use client';
 
 import { useMemo } from 'react';
 import { Activity, DayPlan } from '@/types';
-import { useCatalogActivities } from '@/hooks';
+import { useCatalogActivities } from './useCatalogActivities';
 import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/constants';
 
 /**
- * Hook to fetch and format catalog by destination.
- * @param dest - destination string
- * @param options.enabled - whether to enable the query
- * - Fetches /api/catalog?dest=… when enabled
+ * Hook to format cached catalog activities into day buckets.
+ * @param planId - planner identifier used for the storage key
+ * @param options.enabled - whether to load the cached data
  * - Splits activities into days, 3 per day
- * - Returns both React Query props and `days` as DayPlan[]
+ * - Returns loading and error flags from `useCatalogActivities`
  */
 
-export function useCatalog(dest: string | null, options: { enabled: boolean }) {
+export function useCatalog(planId: string | null, options: { enabled: boolean }) {
   // 1) Load catalog activities using the shared hook
-  const { activities, ...query } = useCatalogActivities(dest, options);
+  const { activities, ...query } = useCatalogActivities(planId, options);
 
   // 2) Memoize transforming raw activities into day-based buckets
   const days: DayPlan[] | undefined = useMemo(() => {

--- a/src/hooks/catalog/useCatalogActivities.test.ts
+++ b/src/hooks/catalog/useCatalogActivities.test.ts
@@ -1,38 +1,18 @@
 // src/hooks/catalog/useCatalogActivities.test.ts
 
-import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-vi.mock('@/hooks', () => ({
-  fetchCatalog: vi.fn(),
-}));
-
-import { fetchCatalog } from '@/hooks';
 import { useCatalogActivities } from './useCatalogActivities';
 
-const mockFetchCatalog = vi.mocked(fetchCatalog);
-
-function createWrapper() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
-  }
-  return Wrapper;
-}
-
 describe('useCatalogActivities', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    localStorage.clear();
   });
 
-  test('returns activities on success', async () => {
+  test('returns activities from storage', async () => {
     const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
-    mockFetchCatalog.mockResolvedValue({ activities: mockActivities });
+    localStorage.setItem('catalog-p1', JSON.stringify(mockActivities));
 
-    const { result } = renderHook(() => useCatalogActivities('Paris', { enabled: true }), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(() => useCatalogActivities('p1', { enabled: true }));
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -40,16 +20,12 @@ describe('useCatalogActivities', () => {
     expect(result.current.isError).toBe(false);
   });
 
-  test('handles errors', async () => {
-    mockFetchCatalog.mockRejectedValue(new Error('fail'));
+  test('handles missing data', async () => {
+    const { result } = renderHook(() => useCatalogActivities('p1', { enabled: true }));
 
-    const { result } = renderHook(() => useCatalogActivities('Paris', { enabled: true }), {
-      wrapper: createWrapper(),
-    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
-
-    expect(result.current.activities).toBeUndefined();
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.activities).toEqual([]);
+    expect(result.current.isError).toBe(true);
   });
 });

--- a/src/hooks/catalog/useCatalogActivities.ts
+++ b/src/hooks/catalog/useCatalogActivities.ts
@@ -1,21 +1,41 @@
 // src/hooks/useCatalogActivities.ts
+'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { fetchCatalog } from '@/hooks';
+import { useEffect, useState } from 'react';
 import type { CatalogActivity } from '@/types';
 
 /**
- * Hook to load catalog activities for a destination.
- * Provides raw activity data along with React Query state.
+ * Loads catalog activities for the given plan from localStorage.
+ * Returns the raw list along with simple loading and error flags.
  */
-export function useCatalogActivities(dest: string | null, options: { enabled: boolean }) {
-  const query = useQuery({
-    queryKey: ['catalog', dest],
-    queryFn: () => fetchCatalog(dest || ''),
-    enabled: options.enabled && !!dest,
-  });
+export function useCatalogActivities(planId: string | null, options: { enabled: boolean }) {
+  const [activities, setActivities] = useState<CatalogActivity[]>([]);
+  const [isLoading, setLoading] = useState(true);
+  const [isError, setError] = useState(false);
 
-  const activities: CatalogActivity[] | undefined = query.data?.activities;
+  useEffect(() => {
+    if (!options.enabled || !planId) {
+      setActivities([]);
+      setLoading(false);
+      return;
+    }
 
-  return { activities, ...query };
+    try {
+      const raw = localStorage.getItem(`catalog-${planId}`);
+      if (raw) {
+        setActivities(JSON.parse(raw));
+        setError(false);
+      } else {
+        setActivities([]);
+        setError(true);
+      }
+    } catch {
+      setActivities([]);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [options.enabled, planId]);
+
+  return { activities, isLoading, isError };
 }

--- a/src/hooks/catalog/useCatalogActivities.ts
+++ b/src/hooks/catalog/useCatalogActivities.ts
@@ -11,7 +11,7 @@ import type { CatalogActivity } from '@/types';
 export function useCatalogActivities(dest: string | null, options: { enabled: boolean }) {
   const query = useQuery({
     queryKey: ['catalog', dest],
-    queryFn: () => fetchCatalog(dest || '', []),
+    queryFn: () => fetchCatalog(dest || ''),
     enabled: options.enabled && !!dest,
   });
 

--- a/src/hooks/catalog/useDestinationAutocomplete.test.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.test.ts
@@ -30,7 +30,7 @@ describe('useDestinationAutocomplete', () => {
     const mockResults = [{ name: 'Paris', latitude: 1, longitude: 2 }];
     mockFetchAutocomplete.mockResolvedValue(mockResults);
 
-    const { result } = renderHook(() => useDestinationAutocomplete('par'), {
+    const { result } = renderHook(() => useDestinationAutocomplete('pari'), {
       wrapper: createWrapper(),
     });
 
@@ -43,7 +43,7 @@ describe('useDestinationAutocomplete', () => {
   test('handles errors', async () => {
     mockFetchAutocomplete.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => useDestinationAutocomplete('par'), {
+    const { result } = renderHook(() => useDestinationAutocomplete('pari'), {
       wrapper: createWrapper(),
     });
 

--- a/src/hooks/catalog/useDestinationAutocomplete.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.ts
@@ -6,14 +6,14 @@ import { fetchAutocomplete } from '@/hooks';
 import type { AutocompletePlace } from '@/types';
 
 /**
- * Provides Geoapify autocomplete suggestions when query length is >= 3.
+ * Provides Geoapify autocomplete suggestions when query length is >= 4.
  * Results are cached for one minute and won't refetch on window focus.
  */
 export function useDestinationAutocomplete(query: string) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['autocomplete', query],
     queryFn: () => fetchAutocomplete(query),
-    enabled: query.length >= 3,
+    enabled: query.length >= 4,
     staleTime: 1000 * 60,
     refetchOnWindowFocus: false,
   });

--- a/src/hooks/catalog/useDestinationCatalog.test.ts
+++ b/src/hooks/catalog/useDestinationCatalog.test.ts
@@ -1,58 +1,49 @@
 // src/hooks/catalog/useDestinationCatalog.test.ts
 
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
 
-vi.mock('@/hooks', () => ({
-  fetchCatalog: vi.fn(),
+vi.mock('./useCatalogActivities', () => ({
+  useCatalogActivities: vi.fn(),
 }));
 
-import { fetchCatalog } from '@/hooks';
+import { useCatalogActivities } from './useCatalogActivities';
 import { useDestinationCatalog } from './useDestinationCatalog';
 
-const mockFetchCatalog = vi.mocked(fetchCatalog);
-
-function createWrapper() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
-  }
-  return Wrapper;
-}
+const mockUseCatalogActivities = vi.mocked(useCatalogActivities);
 
 describe('useDestinationCatalog', () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test('returns activities and categories on success', async () => {
+  test('returns activities and categories', () => {
     const mockActivities = [
       { id: '1', name: 'Louvre', category: 'museum' },
       { id: '2', name: 'Arc', category: 'monument' },
     ];
-    mockFetchCatalog.mockResolvedValue({ activities: mockActivities });
-
-    const { result } = renderHook(() => useDestinationCatalog(true, 'Paris'), {
-      wrapper: createWrapper(),
+    mockUseCatalogActivities.mockReturnValue({
+      activities: mockActivities,
+      isLoading: false,
+      isError: false,
     });
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    const { result } = renderHook(() => useDestinationCatalog(true, 'p1'));
 
     expect(result.current.activities).toEqual(mockActivities);
     expect(result.current.categories).toEqual(['monument', 'museum']);
     expect(result.current.error).toBeNull();
   });
 
-  test('handles errors', async () => {
-    mockFetchCatalog.mockRejectedValue(new Error('fail'));
-
-    const { result } = renderHook(() => useDestinationCatalog(true, 'Paris'), {
-      wrapper: createWrapper(),
+  test('handles errors', () => {
+    mockUseCatalogActivities.mockReturnValue({
+      activities: [],
+      isLoading: false,
+      isError: true,
     });
 
-    await waitFor(() => expect(result.current.error).toBe('Failed to load catalog.'));
+    const { result } = renderHook(() => useDestinationCatalog(true, 'p1'));
 
+    expect(result.current.error).toBe('Failed to load catalog.');
     expect(result.current.activities).toEqual([]);
     expect(result.current.loading).toBe(false);
   });

--- a/src/hooks/catalog/useDestinationCatalog.test.ts
+++ b/src/hooks/catalog/useDestinationCatalog.test.ts
@@ -26,30 +26,34 @@ describe('useDestinationCatalog', () => {
     vi.clearAllMocks();
   });
 
-  test('returns visibleItems on success', async () => {
-    const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
+  test('returns activities and categories on success', async () => {
+    const mockActivities = [
+      { id: '1', name: 'Louvre', category: 'museum' },
+      { id: '2', name: 'Arc', category: 'monument' },
+    ];
     mockFetchCatalog.mockResolvedValue({ activities: mockActivities });
 
-    const { result } = renderHook(() => useDestinationCatalog(true, ['museum'], 'Paris'), {
+    const { result } = renderHook(() => useDestinationCatalog(true, 'Paris'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.visibleItems).toEqual(mockActivities);
+    expect(result.current.activities).toEqual(mockActivities);
+    expect(result.current.categories).toEqual(['monument', 'museum']);
     expect(result.current.error).toBeNull();
   });
 
   test('handles errors', async () => {
     mockFetchCatalog.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => useDestinationCatalog(true, ['museum'], 'Paris'), {
+    const { result } = renderHook(() => useDestinationCatalog(true, 'Paris'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.error).toBe('Failed to load catalog.'));
 
-    expect(result.current.visibleItems).toEqual([]);
+    expect(result.current.activities).toEqual([]);
     expect(result.current.loading).toBe(false);
   });
 });

--- a/src/hooks/catalog/useDestinationCatalog.ts
+++ b/src/hooks/catalog/useDestinationCatalog.ts
@@ -1,23 +1,18 @@
 // src/hooks/useDestinationCatalog.ts
+'use client';
 
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { fetchCatalog } from '@/hooks';
+import { useCatalogActivities } from './useCatalogActivities';
 import type { CatalogActivity } from '@/types';
 
 /**
- * Loads catalog activities for a destination and derives available categories.
+ * Loads catalog activities for the given plan and derives available categories.
  */
-export function useDestinationCatalog(enabled: boolean, city: string) {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['catalog', city],
-    queryFn: () => fetchCatalog(city),
-    enabled,
-  });
+export function useDestinationCatalog(enabled: boolean, planId: string | null) {
+  const { activities = [], isLoading, isError } = useCatalogActivities(planId, { enabled });
 
-  const activities: CatalogActivity[] = useMemo(() => data?.activities ?? [], [data?.activities]);
   const categories = useMemo(
-    () => Array.from(new Set(activities.map((a) => a.category))).sort(),
+    () => Array.from(new Set(activities.map((a: CatalogActivity) => a.category))).sort(),
     [activities]
   );
 

--- a/src/hooks/catalog/useDestinationCatalog.ts
+++ b/src/hooks/catalog/useDestinationCatalog.ts
@@ -1,40 +1,30 @@
 // src/hooks/useDestinationCatalog.ts
 
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchCatalog } from '@/hooks';
+import type { CatalogActivity } from '@/types';
 
 /**
- * Hook to fetch and manage the catalog activities.
- * - Loads catalog activities by destination from the API with React Query.
- * - Loads results after the user selects categories.
- * - Handles loading and error states.
+ * Loads catalog activities for a destination and derives available categories.
  */
-
-export function useDestinationCatalog(enabled: boolean, categories: string[], city: string) {
+export function useDestinationCatalog(enabled: boolean, city: string) {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['catalog', city, categories],
-    queryFn: () => fetchCatalog(city, categories),
-    enabled: enabled && categories.length > 0,
+    queryKey: ['catalog', city],
+    queryFn: () => fetchCatalog(city),
+    enabled,
   });
-  const loading = isLoading;
-  const error = isError ? 'Failed to load catalog.' : null;
-  const [search, setSearch] = useState('');
 
-  /**
-   * Filters activities by search term.
-   */
-  const visibleItems = useMemo(() => {
-    const activities = data?.activities ?? [];
-    const searchLower = search.toLowerCase();
-    return activities.filter((it) => it.name.toLowerCase().includes(searchLower));
-  }, [data?.activities, search]);
+  const activities: CatalogActivity[] = useMemo(() => data?.activities ?? [], [data?.activities]);
+  const categories = useMemo(
+    () => Array.from(new Set(activities.map((a) => a.category))).sort(),
+    [activities]
+  );
 
   return {
-    visibleItems,
-    loading,
-    error,
-    search,
-    setSearch,
+    activities,
+    categories,
+    loading: isLoading,
+    error: isError ? 'Failed to load catalog.' : null,
   };
 }

--- a/src/hooks/catalog/useGeoapifySearch.test.ts
+++ b/src/hooks/catalog/useGeoapifySearch.test.ts
@@ -30,7 +30,7 @@ describe('useGeoapifySearch', () => {
     const mockActivities = [{ id: '1', name: 'Louvre', category: 'museum' }];
     mockFetchSearch.mockResolvedValue(mockActivities);
 
-    const { result } = renderHook(() => useGeoapifySearch('par'), {
+    const { result } = renderHook(() => useGeoapifySearch('pari'), {
       wrapper: createWrapper(),
     });
 
@@ -43,7 +43,7 @@ describe('useGeoapifySearch', () => {
   test('handles errors', async () => {
     mockFetchSearch.mockRejectedValue(new Error('fail'));
 
-    const { result } = renderHook(() => useGeoapifySearch('par'), {
+    const { result } = renderHook(() => useGeoapifySearch('pari'), {
       wrapper: createWrapper(),
     });
 

--- a/src/hooks/catalog/useGeoapifySearch.ts
+++ b/src/hooks/catalog/useGeoapifySearch.ts
@@ -6,13 +6,13 @@ import { fetchSearch } from '@/hooks/catalog/fetchSearch';
 import type { CatalogActivity } from '@/types';
 
 /**
- * Runs a Geoapify place search when the query has 3+ characters.
+ * Runs a Geoapify place search when the query has 4+ characters.
  */
 export function useGeoapifySearch(query: string) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['geoapify-search', query],
     queryFn: () => fetchSearch(query),
-    enabled: query.length >= 3,
+    enabled: query.length >= 4,
   });
 
   return {

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -9,10 +9,11 @@ vi.mock('focus-trap-react', () => ({
 
 // Canvas isn't implemented in jsdom. Provide a minimal mock so tests using
 // measureText can run without installing additional packages.
-HTMLCanvasElement.prototype.getContext = vi.fn(
-  () =>
-    ({
-      font: '',
-      measureText: vi.fn(() => ({ width: 0 })),
-    }) as unknown as CanvasRenderingContext2D,
-);
+HTMLCanvasElement.prototype.getContext = vi
+  .fn(
+    () =>
+      ({
+        font: '',
+        measureText: vi.fn(() => ({ width: 0 })),
+      }) as unknown as CanvasRenderingContext2D,
+  ) as unknown as HTMLCanvasElement['getContext'];


### PR DESCRIPTION
## Summary
- restore catalog panel with dynamic categories, search, and sorting
- require four characters before triggering autocomplete or search queries
- validate API requests and use cached data for catalog search

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688beeba61dc8322ba092ad68bfd5b81