### PR TITLE
🐛 Restore budget persistence using entries column

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -23,14 +23,12 @@ CONSTRAINT activities_pkey PRIMARY KEY (id),
 CONSTRAINT activities_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.plan_days(id),
 CONSTRAINT activities_catalog_id_fkey FOREIGN KEY (catalog_id) REFERENCES public.catalog(id)
 );
-CREATE TABLE public.budget_entries (
-id uuid NOT NULL DEFAULT uuid_generate_v4(),
+CREATE TABLE public.budget (
 plan_id uuid NOT NULL,
-description text,
-category text,
-amount numeric,
-CONSTRAINT budget_entries_pkey PRIMARY KEY (id),
-CONSTRAINT budget_entries_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id)
+budget numeric,
+entries jsonb,
+CONSTRAINT budget_pkey PRIMARY KEY (plan_id),
+CONSTRAINT budget_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id)
 );
 CREATE TABLE public.catalog (
 id text NOT NULL,

--- a/src/hooks/budget/useBudgetSupabase.test.ts
+++ b/src/hooks/budget/useBudgetSupabase.test.ts
@@ -14,25 +14,17 @@ describe('useBudgetSupabase', () => {
     mockFrom.mockReset();
   });
 
-  test('sets persistError when Supabase fails', async () => {
-    const selectBudget = vi.fn().mockResolvedValue({ data: { budget: 0 }, error: null });
-    const selectEntries = vi.fn().mockResolvedValue({ data: [], error: null });
+  test('sets persistError when upsert fails', async () => {
+    const selectBudget = vi
+      .fn()
+      .mockResolvedValue({ data: { budget: 0, entries: [] }, error: null });
     const upsertBudget = vi.fn().mockResolvedValue({ error: new Error('boom') });
-    const deleteEntries = vi.fn().mockResolvedValue({ error: null });
-    const insertEntries = vi.fn().mockResolvedValue({ error: null });
 
     mockFrom.mockImplementation((table: string) => {
       if (table === 'budget') {
         return {
           select: () => ({ eq: () => ({ single: () => selectBudget() }) }),
           upsert: () => upsertBudget(),
-        } as unknown;
-      }
-      if (table === 'budget_entries') {
-        return {
-          select: () => ({ eq: () => selectEntries() }),
-          delete: () => ({ eq: () => deleteEntries() }),
-          insert: () => insertEntries(),
         } as unknown;
       }
       return {} as unknown;

--- a/src/hooks/budget/useBudgetSupabase.ts
+++ b/src/hooks/budget/useBudgetSupabase.ts
@@ -1,11 +1,10 @@
 // src/hooks/budget/useBudgetSupabase.ts
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database, Json } from '@/types/supabase';
 import type { CategoryKey } from '@/constants';
 import type { Entry } from '@/types/budget';
-import type { Database } from '@/types/supabase';
-
-type BudgetTableRow = Database['public']['Tables']['budget']['Row'];
 
 export function useBudget(planId: string, activitiesTotal: number) {
   const [budget, setBudget] = useState(0);
@@ -18,35 +17,40 @@ export function useBudget(planId: string, activitiesTotal: number) {
   const [hasLoaded, setHasLoaded] = useState(false);
   const hasLoadedRef = useRef(false);
   const [persistError, setPersistError] = useState<string | null>(null);
+  const sb: SupabaseClient<Database> = supabase;
 
   useEffect(() => {
     hasLoadedRef.current = false;
     setHasLoaded(false);
     const load = async () => {
-      const sb = supabase as any;
+      type BudgetRow = Database['public']['Tables']['budget']['Row'];
       const { data } = (await sb
         .from('budget')
         .select('budget, entries')
         .eq('plan_id', planId)
-        .single()) as { data: BudgetTableRow | null };
+        .single()) as { data: BudgetRow | null };
       if (data) {
         setBudget(data.budget ?? 0);
-        setEntries((data.entries as Entry[] | null) ?? []);
+        setEntries((data.entries as unknown as Entry[] | null) ?? []);
       }
       hasLoadedRef.current = true;
       setHasLoaded(true);
     };
     void load();
-  }, [planId]);
+  }, [planId, sb]);
 
   useEffect(() => {
     if (!hasLoadedRef.current) return;
     const persist = async () => {
       setPersistError(null);
-      const sb = supabase as any;
+      const payload: Database['public']['Tables']['budget']['Insert'] = {
+        plan_id: planId,
+        budget,
+        entries: entries as unknown as Json,
+      };
       const { error } = (await sb
         .from('budget')
-        .upsert({ plan_id: planId, budget, entries }, { onConflict: 'plan_id' })) as {
+        .upsert(payload, { onConflict: 'plan_id' })) as unknown as {
         error: unknown;
       };
       if (error) {
@@ -54,7 +58,7 @@ export function useBudget(planId: string, activitiesTotal: number) {
       }
     };
     void persist();
-  }, [planId, budget, entries, hasLoaded]);
+  }, [planId, budget, entries, hasLoaded, sb]);
 
   const categoryTotals = useMemo(() => {
     const totals: Record<CategoryKey, number> = {


### PR DESCRIPTION
## Summary
- Load and save budget entries directly through the `budget.entries` column
- Update Supabase types to reintroduce `entries` and drop the unused `budget_entries` table
- Reflect schema changes in database documentation and tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68915c52cf00832283c00f17e81276c4