### PR TITLE
fix: resolve accessibility issues in planner

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -12,6 +12,15 @@ This project aims to meet WCAG 2.1 AA requirements. Use the checklist below when
 - Use semantic HTML and ARIA roles only when necessary
 - Add `aria-label="Itinerary map"` to `<MapContainer>` components so screen
   readers can identify the map
+- Elements labelled by their content must include that visible text in the
+  accessible name
+- Touch targets for interactive controls should be at least 44×44&nbsp;px with
+  adequate spacing
+- Provide valid `role` values and prefer native elements over overriding roles
+- Do not repeat image alternative text in adjacent visible captions or
+  headings
+- Elements hidden with `aria-hidden="true"` must not contain focusable content
+  and should be removed if used solely for layout
 
 Refer to the official guidelines for details: <https://www.w3.org/WAI/WCAG21/quickref/>
 

--- a/docs/STYLE-GUIDE.md
+++ b/docs/STYLE-GUIDE.md
@@ -52,3 +52,8 @@ Follow accessible markup practices throughout the codebase.
 - Provide meaningful labels for interactive controls using `aria-label`, `aria-labelledby` or visible text.
 - Ensure keyboard interaction for custom components (e.g. handling `Enter` and `Space` keys when appropriate).
 - Hidden content for assistive technology should use the `.sr-only` utility defined in `globals.css`.
+- Elements labelled through their visible content must include that text in the accessible name.
+- Touch targets for interactive controls should be at least 44×44&nbsp;px with appropriate spacing.
+- Assign valid `role` values and prefer native elements over role overrides.
+- Avoid repeating alternative text in adjacent visible captions or headings.
+- Elements with `aria-hidden="true"` must not contain focusable content and should be removed when used solely for layout.

--- a/src/app/planner/BudgetPanel.tsx
+++ b/src/app/planner/BudgetPanel.tsx
@@ -67,7 +67,7 @@ export default function BudgetPanel({ planId, activitiesTotal, days, onUpdateBud
         <div className="flex items-center justify-between">
           <h3 id="expenses-heading" className="flex items-center gap-1 font-semibold">
             Expenses
-            <InfoPopup content={BUDGET_INFO.expenses} aria-hidden="true">
+            <InfoPopup content={BUDGET_INFO.expenses}>
               <Info size={12} className="text-muted-foreground" aria-hidden="true" />
             </InfoPopup>
           </h3>

--- a/src/components/planner/dnd/ActivityCardBase.tsx
+++ b/src/components/planner/dnd/ActivityCardBase.tsx
@@ -48,14 +48,17 @@ export default function ActivityCardBase({
       >
         {/* Image */}
         {imageUrl && (
-          <Image
-            src={imageUrl}
-            alt={title}
-            width={400}
-            height={200}
-            unoptimized
-            className="h-30 w-full rounded-t-lg object-cover"
-          />
+          <>
+            {/* Decorative image: alt text intentionally empty to avoid repeating the title */}
+            <Image
+              src={imageUrl}
+              alt=""
+              width={400}
+              height={200}
+              unoptimized
+              className="h-30 w-full rounded-t-lg object-cover"
+            />
+          </>
         )}
 
         {/* Title */}

--- a/src/components/planner/dnd/SortableItem.tsx
+++ b/src/components/planner/dnd/SortableItem.tsx
@@ -84,6 +84,7 @@ export default function SortableItem({
       )}
       {...attributes}
       {...listeners}
+      role="listitem"
     >
       <div className={cn(isDragging && 'opacity-0')}>
         <ActivityCard

--- a/src/components/planner/modal/ActivityModalHeader.tsx
+++ b/src/components/planner/modal/ActivityModalHeader.tsx
@@ -80,14 +80,17 @@ export default function ActivityModalHeader({
         }}
       >
         {editedImageUrl && (
-          <Image
-            src={editedImageUrl}
-            alt={activity.title}
-            className="absolute top-0 left-0 h-full w-full rounded-t-lg object-cover"
-            width={400}
-            height={200}
-            unoptimized
-          />
+          <>
+            {/* Decorative image: empty alt to prevent repeating the activity title */}
+            <Image
+              src={editedImageUrl}
+              alt=""
+              className="absolute top-0 left-0 h-full w-full rounded-t-lg object-cover"
+              width={400}
+              height={200}
+              unoptimized
+            />
+          </>
         )}
         {editedImageUrl && (
           <Button

--- a/src/components/planner/onboarding/OnboardingCarousel.tsx
+++ b/src/components/planner/onboarding/OnboardingCarousel.tsx
@@ -74,7 +74,8 @@ function Slide({
     >
       <div className={round ? 'm-0 p-0' : 'mb-4 h-full p-5'}>
         <div className="relative h-[70%] w-full flex-none">
-          <Image src={step.image} alt={step.title} fill className="object-cover" />
+          {/* Decorative image – empty alt to avoid repeating the step title */}
+          <Image src={step.image} alt="" fill className="object-cover" />
         </div>
         <div className="mt-2 flex-1">
           <h3 className="text-foreground mb-1 text-3xl font-semibold">{step.title}</h3>

--- a/src/components/ui/DatePicker.tsx
+++ b/src/components/ui/DatePicker.tsx
@@ -31,7 +31,7 @@ export function DateRangePicker({ className, value, onChange }: Props) {
             !value?.from && 'text-muted-foreground italic',
             className
           )}
-          aria-label="Pick a date range"
+          aria-label={label}
         >
           <span>{label}</span>
           <CalendarIcon className="text-muted-foreground h-4 w-4" aria-hidden="true" />

--- a/src/components/ui/button-icons/EditCardButton.tsx
+++ b/src/components/ui/button-icons/EditCardButton.tsx
@@ -7,8 +7,8 @@ import { Button } from '@/components';
 
 export default function EditCardButton(props: React.ComponentProps<'button'>) {
   return (
-    <Button variant="iconrd" size="iconsm" title="Edit Card" position="bottom" {...props}>
-      <Pencil aria-hidden="true" className="w-1" />
+    <Button variant="iconrd" size="icon" title="Edit Card" position="bottom" {...props}>
+      <Pencil aria-hidden="true" />
     </Button>
   );
 }

--- a/src/components/ui/button-icons/NavCircleButton.tsx
+++ b/src/components/ui/button-icons/NavCircleButton.tsx
@@ -22,7 +22,7 @@ export default function NavCircleButton({
       type="button"
       {...props}
       className={cn(
-        'bg-background border-bg-gray-200 focus:ring-primary cursor-pointer rounded-full border p-1 hover:bg-gray-200 focus:ring-2 focus:outline-none',
+        'bg-background border-bg-gray-200 focus:ring-primary flex h-11 w-11 cursor-pointer items-center justify-center rounded-full border hover:bg-gray-200 focus:ring-2 focus:outline-none',
         className
       )}
     >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,8 +21,7 @@ const buttonVariants = cva(
       size: {
         default: 'h-9 px-6 py-6 text-base has-[>svg]:px-3',
         sm: 'h-8 gap-1.5 px-3 text-sm has-[>svg]:px-2.5',
-        icon: 'h-8 w-8 [&_svg:not([class*="size-"])]:size-4',
-        iconsm: 'h-6 w-6 [&_svg:not([class*="size-"])]:size-3',
+        icon: 'h-11 w-11 [&_svg:not([class*="size-"])]:size-5',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- remove redundant alternative text from decorative images
- enlarge icon buttons and navigation controls for sufficient touch targets
- use semantic list item roles and expose info popups to assistive tech

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c01a53228832280dca98d546ecf68