### PR TITLE
Add location autocomplete on home form

### DIFF
--- a/src/components/home/LocationSearch.tsx
+++ b/src/components/home/LocationSearch.tsx
@@ -1,0 +1,102 @@
+// src/components/home/LocationSearch.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface LocationSearchProps {
+  /** Current destination value */
+  value: string;
+  /** Callback when a destination is chosen */
+  onChange: (value: string) => void;
+}
+
+interface Suggestion {
+  id: string;
+  name: string;
+}
+
+interface NominatimResult {
+  place_id: number;
+  display_name: string;
+  type: string;
+}
+
+export default function LocationSearch({ value, onChange }: LocationSearchProps) {
+  const [query, setQuery] = useState(value);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+
+  useEffect(() => {
+    if (!query) {
+      setSuggestions([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const fetchSuggestions = async () => {
+      try {
+        const params = new URLSearchParams({
+          format: 'json',
+          addressdetails: '1',
+          limit: '5',
+          q: query,
+        });
+        const res = await fetch(`https://nominatim.openstreetmap.org/search?${params.toString()}`, {
+          signal: controller.signal,
+          headers: {
+            'Accept-Language': 'en',
+            'User-Agent': 'travel-planner-app',
+          },
+        });
+        const data: NominatimResult[] = await res.json();
+        const filtered = data.filter((item) => ['city', 'state', 'country'].includes(item.type));
+        setSuggestions(
+          filtered.map((item) => ({ id: String(item.place_id), name: item.display_name }))
+        );
+      } catch {
+        // ignore fetch errors; suggestions list simply stays empty
+      }
+    };
+
+    fetchSuggestions();
+    return () => controller.abort();
+  }, [query]);
+
+  function handleSelect(name: string) {
+    onChange(name);
+    setQuery(name);
+    setSuggestions([]);
+  }
+
+  return (
+    <div className="w-full" aria-label="Destination search">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          const val = e.target.value;
+          setQuery(val);
+          onChange(val);
+        }}
+        className="border-input bg-background focus-visible:ring-ring w-full rounded-md border p-2 text-sm shadow-sm outline-none focus-visible:ring-2"
+        placeholder="Search city, state or country"
+        aria-label="Destination"
+        autoComplete="off"
+      />
+      {suggestions.length > 0 && (
+        <ul className="bg-background mt-2 max-h-60 w-full overflow-auto rounded-md border p-1 shadow-md">
+          {suggestions.map((s) => (
+            <li key={s.id}>
+              <button
+                type="button"
+                onClick={() => handleSelect(s.name)}
+                className="hover:bg-accent hover:text-accent-foreground w-full rounded-sm px-2 py-1 text-left"
+              >
+                {s.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/home/WelcomeForm.tsx
+++ b/src/components/home/WelcomeForm.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { DateRange } from 'react-day-picker';
 import Image from 'next/image';
 
-import { Button, DateRangePicker } from '@/components';
+import { Button, DateRangePicker, LocationSearch } from '@/components';
 import { STARTER_PLANNER_TITLE } from '@/constants';
 import { useRouter } from 'next/navigation';
 import { addDays } from 'date-fns';
@@ -16,6 +16,7 @@ export default function WelcomeForm() {
     from: new Date(),
     to: addDays(new Date(), 7),
   });
+  const [destination, setDestination] = useState('');
 
   // Declare error state
   const [error, setError] = useState<string>('');
@@ -37,7 +38,7 @@ export default function WelcomeForm() {
     }
 
     setError('');
-    const destParam = STARTER_PLANNER_TITLE;
+    const destParam = destination || STARTER_PLANNER_TITLE;
 
     const query = new URLSearchParams({
       dest: destParam,
@@ -61,10 +62,11 @@ export default function WelcomeForm() {
               </h1>
 
               <form onSubmit={handleSubmit} noValidate>
-                <fieldset className="flex pb-4" aria-labelledby="daterange-label">
-                  <legend id="daterange-label" className="sr-only">
-                    Travel dates
+                <fieldset className="flex flex-col gap-4 pb-4" aria-labelledby="trip-details-label">
+                  <legend id="trip-details-label" className="sr-only">
+                    Trip details
                   </legend>
+                  <LocationSearch value={destination} onChange={setDestination} />
                   <DateRangePicker
                     value={range}
                     onChange={handleRangeChange}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -2,3 +2,4 @@
 
 export { default as WelcomeForm } from './WelcomeForm';
 export { default as FeaturePreview } from './FeaturePreview';
+export { default as LocationSearch } from './LocationSearch';

--- a/src/hooks/fetchCatalog.ts
+++ b/src/hooks/fetchCatalog.ts
@@ -12,7 +12,7 @@ export interface CatalogApiResponse {
  */
 export async function fetchCatalog(
   dest: string,
-  categories: string[],
+  categories: string[]
 ): Promise<CatalogApiResponse> {
   const params = new URLSearchParams({ dest });
   if (categories.length > 0) {

--- a/src/hooks/useCatalogActivities.ts
+++ b/src/hooks/useCatalogActivities.ts
@@ -11,7 +11,7 @@ import type { CatalogActivity } from '@/types';
 export function useCatalogActivities(
   dest: string | null,
   categories: string[],
-  options: { enabled: boolean },
+  options: { enabled: boolean }
 ) {
   const query = useQuery({
     queryKey: ['catalog', dest, categories],


### PR DESCRIPTION
## Summary
- add `LocationSearch` component using Nominatim and filter to city/state/country
- integrate location search into home `WelcomeForm` with full-width layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c074e168c83228ed16215e210f7c6