### PR TITLE
:sparkles: feat: public sharing model with slug + edit token (no-auth)

### DIFF
--- a/src/app/planner/PlannerClient.tsx
+++ b/src/app/planner/PlannerClient.tsx
@@ -36,6 +36,7 @@ const modeOrder: Mode[] = ['planner', 'map', 'budget'];
 interface PlannerClientProps {
   initialDays?: DayPlan[];
   planId?: string;
+  slug?: string;
   dest?: string;
   title?: string;
   hideOnboarding?: boolean;
@@ -164,6 +165,7 @@ function PlannerClientInner({
 export default function PlannerClient({
   initialDays,
   planId,
+  slug,
   dest,
   title,
   hideOnboarding = false,
@@ -175,9 +177,9 @@ export default function PlannerClient({
 
   useEffect(() => {
     if (search.toString()) {
-      router.replace(`/planner/${planId}`, { scroll: false });
+      router.replace(`/planner/${slug ?? planId}`, { scroll: false });
     }
-  }, [search, router, planId]);
+  }, [search, router, slug, planId]);
 
   return (
     <PlannerProvider initialDays={initialDays} planId={planId ?? ''} dest={dest} persist={persist}>

--- a/src/app/planner/[slug]/page.tsx
+++ b/src/app/planner/[slug]/page.tsx
@@ -1,4 +1,4 @@
-// src/app/planner/[planId]/page.tsx
+// src/app/planner/[slug]/page.tsx
 export const dynamic = 'force-dynamic';
 
 import PlannerClient from '../PlannerClient';
@@ -8,12 +8,12 @@ import { format, parseISO } from 'date-fns';
 import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
 
 type PageProps = {
-  params: Promise<{ planId: string }>;
+  params: Promise<{ slug: string }>;
   searchParams: Promise<{ dest?: string }>;
 };
 
 export default async function PlannerPlanPage({ params, searchParams }: PageProps) {
-  const { planId } = await params;
+  const { slug } = await params;
   const { dest } = await searchParams;
 
   let destination = dest;
@@ -21,24 +21,27 @@ export default async function PlannerPlanPage({ params, searchParams }: PageProp
   let initialDays: DayPlan[] | undefined;
 
   const supabase = await supabaseServer();
-  if (!destination) {
-    const { data, error } = (await supabase
-      .from('plans')
-      .select('title, plan_destinations(destinations(name))')
-      .eq('id', planId)
-      .single()) as unknown as {
-      data: {
-        title: string | null;
-        plan_destinations: { destinations: { name: string } }[] | null;
-      } | null;
-      error: unknown;
-    };
+  const { data: planRow, error: planErr } = (await supabase
+    .from('plans')
+    .select('id, title, plan_destinations(destinations(name))')
+    .eq('public_slug', slug)
+    .eq('is_public', true)
+    .single()) as unknown as {
+    data: {
+      id: string;
+      title: string | null;
+      plan_destinations: { destinations: { name: string } }[] | null;
+    } | null;
+    error: unknown;
+  };
 
-    if (!error && data) {
-      title = data.title ?? undefined;
-      destination = data.plan_destinations?.[0]?.destinations?.name ?? undefined;
-    }
+  if (planErr || !planRow) {
+    return <p className="p-4">Plan not found.</p>;
   }
+
+  const planId = planRow.id;
+  title = planRow.title ?? undefined;
+  destination = destination ?? planRow.plan_destinations?.[0]?.destinations?.name ?? undefined;
 
   const { data: dayRows, error: dayErr } = (await supabase
     .from('plan_days')
@@ -92,6 +95,7 @@ export default async function PlannerPlanPage({ params, searchParams }: PageProp
     <PlannerClient
       initialDays={initialDays}
       planId={planId}
+      slug={slug}
       dest={destination}
       title={title ?? destination}
     />

--- a/src/app/planner/actions/addActivity.ts
+++ b/src/app/planner/actions/addActivity.ts
@@ -1,0 +1,2 @@
+// src/app/planner/actions/addActivity.ts
+export { addActivity } from '@/server/actions/addActivity';

--- a/src/app/planner/actions/updatePlanTitle.ts
+++ b/src/app/planner/actions/updatePlanTitle.ts
@@ -1,0 +1,2 @@
+// src/app/planner/actions/updatePlanTitle.ts
+export { updatePlanTitle } from '@/server/actions/updatePlanTitle';

--- a/src/features/home/components/WelcomeForm.tsx
+++ b/src/features/home/components/WelcomeForm.tsx
@@ -11,6 +11,7 @@ import LoadingScreen from '@/shared/components/LoadingScreen';
 import { useRouter } from 'next/navigation';
 import { addDays } from 'date-fns';
 import { createPlan } from '@/app/planner/actions/createPlan';
+import { saveEditToken } from '@/shared/lib/planEditToken';
 
 export default function WelcomeForm() {
   const router = useRouter();
@@ -63,12 +64,18 @@ export default function WelcomeForm() {
 
     setLoading(true);
     try {
-      const { id: planId } = await createPlan(
+      const {
+        id: planId,
+        publicSlug,
+        editToken,
+      } = await createPlan(
         title || destParam,
         { name: destParam, latitude: coords?.lat, longitude: coords?.lng },
         range.from.toISOString(),
         range.to.toISOString()
       );
+
+      saveEditToken(planId, editToken);
 
       const query = new URLSearchParams({
         dest: destParam,
@@ -80,7 +87,7 @@ export default function WelcomeForm() {
         query.set('lng', String(coords.lng));
       }
       const queryString = query.toString();
-      router.push(`/planner/${planId}?${queryString}`);
+      router.push(`/planner/${publicSlug}?${queryString}`);
     } catch {
       setError('Failed to create plan.');
       setLoading(false);

--- a/src/features/planner/hooks/usePlanTitleSupabase.ts
+++ b/src/features/planner/hooks/usePlanTitleSupabase.ts
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/shared/lib/supabaseClient';
 import { capitalize } from '@/shared/utils';
+import { getEditToken } from '@/shared/lib/planEditToken';
+import { updatePlanTitle } from '@/app/planner/actions/updatePlanTitle';
 
 export function usePlanTitle(planId: string, defaultTitle = '', persist = true) {
   const initialTitle = capitalize(defaultTitle);
@@ -35,11 +37,9 @@ export function usePlanTitle(planId: string, defaultTitle = '', persist = true) 
 
   const mutation = useMutation({
     mutationFn: async (newTitle: string) => {
-      const { error } = (await supabase
-        .from('plans')
-        .update({ title: newTitle })
-        .eq('id', planId)) as unknown as { error: unknown };
-      if (error) throw error;
+      const token = getEditToken(planId);
+      if (!token) throw new Error('Missing edit token');
+      await updatePlanTitle(planId, token, newTitle);
       return newTitle;
     },
     onSuccess: (t) => qc.setQueryData(['plan_title', planId], t),

--- a/src/server/actions/addActivity.ts
+++ b/src/server/actions/addActivity.ts
@@ -1,0 +1,37 @@
+// src/server/actions/addActivity.ts
+'use server';
+
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+
+interface AddActivityInput {
+  dayId: string;
+  editToken: string;
+  title: string;
+  startTime?: string; // "HH:mm:ss"
+  duration?: number;
+  catalogId?: string;
+  budget?: number;
+  imageUrl?: string;
+  color?: string;
+  address?: string;
+  position?: number;
+}
+
+export async function addActivity(input: AddActivityInput) {
+  const supabase = supabaseServer();
+  const { data, error } = await supabase.rpc('add_activity', {
+    _day_id: input.dayId,
+    _edit_token: input.editToken,
+    _title: input.title,
+    _start_time: input.startTime ?? null,
+    _duration: input.duration ?? null,
+    _catalog_id: input.catalogId ?? null,
+    _budget: input.budget ?? null,
+    _image_url: input.imageUrl ?? null,
+    _color: input.color ?? null,
+    _address: input.address ?? null,
+    _position: input.position ?? 0,
+  });
+  if (error) throw error;
+  return data as string; // activity id
+}

--- a/src/server/actions/createPlan.ts
+++ b/src/server/actions/createPlan.ts
@@ -18,7 +18,7 @@ export async function createPlan(title: string, dest: DestinationInfo, start: st
 
   const totalStart = performance.now();
   console.time('create_full_plan');
-  const { data: planId, error } = await supabase.rpc('create_full_plan', {
+  const { data, error } = await supabase.rpc('create_full_plan', {
     _title: title,
     _dest_name: dest.name,
     _dest_lat: dest.latitude ?? null,
@@ -30,7 +30,18 @@ export async function createPlan(title: string, dest: DestinationInfo, start: st
   const totalMs = performance.now() - totalStart;
   console.log(`createPlan RPC total ${totalMs.toFixed(1)}ms`);
 
-  if (error || !planId) throw error ?? new Error('Failed to create plan');
+  if (error || !data) throw error ?? new Error('Failed to create plan');
 
-  return { id: planId };
+  const { plan_id, public_slug, edit_token } = data as {
+    plan_id: string;
+    public_slug: string;
+    edit_token: string;
+  };
+  // Persist the token locally (do not expose it in the URL)
+  try {
+    // On the client, save it in localStorage the first time it's received.
+    // If this action runs on the server, return it to the client for persistence.
+  } catch {}
+
+  return { id: plan_id, publicSlug: public_slug, editToken: edit_token };
 }

--- a/src/server/actions/updatePlanTitle.ts
+++ b/src/server/actions/updatePlanTitle.ts
@@ -1,0 +1,14 @@
+// src/server/actions/updatePlanTitle.ts
+'use server';
+
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+
+export async function updatePlanTitle(planId: string, editToken: string, newTitle: string) {
+  const supabase = supabaseServer();
+  const { error } = await supabase.rpc('update_plan_title', {
+    _plan_id: planId,
+    _edit_token: editToken,
+    _new_title: newTitle,
+  });
+  if (error) throw error;
+}

--- a/src/shared/lib/planEditToken.ts
+++ b/src/shared/lib/planEditToken.ts
@@ -1,0 +1,17 @@
+const KEY = 'plan_edit_tokens'; // map of plan_id -> token
+
+export function saveEditToken(planId: string, token: string) {
+  if (typeof window === 'undefined') return;
+  const raw = window.localStorage.getItem(KEY);
+  const map = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  map[planId] = token;
+  window.localStorage.setItem(KEY, JSON.stringify(map));
+}
+
+export function getEditToken(planId: string): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const raw = window.localStorage.getItem(KEY);
+  if (!raw) return undefined;
+  const map = JSON.parse(raw) as Record<string, string>;
+  return map[planId];
+}

--- a/supabase/migrations/20241010120000_public_share_and_token.sql
+++ b/supabase/migrations/20241010120000_public_share_and_token.sql
@@ -1,0 +1,176 @@
+-- 1) Extension to generate tokens
+create extension if not exists pgcrypto;
+
+-- 2) New columns on plans
+alter table public.plans
+  add column if not exists is_public boolean not null default true,
+  add column if not exists public_slug text not null default translate(encode(gen_random_bytes(9), 'base64'), '/+', '_-'),
+  add column if not exists edit_token uuid not null default gen_random_uuid();
+
+create unique index if not exists idx_plans_public_slug on public.plans(public_slug);
+
+-- 3) RLS ON
+alter table public.plans enable row level security;
+alter table public.plan_days enable row level security;
+alter table public.activities enable row level security;
+alter table public.plan_destinations enable row level security;
+alter table public.catalog enable row level security;
+
+-- 4) Policies (public SELECT and unrestricted INSERT on plans)
+-- plans
+drop policy if exists plans_insert_any on public.plans;
+create policy plans_insert_any
+on public.plans for insert
+to anon
+with check (true);
+
+drop policy if exists plans_select_public on public.plans;
+create policy plans_select_public
+on public.plans for select
+to anon
+using (is_public = true);
+
+-- plan_days
+drop policy if exists plan_days_select_public on public.plan_days;
+create policy plan_days_select_public
+on public.plan_days for select
+to anon
+using (exists (
+  select 1 from public.plans p
+  where p.id = plan_id and p.is_public = true
+));
+
+-- activities
+drop policy if exists activities_select_public on public.activities;
+create policy activities_select_public
+on public.activities for select
+to anon
+using (exists (
+  select 1
+  from public.plan_days d
+  join public.plans p on p.id = d.plan_id
+  where d.id = day_id and p.is_public = true
+));
+
+-- plan_destinations
+drop policy if exists plan_destinations_select_public on public.plan_destinations;
+create policy plan_destinations_select_public
+on public.plan_destinations for select
+to anon
+using (exists (
+  select 1 from public.plans p
+  where p.id = plan_id and p.is_public = true
+));
+
+-- catalog: public read only
+drop policy if exists catalog_select_public on public.catalog;
+create policy catalog_select_public
+on public.catalog for select
+to anon
+using (true);
+
+-- 5) Update create_full_plan to return plan_id, public_slug, edit_token
+create or replace function create_full_plan(
+  _title text,
+  _dest_name text,
+  _dest_lat double precision,
+  _dest_long double precision,
+  _start_date date,
+  _end_date date
+)
+returns table (plan_id uuid, public_slug text, edit_token uuid)
+language plpgsql
+as $$
+declare
+  v_plan_id uuid;
+  v_dest_id uuid;
+  v_slug text;
+  v_token uuid;
+begin
+  if _start_date is null or _end_date is null or _start_date > _end_date then
+    raise exception 'Invalid date range: % .. %', _start_date, _end_date
+      using errcode = '22007';
+  end if;
+
+  insert into public.plans(title, user_id, start_date, end_date)
+  values (_title, null, _start_date, _end_date)
+  returning id, public_slug, edit_token into v_plan_id, v_slug, v_token;
+
+  insert into public.destinations(name, latitude, longitude)
+  values (_dest_name, _dest_lat, _dest_long)
+  on conflict (name) do update
+    set latitude = excluded.latitude,
+        longitude = excluded.longitude
+  returning id into v_dest_id;
+
+  insert into public.plan_destinations(plan_id, destination_id, position)
+  values (v_plan_id, v_dest_id, 0);
+
+  insert into public.plan_days(plan_id, date, position, destination_id)
+  select v_plan_id,
+         gs::date,
+         row_number() over (order by gs) - 1,
+         v_dest_id
+  from generate_series(_start_date, _end_date, interval '1 day') as gs;
+
+  return query select v_plan_id, v_slug, v_token;
+end;
+$$;
+
+-- 6) Editing RPCs protected by edit_token
+-- a) Update plan title
+create or replace function update_plan_title(
+  _plan_id uuid,
+  _edit_token uuid,
+  _new_title text
+) returns void
+language plpgsql
+security definer
+as $$
+begin
+  if not exists (select 1 from public.plans where id = _plan_id and edit_token = _edit_token) then
+    raise exception 'Forbidden' using errcode = '42501';
+  end if;
+
+  update public.plans set title = _new_title where id = _plan_id;
+end;
+$$;
+
+-- b) Add activity to a day
+create or replace function add_activity(
+  _day_id uuid,
+  _edit_token uuid,
+  _title text,
+  _start_time time without time zone,
+  _duration int,
+  _catalog_id text,
+  _budget numeric,
+  _image_url text,
+  _color text,
+  _address text,
+  _position int
+) returns uuid
+language plpgsql
+security definer
+as $$
+declare
+  v_plan_id uuid;
+  v_id uuid;
+begin
+  select d.plan_id into v_plan_id from public.plan_days d where d.id = _day_id;
+
+  if v_plan_id is null
+     or not exists (select 1 from public.plans where id = v_plan_id and edit_token = _edit_token) then
+    raise exception 'Forbidden' using errcode = '42501';
+  end if;
+
+  insert into public.activities(
+    day_id, title, start_time, duration, catalog_id, budget, image_url, color, address, position
+  ) values (
+    _day_id, _title, _start_time, _duration, _catalog_id, _budget, _image_url, _color, _address, _position
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add migration for public sharing with `public_slug`, `edit_token`, and RLS policies (slug now uses base64 with `translate` for URL-safety)
- save edit token locally and expose RPC actions for updating plan and adding activities
- load plans by `public_slug` and return slug/token on plan creation
- translate Portuguese comments to English for consistency
- remove manual SQL verification script in preparation for automated tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689743905adc8322af09c6b607b09790