### PR TITLE
fix: prevent image drag in onboarding carousel

### DIFF
--- a/src/components/planner/onboarding/OnboardingCarousel.tsx
+++ b/src/components/planner/onboarding/OnboardingCarousel.tsx
@@ -62,7 +62,14 @@ function Slide({
     >
       <div className="mb-4 h-full p-5">
         <div className="relative h-[70%] w-full flex-none">
-          <Image src={step.image} alt={step.title} fill className="object-cover" />
+          <Image
+            src={step.image}
+            alt={step.title}
+            fill
+            className="object-cover"
+            draggable={false}
+            onDragStart={(e) => e.preventDefault()}
+          />
         </div>
         <div className="mt-2 flex-1">
           <h3 className="text-foreground mb-1 text-3xl font-semibold">{step.title}</h3>

--- a/src/hooks/catalog/useCatalog.test.ts
+++ b/src/hooks/catalog/useCatalog.test.ts
@@ -8,6 +8,7 @@ vi.mock('./useCatalogActivities', () => ({
 
 import { useCatalogActivities } from './useCatalogActivities';
 import { useCatalog } from './useCatalog';
+import type { CatalogActivity } from '@/types';
 
 const mockUseCatalogActivities = vi.mocked(useCatalogActivities);
 
@@ -39,7 +40,7 @@ describe('useCatalog', () => {
 
   test('propagates error state', () => {
     mockUseCatalogActivities.mockReturnValue({
-      activities: undefined,
+      activities: undefined as unknown as CatalogActivity[],
       isLoading: false,
       isError: true,
     });


### PR DESCRIPTION
## Summary
- prevent native image dragging in onboarding carousel images
- adjust catalog hook test to satisfy type checking
- type test mock to avoid any warnings

## Testing
- `npm run format`
- `npm run lint` (1 warning)
- `npm run test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688e1ff339dc8322b70301492a465c11