### PR TITLE
Use RPC for plan creation transaction

### DIFF
--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -39,6 +39,7 @@ src/app
 - **page.tsx** – Client entry that dynamically loads `PlannerClient` for the planner experience.
 - **PlannerClient.tsx**, **PlannerBoard.tsx**, **MapView.tsx**, **BudgetPanel.tsx** – Route-level wrappers that consume modules from `src/features/planner` and `src/features/budget`.
 - **actions/** – Server actions `createPlan` and `updatePlan` re-exported from `src/server/actions`.
+  `createPlan` calls Supabase RPC `create_full_plan` to set up the plan, destination and days in a single transaction.
 - **[planId]/page.tsx** – Loads an existing plan and passes it to `InspirationPlanner`.
 
 ### inspiration/

--- a/docs/features/home.md
+++ b/docs/features/home.md
@@ -14,7 +14,7 @@ import { WelcomeForm } from '@/features/home';
 - **Props:** none
 - **State:** `range`, `dest`, `coords`, `title`, `error`, `loading`
 - **External hooks:** `useRouter`
-- **Side-effects:** Navigates to `/planner` after server action `createPlan`
+- **Side-effects:** Navigates to `/planner` after server action `createPlan` (Supabase RPC `create_full_plan`)
 - **Accessibility:** Fieldsets with legends, error messaging via `role="alert"`
 - **Interactions:** Users select dates and destination then submit to start planning
 - **Performance notes:** none

--- a/src/server/actions/createPlan.ts
+++ b/src/server/actions/createPlan.ts
@@ -1,9 +1,8 @@
 // src/server/actions/createPlan.ts
 'use server';
 
-import { eachDayOfInterval } from 'date-fns';
+import { performance } from 'node:perf_hooks';
 import { supabaseServer } from '@/shared/lib/supabaseServer';
-import { buildInitialDays } from '@/features/planner/services';
 
 interface DestinationInfo {
   name: string;
@@ -14,63 +13,24 @@ interface DestinationInfo {
 export async function createPlan(title: string, dest: DestinationInfo, start: string, end: string) {
   const supabase = supabaseServer();
 
-  // Get current user
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Insert plan
   const startDate = start.slice(0, 10);
   const endDate = end.slice(0, 10);
-  const { data: plan, error: planError } = await supabase
-    .from('plans')
-    .insert({
-      title,
-      user_id: user?.id ?? null,
-      start_date: startDate,
-      end_date: endDate,
-    })
-    .select('id')
-    .single();
-  if (planError || !plan) throw planError ?? new Error('Failed to create plan');
-  const planId = plan.id;
 
-  // Upsert destination (avoids duplicate‐key errors)
-  const { data: destRow, error: destError } = await supabase
-    .from('destinations')
-    .upsert(
-      {
-        name: dest.name,
-        latitude: dest.latitude,
-        longitude: dest.longitude,
-      },
-      { onConflict: 'name' }
-    )
-    .select('id')
-    .single();
-  if (destError || !destRow) throw destError ?? new Error('Failed to upsert destination');
-  const destId = destRow.id;
+  const totalStart = performance.now();
+  console.time('create_full_plan');
+  const { data: planId, error } = await supabase.rpc('create_full_plan', {
+    _title: title,
+    _dest_name: dest.name,
+    _dest_lat: dest.latitude ?? null,
+    _dest_long: dest.longitude ?? null,
+    _start_date: startDate,
+    _end_date: endDate,
+  });
+  console.timeEnd('create_full_plan');
+  const totalMs = performance.now() - totalStart;
+  console.log(`createPlan RPC total ${totalMs.toFixed(1)}ms`);
 
-  // 4) Link plan → destination
-  const { error: linkError } = await supabase
-    .from('plan_destinations')
-    .insert({ plan_id: planId, destination_id: destId, position: 0 });
-  if (linkError) throw linkError;
-
-  // 5) Build and insert days
-  const tripDays = eachDayOfInterval({ start: new Date(start), end: new Date(end) });
-  const days = buildInitialDays(tripDays);
-
-  if (days.length) {
-    const scaffold = days.map((d, idx) => ({
-      plan_id: planId,
-      date: d.id,
-      position: idx,
-      destination_id: destId,
-    }));
-    const { error: daysError } = await supabase.from('plan_days').insert(scaffold);
-    if (daysError) throw daysError;
-  }
+  if (error || !planId) throw error ?? new Error('Failed to create plan');
 
   return { id: planId };
 }

--- a/supabase/functions/create_full_plan.sql
+++ b/supabase/functions/create_full_plan.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION create_full_plan(
+  _title text,
+  _dest_name text,
+  _dest_lat double precision,
+  _dest_long double precision,
+  _start_date date,
+  _end_date date
+)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_plan_id uuid;
+  v_dest_id uuid;
+BEGIN
+  INSERT INTO plans(title, user_id, start_date, end_date)
+    VALUES (_title, auth.uid(), _start_date, _end_date)
+    RETURNING id INTO v_plan_id;
+
+  INSERT INTO destinations(name, latitude, longitude)
+    VALUES (_dest_name, _dest_lat, _dest_long)
+    ON CONFLICT (name) DO UPDATE
+      SET latitude = EXCLUDED.latitude,
+          longitude = EXCLUDED.longitude
+    RETURNING id INTO v_dest_id;
+
+  INSERT INTO plan_destinations(plan_id, destination_id, position)
+    VALUES (v_plan_id, v_dest_id, 0);
+
+  INSERT INTO plan_days(plan_id, date, position, destination_id)
+  SELECT v_plan_id,
+         gs::date,
+         row_number() OVER () - 1,
+         v_dest_id
+  FROM generate_series(_start_date, _end_date, interval '1 day') AS gs;
+
+  RETURN v_plan_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
- create `create_full_plan` Postgres function to insert plans, destinations, links and days in one transaction
- call Supabase RPC from `createPlan` server action with timing logs
- document new RPC-based flow in routing and home feature docs

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- mock timing run: sequential 202.989ms vs RPC 50.579ms


------
https://chatgpt.com/codex/tasks/task_e_689715d58f0883229ef45439fac7d2eb