### PR TITLE
Improve catalog filtering and image loading

### DIFF
--- a/src/components/planner/catalog/DestinationCard.tsx
+++ b/src/components/planner/catalog/DestinationCard.tsx
@@ -1,7 +1,7 @@
 // src/components/planner/catalog/DestinationCard.tsx
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { RemoveCardButton, DestinationActionButton } from '@/components';
 import type { CatalogActivity } from '@/types';
@@ -30,6 +30,7 @@ export default function DestinationCard({
   onRemove,
 }: DestinationCardProps) {
   const titleId = `destination-title-${name.replace(/\s+/g, '-')}`;
+  const [imgLoaded, setImgLoaded] = useState(false);
 
   return (
     <li
@@ -44,8 +45,16 @@ export default function DestinationCard({
           alt={`Photo of ${name}`}
           width={400}
           height={200}
-          className="h-40 w-full rounded-t object-cover"
+          className={`h-40 w-full rounded-t object-cover transition-opacity duration-300 ${
+            imgLoaded ? 'opacity-100' : 'opacity-0'
+          }`}
+          loading="lazy"
+          placeholder="blur"
+          blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAgMBgLf3OBAAAAAASUVORK5CYII="
+          onLoadingComplete={() => setImgLoaded(true)}
+          onError={() => setImgLoaded(true)}
         />
+        {!imgLoaded && <div className="bg-muted absolute inset-0 z-10 animate-pulse rounded-t" />}
         {/* quick-remove icon (only when added) */}
         <div className="absolute top-2 left-2">
           {added && <RemoveCardButton aria-label={`Remove ${name}`} onClick={onRemove} />}

--- a/src/components/planner/catalog/DestinationFilterPanel.tsx
+++ b/src/components/planner/catalog/DestinationFilterPanel.tsx
@@ -24,7 +24,7 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
   const addedIds = useMemo(() => new Set<string>(Object.keys(activitiesById)), [activitiesById]);
   const [selectedCats, setSelectedCats] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
-  const [sort, setSort] = useState<'name' | 'rating'>('name');
+  const [sort, setSort] = useState<'name' | 'rating'>('rating');
 
   const { activities, categories, loading, error } = useDestinationCatalog(isOpen, planId);
 
@@ -90,12 +90,23 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
       className="bg-background focus:ring-primary relative flex h-[90vh] w-[95vw] max-w-[1350px] flex-col rounded-lg shadow-xl focus:ring-2 focus:outline-none"
     >
       {/* header */}
-      <DestinationHeader search={search} onSearchChange={setSearch} onClose={onClose} />
+      <DestinationHeader onClose={onClose} />
 
-      <div className="flex items-center justify-between gap-2 border-b px-4 py-2">
+      <div className="flex flex-wrap items-center gap-2 border-b px-4 py-2">
         <div className="flex-1 overflow-x-auto">
           <CategoryFilterBar categories={categories} active={selectedCats} onToggle={toggleCat} />
         </div>
+        <label htmlFor="catalog-search" className="sr-only">
+          Search catalog
+        </label>
+        <input
+          id="catalog-search"
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search"
+          className="w-48 rounded border px-2 py-1 text-sm"
+        />
         <select
           value={sort}
           onChange={(e) => setSort(e.target.value as 'name' | 'rating')}

--- a/src/components/planner/catalog/DestinationHeader.tsx
+++ b/src/components/planner/catalog/DestinationHeader.tsx
@@ -5,38 +5,16 @@ import React from 'react';
 import { CloseButton } from '@/components';
 
 interface DestinationHeaderProps {
-  search: string;
-  onSearchChange: (s: string) => void;
   onClose: () => void;
 }
 
-export default function DestinationHeader({
-  search,
-  onSearchChange,
-  onClose,
-}: DestinationHeaderProps) {
+export default function DestinationHeader({ onClose }: DestinationHeaderProps) {
   return (
-    <>
-      <div className="flex items-center justify-between border-b px-4 py-2">
-        <h3 id="destination-filter-title" className="flex-1 text-center text-2xl font-bold">
-          Search Your Adventures
-        </h3>
-        <CloseButton onClick={onClose} />
-      </div>
-
-      <div className="flex items-center gap-2 border-b px-4 py-2">
-        <label htmlFor="catalog-search" className="sr-only">
-          Search catalog
-        </label>
-        <input
-          id="catalog-search"
-          type="text"
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search"
-          className="w-full rounded border px-2 py-1 text-sm"
-        />
-      </div>
-    </>
+    <div className="flex items-center justify-between border-b px-4 py-2">
+      <h3 id="destination-filter-title" className="flex-1 text-center text-2xl font-bold">
+        Search Your Adventures
+      </h3>
+      <CloseButton onClick={onClose} />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- place catalog search beside category filter and default sorting to rating
- lazy-load destination images with a blurred placeholder

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688e0eaaca2483228ddd06a81d5954ad