### PR TITLE
perf: memoize planner panels

### DIFF
--- a/src/app/planner/BudgetPanel.tsx
+++ b/src/app/planner/BudgetPanel.tsx
@@ -21,7 +21,7 @@ interface Props {
   onUpdateBudget: (id: string, amount: number) => void;
 }
 
-export default function BudgetPanel({ planId, activitiesTotal, days, onUpdateBudget }: Props) {
+function BudgetPanel({ planId, activitiesTotal, days, onUpdateBudget }: Props) {
   const {
     budget,
     setBudget,
@@ -98,3 +98,5 @@ export default function BudgetPanel({ planId, activitiesTotal, days, onUpdateBud
     </div>
   );
 }
+
+export default React.memo(BudgetPanel);

--- a/src/app/planner/MapView.tsx
+++ b/src/app/planner/MapView.tsx
@@ -43,7 +43,7 @@ function FitAllMarkers({ coords }: { coords: LatLngExpression[] }) {
   return null;
 }
 
-export default function MapView({ days, onSelectActivity }: MapViewProps) {
+function MapView({ days, onSelectActivity }: MapViewProps) {
   const dayPaths = useMemo(
     () =>
       days
@@ -133,3 +133,5 @@ export default function MapView({ days, onSelectActivity }: MapViewProps) {
     </div>
   );
 }
+
+export default React.memo(MapView);

--- a/src/app/planner/PlannerBoard.tsx
+++ b/src/app/planner/PlannerBoard.tsx
@@ -39,7 +39,7 @@ export interface PlannerBoardProps {
  * Presentation component to render the DnD board.
  * Receives state and handlers from parent via props.
  */
-export default function PlannerBoard({
+function PlannerBoard({
   days,
   activeId,
   sensors,
@@ -113,3 +113,5 @@ export default function PlannerBoard({
     </DndContext>
   );
 }
+
+export default React.memo(PlannerBoard);


### PR DESCRIPTION
## Summary
- memoize PlannerBoard, BudgetPanel and MapView to avoid unnecessary re-renders

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c02673e0c8322b02093cef155e0dc