### PR TITLE
🔧 Configure Gitmoji commit lint and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Write a concise description of your changes and paste the same text into the PR description. -->
+
+## Testing
+
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run typecheck`
+
+> **Note:** PR titles and commits must start with the appropriate Gitmoji and use English.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx commitlint --edit "$1"
+

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -3,8 +3,8 @@
 if npx -v >&/dev/null
 then
   exec < /dev/tty
-  npx -c "gitmoji --hook $1 $2"
+  npx -c "gitmoji -c --hook $1 $2"
 else
   exec < /dev/tty
-  gitmoji --hook $1 $2
+  gitmoji -c --hook $1 $2
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This `Agents.md` file provides comprehensive guidance for any AI agents working 
 - **Linting**: Ensure `npm run lint` passes.
 - **Type checking**: Ensure `npm run typecheck` passes.
 - **Tests**: Execute `npm run test` and make sure tests succeed.
-- **Commit style**: Use short, imperative, English commit messages. Prefix with `feat:`, `fix:`, `chore:`, etc. when applicable.
+- **Commit style**: Start commit messages with the appropriate [Gitmoji](https://gitmoji.dev/) emoji, followed by a space and a short, imperative message that begins with an uppercase letter. Example: `✨ Add date picker to planner`.
 
 ## General Conventions for AI Agents
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ You can deploy the same app to Vercel or Netlify.
 5. Run the type checker with `npm run typecheck`.
 6. Ensure all tests pass with `npm run test`.
 7. Follow the commit message style: Start with an appropriate [Gitmoji](https://gitmoji.dev/) emoji, followed by a space and a short, imperative message that begins with an uppercase letter. Example: `✨ Add date picker to planner`.
+8. Validate commit messages with `npx commitlint --from origin/main --to HEAD`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can deploy the same app to Vercel or Netlify.
 4. Run the linter via `npm run lint`.
 5. Run the type checker with `npm run typecheck`.
 6. Ensure all tests pass with `npm run test`.
-7. Follow the commit message style: Use short, imperative, English commit messages. Prefix with `feat:`, `fix:`, `chore:`, etc. when applicable.
+7. Follow the commit message style: Start with an appropriate [Gitmoji](https://gitmoji.dev/) emoji, followed by a space and a short, imperative message that begins with an uppercase letter. Example: `✨ Add date picker to planner`.
 
 ---
 

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { extends: ['gitmoji'] };

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for taking the time to contribute to Turistar! This document outlines 
   - Start with the appropriate emoji, followed by a space and a short, imperative message that begins with an uppercase letter.
   - Example: `✨ Add date picker to planner`
 - Squash commits before merging so the main branch history stays tidy.
+- To verify commit history, run `npx commitlint --from origin/main --to HEAD` before pushing.
 
 ## Linting and Formatting
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,13 +2,12 @@
 
 Thank you for taking the time to contribute to Turistar! This document outlines the development conventions for the project so that all contributions are consistent and easy to review.
 
-## Branches and Conventional Commits
+## Branches and Commit Messages
 
 - Use short branch names starting with a type, for example `feature/*`, `fix/*` or `chore/*`.
-- Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
-  - Prefix your commit subject with `feat:`, `fix:`, `chore:` and so on.
-  - Keep messages brief and imperative.
-  - Example: `feat: add date picker to planner`
+- Commit messages must use [Gitmoji](https://gitmoji.dev/).
+  - Start with the appropriate emoji, followed by a space and a short, imperative message that begins with an uppercase letter.
+  - Example: `✨ Add date picker to planner`
 - Squash commits before merging so the main branch history stays tidy.
 
 ## Linting and Formatting
@@ -33,6 +32,12 @@ npm run test
 ```
 
 Use `npm run test:watch` for watch mode or `npm run test:coverage` to produce coverage reports.
+
+## Pull Requests
+
+- Use the pull request template from `.github/pull_request_template.md`.
+- Repeat the summary from the template in the PR description.
+- Ensure PR titles and commits use Gitmoji and are written in English.
 
 ## Storybook
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^8.0.0",
     "@commitlint/cli": "^19.5.0",
-    "commitlint-config-gitmoji": "^3.0.0",
+    "commitlint-config-gitmoji": "^2.3.1",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^8.0.0",
+    "@commitlint/cli": "^19.5.0",
+    "commitlint-config-gitmoji": "^3.1.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^8.0.0",
     "@commitlint/cli": "^19.5.0",
-    "commitlint-config-gitmoji": "^3.1.0",
+    "commitlint-config-gitmoji": "^3.0.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",

--- a/src/hooks/fetchCatalog.ts
+++ b/src/hooks/fetchCatalog.ts
@@ -12,7 +12,7 @@ export interface CatalogApiResponse {
  */
 export async function fetchCatalog(
   dest: string,
-  categories: string[],
+  categories: string[]
 ): Promise<CatalogApiResponse> {
   const params = new URLSearchParams({ dest });
   if (categories.length > 0) {

--- a/src/hooks/useCatalogActivities.ts
+++ b/src/hooks/useCatalogActivities.ts
@@ -11,7 +11,7 @@ import type { CatalogActivity } from '@/types';
 export function useCatalogActivities(
   dest: string | null,
   categories: string[],
-  options: { enabled: boolean },
+  options: { enabled: boolean }
 ) {
   const query = useQuery({
     queryKey: ['catalog', dest, categories],


### PR DESCRIPTION
## Summary
- document Gitmoji commit style in AGENTS, README, and CONTRIBUTING
- enforce commit messages with commitlint and Gitmoji Husky hooks
- add pull request template requiring summary and testing sections

## Testing
- `npm install` (failed: 403 Forbidden)
- `npm run format` (failed: Cannot find package 'prettier-plugin-tailwindcss')
- `npm run lint` (failed: Cannot find package '@eslint/eslintrc')
- `npm run typecheck` (failed: Cannot find type definition file for 'node')
- `npm run test` (failed: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_688e23978bcc8322b02b218be7afba58