### PR TITLE
Refactor wildcard exports to named re-exports

### DIFF
--- a/src/features/budget/hooks/index.ts
+++ b/src/features/budget/hooks/index.ts
@@ -1,4 +1,4 @@
 // src/features/budget/hooks/index.ts
 
-export * from './BudgetContext';
-export * from './useBudgetSupabase';
+export { BudgetContext, BudgetProvider, useBudgetContext } from './BudgetContext';
+export { useBudget, useBudgetSupabase } from './useBudgetSupabase';

--- a/src/features/budget/types/index.ts
+++ b/src/features/budget/types/index.ts
@@ -1,3 +1,3 @@
 // src/features/budget/types/index.ts
 
-export * from './budget';
+export type { Entry, CategoryKey } from './budget';

--- a/src/features/planner/components/index.ts
+++ b/src/features/planner/components/index.ts
@@ -1,7 +1,22 @@
 // src/features/planner/components/index.ts
 
-export * from './catalog';
-export * from './dnd';
-export * from './modal';
+export {
+  CategoryFilterBar,
+  DestinationCard,
+  DestinationCardGrid,
+  DestinationResultsList,
+  DestinationFilterPanel,
+  DestinationHeader,
+  CategorySelection,
+} from './catalog';
+export {
+  SortableItem,
+  DayColumn,
+  ActivityCard,
+  ActivityCardBase,
+  ActivityCardEditing,
+  ActivityCardEditorOverlay,
+} from './dnd';
+export { ActivityModal, ActivityModalForm, ActivityModalHeader } from './modal';
 
 export { default as PlannerControls } from './PlannerControls';

--- a/src/features/planner/services/index.ts
+++ b/src/features/planner/services/index.ts
@@ -1,10 +1,10 @@
 // src/features/planner/services/index.ts
 
-export * from './buildDaysFromInspirationData';
-export * from './formatDayPlan';
-export * from './initialDays';
-export * from './cloneDays';
-export * from './moveActivityToDay';
-export * from './moveActivityPosition';
-export * from './normalizeAmount';
-export * from './syncDaysWithTripRange';
+export { buildDaysFromInspirationData, type InspirationData } from './buildDaysFromInspirationData';
+export { formatDayPlan } from './formatDayPlan';
+export { buildInitialDays } from './initialDays';
+export { cloneDays } from './cloneDays';
+export { moveActivityToDay } from './moveActivityToDay';
+export { moveActivityPosition } from './moveActivityPosition';
+export { normalizeAmount } from './normalizeAmount';
+export { syncDaysWithTripRange } from './syncDaysWithTripRange';

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,8 +1,21 @@
 // src/shared/constants/index.ts
 
-export * from './colors';
-export * from './ui';
-export * from './budget';
-export * from './budgetInfo';
-export * from './keyBinds';
-export * from './onboarding';
+export {
+  DEFAULT_NEW_CARD_COLOR_INDEX,
+  DEFAULT_ADD_ACTIVITY_COLOR_INDEX,
+  DEFAULT_COLORS,
+} from './colors';
+export type { CardColor } from './colors';
+
+export { EMPTY_ACTIVITY_TITLE, MAX_FILE_SIZE } from './ui';
+
+export { CATEGORIES, CHART_COLORS } from './budget';
+export type { CategoryKey } from './budget';
+
+export { BUDGET_INFO } from './budgetInfo';
+
+export { KEY_BINDS } from './keyBinds';
+export type { KeyBind } from './keyBinds';
+
+export { ONBOARDING_STEPS } from './onboarding';
+export type { OnboardingStep } from './onboarding';

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,6 +1,14 @@
 // src/shared/lib/index.ts
 
-export * from './geoapify';
-export * from './http';
-export * from './supabaseClient';
-export * from './env';
+export {
+  GEOAPIFY_CATEGORIES,
+  getGeoapifyKey,
+  mapGeoapifyFeature,
+  fetchGeoapifyAutocomplete,
+  fetchGeoapifyCatalog,
+  fetchGeoapifySearch,
+} from './geoapify';
+export { fetchJson } from './http';
+export { supabase } from './supabaseClient';
+export { env } from './env';
+export type { Env } from './env';

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -12,10 +12,23 @@ export { default as Spinner } from './Spinner';
 export { default as Modal } from './Modal';
 
 // Icons components
-export * from './button-icons';
+export { default as CardColorButton } from './button-icons/CardColorButton';
+export { default as CloseButton } from './button-icons/CloseButton';
+export { default as RemoveCardButton } from './button-icons/DeleteCardButton';
+export { default as EditCardButton } from './button-icons/EditCardButton';
+export { default as SearchCatalogButton } from './button-icons/SearchCatalogButton';
+export { default as NavCircleButton } from './button-icons/NavCircleButton';
 
 // Unique buttons
-export * from './button-especials';
+export { default as AddCardButton } from './button-especials/AddCardButton';
+export { default as DestinationActionButton } from './button-especials/DestinationAction';
+export { default as ModeToggleButton } from './button-especials/ModeToggleButton';
+export { default as UpdateButton } from './button-especials/UpdateButton';
+export { OpenPanelButton, OpenPanelIcon } from './button-especials/OpenCatalog';
 
 // Popups components
-export * from './popups';
+export { default as CardColorsPopup } from './popups/CardColorsPopup';
+export { default as DayPickerPopup } from './popups/DayPickerPopup';
+export { default as InfoPopup } from './popups/InfoPopup';
+export { default as CatalogSearchPopup } from './popups/CatalogSearchPopup';
+export { default as Popup, popupVariants } from './popups/Popup';

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,2 +1,4 @@
-export * from './utils';
-export * from './isTouchDevice';
+// src/shared/utils/index.ts
+
+export { cn, capitalize, measureTextWidth } from './utils';
+export { isTouchDevice } from './isTouchDevice';


### PR DESCRIPTION
## Summary
- replace wildcard exports with explicit names in budget and planner features
- refactor shared utils, lib, constants and UI to use named re-exports
- document shared utils barrel file

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6893fcf2fa908322a067ef6a344ea721