### PR TITLE
✨ Add Wikimedia image fallback for catalog activities

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,3 +35,5 @@ npm start
 ## Catalog API Key
 
 Set the `NEXT_PUBLIC_GEOAPIFY_KEY` environment variable in your hosting platform so the catalog endpoint can request data from Geoapify.
+
+Catalog images are stored as direct links from Geoapify or Wikimedia and are not uploaded to your hosting provider. Ensure outbound access to these domains is permitted.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -9,6 +9,8 @@ Turistar reads environment variables through [`src/shared/lib/env.ts`](../src/sh
 - `NEXT_PUBLIC_GEOAPIFY_KEY` – API key for Geoapify requests.
 - `NODE_ENV` – environment name (defaults to `development`).
 
+The catalog also queries the public Wikimedia API for fallback images. This service requires no API key.
+
 These values configure:
 
 - Supabase clients in [`supabaseClient.ts`](../src/shared/lib/supabaseClient.ts) and [`supabaseServer.ts`](../src/shared/lib/supabaseServer.ts).

--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
       category: a.category,
       description: a.description,
       address: a.address,
-      image_url: a.imageUrl,
+      image_url: a.imageUrl ?? null,
       rating: a.rating,
       latitude: a.latitude,
       longitude: a.longitude,

--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -4,6 +4,7 @@
 
 import type { CatalogActivity, AutocompletePlace } from '@/shared/types';
 import { clientEnv } from './clientEnv';
+import { enrichWithWikimediaImages } from './wikimedia';
 
 /* Types */
 type GeoapifyFeature = {
@@ -117,7 +118,9 @@ export async function fetchGeoapifyCatalog(
   const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) throw new Error(`Geoapify request failed: ${res.status}`);
   const data = (await res.json()) as GeoapifyResponse;
-  const activities = data.features.map((f) => mapGeoapifyFeature(f));
+  const activities = await enrichWithWikimediaImages(
+    data.features.map((f) => mapGeoapifyFeature(f))
+  );
 
   return { activities };
 }
@@ -146,7 +149,9 @@ export async function fetchGeoapifySearch(
   const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) throw new Error(`Geoapify request failed: ${res.status}`);
   const data = (await res.json()) as GeoapifyResponse;
-  const activities = data.features.map((f) => mapGeoapifyFeature(f, text));
+  const activities = await enrichWithWikimediaImages(
+    data.features.map((f) => mapGeoapifyFeature(f, text))
+  );
 
   return { activities };
 }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -8,6 +8,7 @@ export {
   fetchGeoapifyCatalog,
   fetchGeoapifySearch,
 } from './geoapify';
+export { fetchWikimediaImage, enrichWithWikimediaImages } from './wikimedia';
 export { fetchJson } from './http';
 export { supabase } from './supabaseClient';
 export { clientEnv } from './clientEnv';

--- a/src/shared/lib/wikimedia.ts
+++ b/src/shared/lib/wikimedia.ts
@@ -1,0 +1,46 @@
+// src/shared/lib/wikimedia.ts
+// Helpers for retrieving images from the Wikimedia API.
+
+import type { CatalogActivity } from '@/shared/types';
+
+async function fetchWikimediaImage(text: string): Promise<string | undefined> {
+  const params = new URLSearchParams({
+    action: 'query',
+    format: 'json',
+    origin: '*',
+    prop: 'pageimages',
+    generator: 'search',
+    gsrlimit: '1',
+    gsrsearch: text,
+    pithumbsize: '400',
+  });
+
+  try {
+    const res = await fetch(`https://en.wikipedia.org/w/api.php?${params}`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) return undefined;
+    const data = await res.json();
+    const pages = data?.query?.pages;
+    if (!pages) return undefined;
+    const page = pages[Object.keys(pages)[0]];
+    return page?.thumbnail?.source as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function enrichWithWikimediaImages(
+  activities: CatalogActivity[]
+): Promise<CatalogActivity[]> {
+  return Promise.all(
+    activities.map(async (a) => {
+      if (a.imageUrl) return a;
+      const wikiImage =
+        (await fetchWikimediaImage(a.name)) ?? (await fetchWikimediaImage(a.category));
+      return wikiImage ? { ...a, imageUrl: wikiImage } : a;
+    })
+  );
+}
+
+export { fetchWikimediaImage };

--- a/tests/unit/shared/lib/geoapify.test.ts
+++ b/tests/unit/shared/lib/geoapify.test.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 const originalFetch = global.fetch;
 const originalKey = process.env.NEXT_PUBLIC_GEOAPIFY_KEY;
 let fetchGeoapifyAutocomplete: typeof import('@/shared/lib/geoapify').fetchGeoapifyAutocomplete;
+let fetchGeoapifyCatalog: typeof import('@/shared/lib/geoapify').fetchGeoapifyCatalog;
 
 describe('fetchGeoapifyAutocomplete', () => {
   beforeEach(async () => {
@@ -41,5 +42,109 @@ describe('fetchGeoapifyAutocomplete', () => {
       { name: 'Texas, United States', latitude: 5, longitude: 6 },
       { name: 'France', latitude: 7, longitude: 8 },
     ]);
+  });
+});
+
+describe('fetchGeoapifyCatalog images', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = 'test-key';
+    ({ fetchGeoapifyCatalog } = await import('@/shared/lib/geoapify'));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = originalKey;
+  });
+
+  const autoResp = {
+    features: [
+      {
+        properties: { formatted: 'Paris, France', result_type: 'city', lat: 1, lon: 2 },
+      },
+    ],
+  };
+
+  it('uses Geoapify image when provided', async () => {
+    const placesResp = {
+      features: [
+        {
+          properties: {
+            place_id: 1,
+            name: 'Louvre',
+            lat: 1,
+            lon: 2,
+            categories: ['tourism.museum'],
+            image: 'geo.jpg',
+          },
+        },
+      ],
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => autoResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => placesResp });
+
+    const { activities } = await fetchGeoapifyCatalog('paris');
+
+    expect(activities[0].imageUrl).toBe('geo.jpg');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to Wikimedia image', async () => {
+    const placesResp = {
+      features: [
+        {
+          properties: {
+            place_id: 1,
+            name: 'Louvre',
+            lat: 1,
+            lon: 2,
+            categories: ['tourism.museum'],
+          },
+        },
+      ],
+    };
+    const wikiResp = {
+      query: { pages: { a: { thumbnail: { source: 'wiki.jpg' } } } },
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => autoResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => placesResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => wikiResp });
+
+    const { activities } = await fetchGeoapifyCatalog('paris');
+
+    expect(activities[0].imageUrl).toBe('wiki.jpg');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('leaves image undefined when no source provides one', async () => {
+    const placesResp = {
+      features: [
+        {
+          properties: {
+            place_id: 1,
+            name: 'Louvre',
+            lat: 1,
+            lon: 2,
+            categories: ['tourism.museum'],
+          },
+        },
+      ],
+    };
+    const wikiResp = { query: { pages: {} } };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => autoResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => placesResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => wikiResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => wikiResp });
+
+    const { activities } = await fetchGeoapifyCatalog('paris');
+
+    expect(activities[0].imageUrl).toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Summary
- query Wikimedia for images when Geoapify lacks them
- persist external image links in catalog upserts
- document fallback image flow and environment needs
- refactor: move Wikimedia image helper into dedicated module

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6894b04d6f8c832288a54d4eecec2537