### PR TITLE
🚚 Move normalizeAmount to shared utils

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ npm run test -- --coverage
 - [Planner Feature](docs/features/planner.md)
 - [Budget Feature](docs/features/budget.md)
 - [Onboarding Feature](docs/features/onboarding.md)
+- [Shared Utilities](docs/shared/utils.md)
 - [Style Guide](docs/STYLE-GUIDE.md)
 - [Accessibility](docs/ACCESSIBILITY.md)
 - [Testing](docs/TESTING.md)

--- a/docs/features/planner.md
+++ b/docs/features/planner.md
@@ -423,7 +423,7 @@ import { PlannerControls } from '@/features/planner';
 - **Responsibility:** Reorders an activity within a day.
 
 ### normalizeAmount
-- **Location:** [`src/features/planner/services/normalizeAmount.ts`](../../src/features/planner/services/normalizeAmount.ts)
+- **Location:** [`src/shared/utils/normalizeAmount.ts`](../../src/shared/utils/normalizeAmount.ts)
 - **Responsibility:** Parses currency strings into numbers.
 
 ### syncDaysWithTripRange

--- a/docs/shared/utils.md
+++ b/docs/shared/utils.md
@@ -1,0 +1,23 @@
+# Shared Utilities
+
+Reusable helper functions shared across features.
+
+### cn
+- **Location:** [`src/shared/utils/utils.ts`](../../src/shared/utils/utils.ts)
+- **Responsibility:** Combines class names using `clsx` and `tailwind-merge`.
+
+### capitalize
+- **Location:** [`src/shared/utils/utils.ts`](../../src/shared/utils/utils.ts)
+- **Responsibility:** Capitalizes the first letter of a string.
+
+### measureTextWidth
+- **Location:** [`src/shared/utils/utils.ts`](../../src/shared/utils/utils.ts)
+- **Responsibility:** Measures the width of text using a canvas context.
+
+### isTouchDevice
+- **Location:** [`src/shared/utils/isTouchDevice.ts`](../../src/shared/utils/isTouchDevice.ts)
+- **Responsibility:** Detects whether the current environment supports touch input.
+
+### normalizeAmount
+- **Location:** [`src/shared/utils/normalizeAmount.ts`](../../src/shared/utils/normalizeAmount.ts)
+- **Responsibility:** Parses a currency string into a numeric value.

--- a/src/features/budget/components/BudgetPanelHeader.tsx
+++ b/src/features/budget/components/BudgetPanelHeader.tsx
@@ -6,7 +6,7 @@ import { Info, DollarSign } from 'lucide-react';
 import { CATEGORIES, BUDGET_INFO } from '@/shared/constants';
 import { CategoryProgressBar, useBudgetContext } from '@/features/budget';
 import { InfoPopup, Input } from '@/shared/ui';
-import { normalizeAmount } from '@/features/planner';
+import { normalizeAmount } from '@/shared/utils';
 
 interface SummaryValueProps {
   amount: number;

--- a/src/features/budget/components/TableRowEdit.tsx
+++ b/src/features/budget/components/TableRowEdit.tsx
@@ -5,7 +5,7 @@ import React, { useId } from 'react';
 import { Check, X, DollarSign } from 'lucide-react';
 import { CATEGORIES, CategoryKey } from '@/shared/constants';
 import type { Entry } from '@/features/budget/types';
-import { normalizeAmount } from '@/features/planner';
+import { normalizeAmount } from '@/shared/utils';
 import { useBudgetContext } from '@/features/budget';
 import { Button, Input } from '@/shared/ui';
 

--- a/src/features/budget/components/TableRowNew.tsx
+++ b/src/features/budget/components/TableRowNew.tsx
@@ -4,7 +4,7 @@
 import React, { useId } from 'react';
 import { Plus, DollarSign } from 'lucide-react';
 import { CATEGORIES, CategoryKey } from '@/shared/constants';
-import { normalizeAmount } from '@/features/planner';
+import { normalizeAmount } from '@/shared/utils';
 import { useBudgetContext } from '@/features/budget';
 import { Button, Input } from '@/shared/ui';
 

--- a/src/features/budget/components/activities/ActivitiesBudget.tsx
+++ b/src/features/budget/components/activities/ActivitiesBudget.tsx
@@ -6,7 +6,7 @@ import { DollarSign } from 'lucide-react';
 
 import { Input, CloseButton, Modal } from '@/shared/ui';
 import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
-import { normalizeAmount } from '@/features/planner';
+import { normalizeAmount } from '@/shared/utils';
 import type { DayPlan } from '@/shared/types';
 
 interface ActivitiesBudgetProps {

--- a/src/features/planner/index.ts
+++ b/src/features/planner/index.ts
@@ -53,6 +53,5 @@ export {
   cloneDays,
   moveActivityToDay,
   moveActivityPosition,
-  normalizeAmount,
   syncDaysWithTripRange,
 } from './services';

--- a/src/features/planner/services/index.ts
+++ b/src/features/planner/services/index.ts
@@ -6,5 +6,4 @@ export { buildInitialDays } from './initialDays';
 export { cloneDays } from './cloneDays';
 export { moveActivityToDay } from './moveActivityToDay';
 export { moveActivityPosition } from './moveActivityPosition';
-export { normalizeAmount } from './normalizeAmount';
 export { syncDaysWithTripRange } from './syncDaysWithTripRange';

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -2,3 +2,4 @@
 
 export { cn, capitalize, measureTextWidth } from './utils';
 export { isTouchDevice } from './isTouchDevice';
+export { normalizeAmount } from './normalizeAmount';

--- a/src/shared/utils/normalizeAmount.ts
+++ b/src/shared/utils/normalizeAmount.ts
@@ -1,4 +1,4 @@
-// src/features/planner/services/normalizeAmount.ts
+// src/shared/utils/normalizeAmount.ts
 
 /**
  * Parses a currency string into a numeric value.


### PR DESCRIPTION
## Summary
- move normalizeAmount to shared utils
- update budget imports to use shared normalizeAmount
- refresh docs for normalizeAmount location
- document shared utilities

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6894156908cc832296c9b035a72a4d48