### PR TITLE
🐛 Fix env parsing for client components

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Example environment variables for Turistar
-GEOAPIFY_KEY=your_api_key_here
+NEXT_PUBLIC_GEOAPIFY_KEY=your_api_key_here
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ While editing an activity, you can search the catalog directly from the modal or
 - **Map View**
   View all your planned attractions on an interactive map.
 - **Dynamic Catalog**
-  Activities are fetched from Geoapify via `/api/catalog` using your `GEOAPIFY_KEY`.
+  Activities are fetched from Geoapify via `/api/catalog` using your `NEXT_PUBLIC_GEOAPIFY_KEY`.
 - **Persistent Storage**
   All planner and budget changes are saved to Supabase so they stay when you refresh.
 - **Accessibility & Responsive Design**
@@ -148,8 +148,8 @@ See [Routing](docs/ROUTING.md) for a breakdown of the `src/app` directory.
 
 4. **Configure environment**
  - Copy `.env.example` to `.env.local`.
- - Set the following variables (validated in [`env.ts`](src/shared/lib/env.ts)):
-    - `GEOAPIFY_KEY`
+ - Set the following variables (validated in [`env.ts`](src/shared/lib/env.ts) and [`clientEnv.ts`](src/shared/lib/clientEnv.ts)):
+    - `NEXT_PUBLIC_GEOAPIFY_KEY`
     - `NEXT_PUBLIC_SUPABASE_URL`
     - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
   - Optionally set `SUPABASE_SERVICE_ROLE_KEY` for local type generation.
@@ -201,7 +201,7 @@ Deploy easily to **Vercel** or **Netlify**:
 1. Push your code to GitHub.
 2. Import the repository in your hosting service (https://vercel.com/new or https://app.netlify.com/start).
 3. Add the required environment variables:
-   - `GEOAPIFY_KEY`
+   - `NEXT_PUBLIC_GEOAPIFY_KEY`
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 4. Click "Deploy" — the platform will build and preview automatically.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,5 +21,5 @@ For deeper feature details see [home](features/home.md), [planner](features/plan
 
 - **Next.js App Router** – Provides file based routing and server actions. Planner routes live under `/planner` while API helpers reside in `src/server`.
 - **Drag‑and‑drop with DnD Kit** – Activities move via sensors and sortable logic encapsulated in hooks within `src/features/planner`.
-- **Geoapify Integration** – Catalog data is fetched from Geoapify through `src/server/api/catalog` using the `GEOAPIFY_KEY`.
+- **Geoapify Integration** – Catalog data is fetched from Geoapify through `src/server/api/catalog` using the `NEXT_PUBLIC_GEOAPIFY_KEY`.
 - **State management** – Planner and budget data live in feature contexts and synchronize to Supabase through shared hooks.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,7 @@ This document covers how to deploy **Turistar** and manage environment variables
 
 Copy `.env.example` to `.env.local` and set the following values:
 
-- `GEOAPIFY_KEY`
+- `NEXT_PUBLIC_GEOAPIFY_KEY`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_SERVICE_ROLE_KEY`
@@ -34,4 +34,4 @@ npm start
 
 ## Catalog API Key
 
-Set the `GEOAPIFY_KEY` environment variable in your hosting platform so the catalog endpoint can request data from Geoapify.
+Set the `NEXT_PUBLIC_GEOAPIFY_KEY` environment variable in your hosting platform so the catalog endpoint can request data from Geoapify.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,12 +1,12 @@
 # Environment Variables
 
-Turistar reads environment variables through [`src/shared/lib/env.ts`](../src/shared/lib/env.ts). The module uses Zod to validate required values at runtime and throws when they are missing.
+Turistar reads environment variables through [`src/shared/lib/env.ts`](../src/shared/lib/env.ts) on the server and [`src/shared/lib/clientEnv.ts`](../src/shared/lib/clientEnv.ts) on the client. These modules use Zod to validate required values at runtime and throw when they are missing.
 
 ## Required Variables
 
 - `NEXT_PUBLIC_SUPABASE_URL` – URL of your Supabase project.
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` – public anon key for client access.
-- `GEOAPIFY_KEY` – API key for Geoapify requests.
+- `NEXT_PUBLIC_GEOAPIFY_KEY` – API key for Geoapify requests.
 - `NODE_ENV` – environment name (defaults to `development`).
 
 These values configure:

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -9,7 +9,7 @@ The application lets users create and organize trip itineraries, with plan data 
 - **Planner Board** – Rearrange activities between days using drag‑and‑drop.
 - **Catalog Popup** – Browse suggested activities and insert them directly into the board.
   - Search the catalog in real time.
-- **Geoapify Catalog** – Activities are fetched from Geoapify using your `GEOAPIFY_KEY`.
+- **Geoapify Catalog** – Activities are fetched from Geoapify using your `NEXT_PUBLIC_GEOAPIFY_KEY`.
 - **Persistent Storage** – Planner data and budget are saved in Supabase.
 - **Map Mode** – View itinerary on an interactive map built with Leaflet.
 - **Sample Inspirations** – Browse pre-built example itineraries for select cities.

--- a/src/features/planner/services/supabase/updateSession.ts
+++ b/src/features/planner/services/supabase/updateSession.ts
@@ -3,14 +3,14 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import type { Database } from '@/shared/types/supabase';
-import { env } from '@/shared/lib/env';
+import { clientEnv } from '@/shared/lib/clientEnv';
 
 export async function updateSession(request: NextRequest) {
   let response = NextResponse.next({ request });
 
   const supabase = createServerClient<Database>(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/src/shared/components/Providers.tsx
+++ b/src/shared/components/Providers.tsx
@@ -4,7 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useState } from 'react';
-import { env } from '@/shared/lib/env';
+import { clientEnv } from '@/shared/lib/clientEnv';
 
 /**
  * Client-side context providers (React Query, Theme, etc.).
@@ -17,7 +17,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
+      {clientEnv.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   );
 }

--- a/src/shared/components/providers/SupabaseProvider.tsx
+++ b/src/shared/components/providers/SupabaseProvider.tsx
@@ -4,7 +4,7 @@
 import { createContext, useContext, useMemo } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from '@/shared/types/supabase';
-import { env } from '@/shared/lib/env';
+import { clientEnv } from '@/shared/lib/clientEnv';
 
 // Context
 type Supabase = ReturnType<typeof createBrowserClient<Database>>;
@@ -14,8 +14,8 @@ export default function SupabaseProvider({ children }: { children: React.ReactNo
   const supabase = useMemo(
     () =>
       createBrowserClient<Database>(
-        env.NEXT_PUBLIC_SUPABASE_URL,
-        env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+        clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+        clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
       ),
     []
   );

--- a/src/shared/lib/clientEnv.ts
+++ b/src/shared/lib/clientEnv.ts
@@ -1,0 +1,21 @@
+// src/shared/lib/clientEnv.ts
+import { z } from 'zod';
+
+const clientEnvSchema = z.object({
+  NODE_ENV: z.string().default('development'),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+  NEXT_PUBLIC_GEOAPIFY_KEY: z.string(),
+});
+
+// Next.js replaces `process.env.NEXT_PUBLIC_*` at build time, but the
+// `process.env` object itself is empty in the browser. Referencing each key
+// explicitly ensures the values are inlined during compilation and available at runtime.
+export const clientEnv = clientEnvSchema.parse({
+  NODE_ENV: process.env.NODE_ENV,
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_GEOAPIFY_KEY: process.env.NEXT_PUBLIC_GEOAPIFY_KEY,
+});
+
+export type ClientEnv = z.infer<typeof clientEnvSchema>;

--- a/src/shared/lib/env.ts
+++ b/src/shared/lib/env.ts
@@ -4,9 +4,7 @@ import { z } from 'zod';
 
 const envSchema = z.object({
   NODE_ENV: z.string().default('development'),
-  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
-  GEOAPIFY_KEY: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -3,7 +3,7 @@
 // Helpers for fetching POIs from the Geoapify API.
 
 import type { CatalogActivity, AutocompletePlace } from '@/shared/types';
-import { env } from './env';
+import { clientEnv } from './clientEnv';
 
 /* Types */
 type GeoapifyFeature = {
@@ -47,7 +47,7 @@ const DEFAULT_CATEGORIES = GEOAPIFY_CATEGORIES.join(',');
 
 /* Helpers */
 export function getGeoapifyKey(): string {
-  return env.GEOAPIFY_KEY;
+  return clientEnv.NEXT_PUBLIC_GEOAPIFY_KEY;
 }
 
 export function mapGeoapifyFeature(f: GeoapifyFeature, fallbackName?: string): CatalogActivity {

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -10,5 +10,5 @@ export {
 } from './geoapify';
 export { fetchJson } from './http';
 export { supabase } from './supabaseClient';
-export { env } from './env';
-export type { Env } from './env';
+export { clientEnv } from './clientEnv';
+export type { ClientEnv } from './clientEnv';

--- a/src/shared/lib/supabaseClient.ts
+++ b/src/shared/lib/supabaseClient.ts
@@ -2,10 +2,10 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/shared/types/supabase';
-import { env } from './env';
+import { clientEnv } from './clientEnv';
 
 // Create a browser-ready Supabase client for React components
 export const supabase: SupabaseClient<Database> = createBrowserClient<Database>(
-  env.NEXT_PUBLIC_SUPABASE_URL,
-  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+  clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );

--- a/src/shared/lib/supabaseServer.ts
+++ b/src/shared/lib/supabaseServer.ts
@@ -4,12 +4,12 @@ import { createServerClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { CookieOptions } from '@supabase/ssr';
 import type { Database } from '@/shared/types/supabase';
-import { env } from './env';
+import { clientEnv } from './clientEnv';
 
 export function supabaseServer() {
   return createServerClient<Database>(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {
@@ -25,8 +25,8 @@ export function supabaseServer() {
 export async function supabaseServerAction(): Promise<SupabaseClient<Database>> {
   const cookieStore = await cookies();
   return createServerClient<Database>(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         get(name: string) {

--- a/tests/unit/shared/lib/geoapify.test.ts
+++ b/tests/unit/shared/lib/geoapify.test.ts
@@ -2,19 +2,19 @@
 import { vi } from 'vitest';
 
 const originalFetch = global.fetch;
-const originalKey = process.env.GEOAPIFY_KEY;
+const originalKey = process.env.NEXT_PUBLIC_GEOAPIFY_KEY;
 let fetchGeoapifyAutocomplete: typeof import('@/shared/lib/geoapify').fetchGeoapifyAutocomplete;
 
 describe('fetchGeoapifyAutocomplete', () => {
   beforeEach(async () => {
     vi.resetModules();
-    process.env.GEOAPIFY_KEY = 'test-key';
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = 'test-key';
     ({ fetchGeoapifyAutocomplete } = await import('@/shared/lib/geoapify'));
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.env.GEOAPIFY_KEY = originalKey;
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = originalKey;
   });
 
   it('filters out non city/state/country results', async () => {

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -2,7 +2,8 @@
 process.env.TZ = 'UTC';
 process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'http://localhost:54321';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'anon';
-process.env.GEOAPIFY_KEY = process.env.GEOAPIFY_KEY ?? 'test-key';
+process.env.NEXT_PUBLIC_GEOAPIFY_KEY =
+  process.env.NEXT_PUBLIC_GEOAPIFY_KEY ?? 'test-key';
 import '@testing-library/jest-dom';
 import React from 'react';
 


### PR DESCRIPTION
## Summary
- split environment validation into client and server modules
- use clientEnv in client-side providers and Supabase client
- reference process.env keys individually in clientEnv to avoid runtime ZodError
- document new clientEnv module
- read Geoapify key from clientEnv and drop server env re-export

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894071801008322a333e3f46c5db30d