### PR TITLE
fix: align destination autocomplete and filter results

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -130,24 +130,28 @@ const { activities } = useDestinationCatalog(open, planId);
 
 ### `useDestinationAutocomplete`
 
-_File: `src/hooks/useDestinationAutocomplete.ts`_
+_File: `src/hooks/catalog/useDestinationAutocomplete.ts`_
 
 ```ts
-export function useDestinationAutocomplete(query: string);
+export function useDestinationAutocomplete(
+  query: string,
+  options?: { enabled?: boolean }
+);
 ```
 
 - **Inputs**
   - `query`: user input text.
+  - `options.enabled` (optional): when `false`, prevents fetching.
 - **Outputs**
   Geoapify `results`, loading and error flags.
 - **Lifecycle**
-  Fetches `/api/autocomplete?text=` when the query has at least 4 characters.
+  Fetches `/api/autocomplete?text=` when the query has at least 4 characters and `enabled` is not `false`.
   Results are cached for 1 minute and do not refetch on window focus.
 - **Exceptions**
   Sets an error state when the request fails.
 
 ```ts
-const { results } = useDestinationAutocomplete(query);
+const { results } = useDestinationAutocomplete(query, { enabled: open });
 ```
 
 ### `useDebounce`

--- a/src/components/home/DestinationInput.tsx
+++ b/src/components/home/DestinationInput.tsx
@@ -19,10 +19,12 @@ interface Props {
 export default function DestinationInput({ value, onChange }: Props) {
   const debounced = useDebounce(value);
 
-  const { results, loading, error } = useDestinationAutocomplete(debounced);
-
   const [open, setOpen] = React.useState(false);
   const [active, setActive] = React.useState(-1);
+
+  const { results, loading, error } = useDestinationAutocomplete(debounced, {
+    enabled: open,
+  });
 
   const handleSelect = (r: PlaceSelection) => {
     onChange({ name: r.name, latitude: r.latitude, longitude: r.longitude });

--- a/src/components/home/DestinationInput.tsx
+++ b/src/components/home/DestinationInput.tsx
@@ -31,7 +31,7 @@ export default function DestinationInput({ value, onChange }: Props) {
   };
 
   return (
-    <>
+    <div className="relative w-64">
       <input
         id="dest-input"
         role="combobox"
@@ -70,7 +70,7 @@ export default function DestinationInput({ value, onChange }: Props) {
           setActive(-1);
         }}
         placeholder="Destination"
-        className="bg-background focus:ring-primary flex w-64 items-center justify-between space-x-4 rounded border px-4 py-2 text-sm transition focus:ring-2 focus:outline-none"
+        className="bg-background focus:ring-primary flex w-full items-center justify-between space-x-4 rounded border px-4 py-2 text-sm transition focus:ring-2 focus:outline-none"
         autoComplete="off"
       />
       {loading && <Spinner className="absolute top-2 right-2 size-4" />}
@@ -100,6 +100,6 @@ export default function DestinationInput({ value, onChange }: Props) {
           ))}
         </ul>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/planner/modal/ActivityModalForm.tsx
+++ b/src/components/planner/modal/ActivityModalForm.tsx
@@ -23,10 +23,12 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
   const [duration, setDuration] = useState<number>(activity.duration || 0);
   const [budget, setBudget] = useState<number>(activity.budget || 0);
   const [editedImageUrl, setEditedImageUrl] = useState(activity.imageUrl ?? '');
-  const debouncedAddress = useDebounce(editedAddress);
-  const { results: addressResults, loading: addressLoading } =
-    useDestinationAutocomplete(debouncedAddress);
   const [addressOpen, setAddressOpen] = useState(false);
+  const debouncedAddress = useDebounce(editedAddress);
+  const { results: addressResults, loading: addressLoading } = useDestinationAutocomplete(
+    debouncedAddress,
+    { enabled: addressOpen }
+  );
 
   // Update internal state when the activity prop changes
   useEffect(() => {

--- a/src/hooks/catalog/useDestinationAutocomplete.test.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.test.ts
@@ -52,4 +52,16 @@ describe('useDestinationAutocomplete', () => {
     expect(result.current.results).toEqual([]);
     expect(result.current.loading).toBe(false);
   });
+
+  test('does not fetch when disabled', async () => {
+    const { result } = renderHook(() => useDestinationAutocomplete('paris', { enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockFetchAutocomplete).not.toHaveBeenCalled();
+    expect(result.current.results).toEqual([]);
+    expect(result.current.error).toBe(false);
+  });
 });

--- a/src/hooks/catalog/useDestinationAutocomplete.ts
+++ b/src/hooks/catalog/useDestinationAutocomplete.ts
@@ -9,11 +9,13 @@ import type { AutocompletePlace } from '@/types';
  * Provides Geoapify autocomplete suggestions when query length is >= 4.
  * Results are cached for one minute and won't refetch on window focus.
  */
-export function useDestinationAutocomplete(query: string) {
+export function useDestinationAutocomplete(query: string, options: { enabled?: boolean } = {}) {
+  const isEnabled = (options.enabled ?? true) && query.length >= 4;
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['autocomplete', query],
     queryFn: () => fetchAutocomplete(query),
-    enabled: query.length >= 4,
+    enabled: isEnabled,
     staleTime: 1000 * 60,
     refetchOnWindowFocus: false,
   });

--- a/src/lib/geoapify.test.ts
+++ b/src/lib/geoapify.test.ts
@@ -1,0 +1,43 @@
+// src/lib/geoapify.test.ts
+import { vi } from 'vitest';
+import { fetchGeoapifyAutocomplete } from './geoapify';
+
+const originalFetch = global.fetch;
+const originalKey = process.env.GEOAPIFY_KEY;
+
+describe('fetchGeoapifyAutocomplete', () => {
+  beforeEach(() => {
+    process.env.GEOAPIFY_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.GEOAPIFY_KEY = originalKey;
+  });
+
+  it('filters out non city/state/country results', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [
+          { properties: { formatted: 'Paris, France', result_type: 'city', lat: 1, lon: 2 } },
+          {
+            properties: { formatted: 'Some Street, Paris', result_type: 'street', lat: 3, lon: 4 },
+          },
+          {
+            properties: { formatted: 'Texas, United States', result_type: 'state', lat: 5, lon: 6 },
+          },
+          { properties: { formatted: 'France', result_type: 'country', lat: 7, lon: 8 } },
+        ],
+      }),
+    } as unknown as Response);
+
+    const results = await fetchGeoapifyAutocomplete('paris');
+
+    expect(results).toEqual([
+      { name: 'Paris, France', latitude: 1, longitude: 2 },
+      { name: 'Texas, United States', latitude: 5, longitude: 6 },
+      { name: 'France', latitude: 7, longitude: 8 },
+    ]);
+  });
+});

--- a/src/lib/geoapify.ts
+++ b/src/lib/geoapify.ts
@@ -17,6 +17,7 @@ type GeoapifyFeature = {
     distance?: number;
     image?: string;
     description?: string;
+    result_type?: string;
   };
 };
 type GeoapifyResponse = { features: GeoapifyFeature[] };
@@ -41,11 +42,14 @@ export async function fetchGeoapifyAutocomplete(text: string): Promise<Autocompl
   if (!res.ok) throw new Error(`Geoapify request failed: ${res.status}`);
 
   const data = (await res.json()) as GeoapifyResponse;
-  return data.features.map((f) => ({
-    name: f.properties.formatted ?? f.properties.name ?? text,
-    latitude: f.properties.lat,
-    longitude: f.properties.lon,
-  }));
+  const allowed = new Set(['city', 'state', 'country']);
+  return data.features
+    .filter((f) => allowed.has(f.properties.result_type ?? ''))
+    .map((f) => ({
+      name: f.properties.formatted ?? f.properties.name ?? text,
+      latitude: f.properties.lat,
+      longitude: f.properties.lon,
+    }));
 }
 
 /* Static‑map thumbnail (fallback) */


### PR DESCRIPTION
## Summary
- align destination autocomplete dropdown with input width
- limit Geoapify autocomplete to city, state and country results
- cover filtering logic with unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c1ad408a4832291458974a3651bb2