### PR TITLE
♻️ Refactor context hooks with strict provider helper

### DIFF
--- a/src/features/budget/hooks/BudgetContext.tsx
+++ b/src/features/budget/hooks/BudgetContext.tsx
@@ -1,10 +1,13 @@
 // src/features/budget/hooks/BudgetContext.tsx
 'use client';
 
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
+import { createStrictContext } from '@/shared/context/createStrictContext';
 import { useBudget } from './useBudgetSupabase';
 
-export const BudgetContext = createContext<ReturnType<typeof useBudget> | null>(null);
+const [BudgetContextProvider, useBudgetContext] = createStrictContext<ReturnType<typeof useBudget>>(
+  'useBudgetContext must be inside BudgetProvider'
+);
 
 export function BudgetProvider({
   children,
@@ -16,11 +19,7 @@ export function BudgetProvider({
   activitiesTotal: number;
 }) {
   const value = useBudget(planId, activitiesTotal);
-  return <BudgetContext.Provider value={value}>{children}</BudgetContext.Provider>;
+  return <BudgetContextProvider value={value}>{children}</BudgetContextProvider>;
 }
 
-export function useBudgetContext() {
-  const ctx = useContext(BudgetContext);
-  if (!ctx) throw new Error('useBudgetContext must be inside BudgetProvider');
-  return ctx;
-}
+export { useBudgetContext };

--- a/src/features/budget/hooks/index.ts
+++ b/src/features/budget/hooks/index.ts
@@ -1,4 +1,4 @@
 // src/features/budget/hooks/index.ts
 
-export { BudgetContext, BudgetProvider, useBudgetContext } from './BudgetContext';
+export { BudgetProvider, useBudgetContext } from './BudgetContext';
 export { useBudget, useBudgetSupabase } from './useBudgetSupabase';

--- a/src/features/budget/index.ts
+++ b/src/features/budget/index.ts
@@ -11,6 +11,6 @@ export {
   ActivitiesBudgetPopup,
 } from './components';
 
-export { BudgetContext, BudgetProvider, useBudgetContext, useBudgetSupabase } from './hooks';
+export { BudgetProvider, useBudgetContext, useBudgetSupabase } from './hooks';
 
 export type { Entry, CategoryKey } from './types';

--- a/src/features/onboarding/hooks/OnboardingContext.tsx
+++ b/src/features/onboarding/hooks/OnboardingContext.tsx
@@ -1,18 +1,17 @@
 // src/features/onboarding/hooks/OnboardingContext.tsx
 'use client';
 
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
+import { createStrictContext } from '@/shared/context/createStrictContext';
 import { useOnboardingCheck } from './useOnboardingCheck';
 
-export const OnboardingContext = createContext<ReturnType<typeof useOnboardingCheck> | null>(null);
+const [OnboardingContextProvider, useOnboardingContext] = createStrictContext<
+  ReturnType<typeof useOnboardingCheck>
+>('useOnboardingContext must be inside OnboardingProvider');
 
 export function OnboardingProvider({ planId, children }: { planId: string; children: ReactNode }) {
   const value = useOnboardingCheck(planId);
-  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+  return <OnboardingContextProvider value={value}>{children}</OnboardingContextProvider>;
 }
 
-export function useOnboardingContext() {
-  const ctx = useContext(OnboardingContext);
-  if (!ctx) throw new Error('useOnboardingContext must be inside OnboardingProvider');
-  return ctx;
-}
+export { useOnboardingContext };

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,9 +1,5 @@
 // src/features/onboarding/index.ts
 
 export { OnboardingCarousel, OnboardingModal } from './components';
-export {
-  OnboardingContext,
-  OnboardingProvider,
-  useOnboardingContext,
-} from './hooks/OnboardingContext';
+export { OnboardingProvider, useOnboardingContext } from './hooks/OnboardingContext';
 export { useOnboardingCheck } from './hooks/useOnboardingCheck';

--- a/src/features/planner/hooks/PlannerContext.tsx
+++ b/src/features/planner/hooks/PlannerContext.tsx
@@ -1,14 +1,17 @@
 // src/features/planner/hooks/PlannerContext.tsx
 'use client';
 
-import React, { createContext, useContext, ReactNode, useEffect, useRef } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import { usePlanner, useSelectedActivity, usePlanDays } from '@/features/planner';
 import { useDebounce } from '@/shared/hooks/useDebounce';
+import { createStrictContext } from '@/shared/context/createStrictContext';
 import type { DayPlan } from '@/shared/types';
 
 type PlannerCtx = ReturnType<typeof usePlanner> & ReturnType<typeof useSelectedActivity>;
 
-export const PlannerContext = createContext<PlannerCtx | null>(null);
+const [PlannerContextProvider, usePlannerContext] = createStrictContext<PlannerCtx>(
+  'usePlannerContext must be inside PlannerProvider'
+);
 
 export function PlannerProvider({
   children,
@@ -93,14 +96,8 @@ export function PlannerProvider({
     addBlankActivity: planner.addBlankActivity,
   });
   return (
-    <PlannerContext.Provider value={{ ...planner, ...selected }}>
-      {children}
-    </PlannerContext.Provider>
+    <PlannerContextProvider value={{ ...planner, ...selected }}>{children}</PlannerContextProvider>
   );
 }
 
-export function usePlannerContext() {
-  const ctx = useContext(PlannerContext);
-  if (!ctx) throw new Error('usePlannerContext must be inside PlannerProvider');
-  return ctx;
-}
+export { usePlannerContext };

--- a/src/features/planner/hooks/index.ts
+++ b/src/features/planner/hooks/index.ts
@@ -24,4 +24,4 @@ export {
   type CatalogApiResponse,
 } from './catalog';
 
-export { PlannerContext, PlannerProvider, usePlannerContext } from './PlannerContext';
+export { PlannerProvider, usePlannerContext } from './PlannerContext';

--- a/src/features/planner/index.ts
+++ b/src/features/planner/index.ts
@@ -40,7 +40,6 @@ export {
   fetchAutocomplete,
   fetchCatalog,
   fetchSearch,
-  PlannerContext,
   PlannerProvider,
   usePlannerContext,
 } from './hooks';

--- a/src/shared/context/createStrictContext.ts
+++ b/src/shared/context/createStrictContext.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export function createStrictContext<T>(errorMessage: string) {
+  const context = createContext<T | undefined>(undefined);
+
+  const useStrictContext = () => {
+    const value = useContext(context);
+    if (value === undefined) {
+      throw new Error(errorMessage);
+    }
+    return value;
+  };
+
+  return [context.Provider, useStrictContext] as const;
+}

--- a/tests/unit/features/onboarding/components/OnboardingModal.test.tsx
+++ b/tests/unit/features/onboarding/components/OnboardingModal.test.tsx
@@ -5,14 +5,23 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import OnboardingModal from '@/features/onboarding/components/OnboardingModal';
 import { ONBOARDING_STEPS } from '@/shared/constants';
 import { vi } from 'vitest';
-import { OnboardingContext } from '@/features/onboarding';
+import { OnboardingProvider } from '@/features/onboarding';
+
+const mockSetShowOnboarding = vi.fn();
+vi.mock('@/features/onboarding/hooks/useOnboardingCheck', () => ({
+  useOnboardingCheck: () => ({ showOnboarding: true, setShowOnboarding: mockSetShowOnboarding }),
+}));
 
 describe('OnboardingModal', () => {
+  beforeEach(() => {
+    mockSetShowOnboarding.mockClear();
+  });
+
   it('renders all steps when open', () => {
     render(
-      <OnboardingContext.Provider value={{ showOnboarding: true, setShowOnboarding: vi.fn() }}>
+      <OnboardingProvider planId="p1">
         <OnboardingModal />
-      </OnboardingContext.Provider>
+      </OnboardingProvider>
     );
     ONBOARDING_STEPS.forEach((step) => {
       expect(screen.getAllByText(step.title).length).toBeGreaterThan(0);
@@ -20,13 +29,12 @@ describe('OnboardingModal', () => {
   });
 
   it('calls onClose when close button clicked', () => {
-    const handleClose = vi.fn();
     render(
-      <OnboardingContext.Provider value={{ showOnboarding: true, setShowOnboarding: handleClose }}>
+      <OnboardingProvider planId="p1">
         <OnboardingModal />
-      </OnboardingContext.Provider>
+      </OnboardingProvider>
     );
     fireEvent.click(screen.getByLabelText('Close'));
-    expect(handleClose).toHaveBeenCalled();
+    expect(mockSetShowOnboarding).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add `createStrictContext` helper to wrap context usage
- refactor budget, onboarding and planner contexts to use helper
- update onboarding modal test to use provider

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68940c2a1268832283e13d23c5028dc1