### PR TITLE
🐛 Use dest column for plan destination

### DIFF
--- a/src/app/planner/[planId]/page.tsx
+++ b/src/app/planner/[planId]/page.tsx
@@ -18,13 +18,13 @@ export default async function PlannerPlanPage({ params, searchParams }: PageProp
     const supabase = supabaseServer();
     const { data, error } = (await supabase
       .from('plans')
-      .select('destination')
+      .select('dest')
       .eq('id', planId)
       .single()) as unknown as {
-      data: { destination: string | null } | null;
+      data: { dest: string | null } | null;
       error: unknown;
     };
-    if (!error) destination = data?.destination ?? undefined;
+    if (!error) destination = data?.dest ?? undefined;
   }
 
   if (!destination) {

--- a/src/app/planner/actions/createPlan.ts
+++ b/src/app/planner/actions/createPlan.ts
@@ -19,7 +19,7 @@ export async function createPlan(dest: string, start: string, end: string) {
     .from('plans')
     .insert({
       title: dest,
-      destination: dest,
+      dest,
       user_id: user.id,
       start_date: startDate,
       end_date: endDate,


### PR DESCRIPTION
## Summary
- replace `destination` with `dest` when inserting plans
- query the `dest` column instead of `destination` when fetching a plan

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688ec7c2ab4483228cd22ef5dd58d69c