### PR TITLE
✨ Add Wikimedia pageviews helper

### DIFF
--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -8,7 +8,12 @@ export {
   fetchGeoapifyCatalog,
   fetchGeoapifySearch,
 } from './geoapify';
-export { fetchWikimediaImage, fetchWikimediaSignals, enrichWithWikimediaImages } from './wikimedia';
+export {
+  fetchWikimediaImage,
+  fetchWikimediaSignals,
+  enrichWithWikimediaImages,
+  withPageviews,
+} from './wikimedia';
 export { fetchJson } from './http';
 export { pLimit } from './pLimit';
 export { supabase } from './supabaseClient';

--- a/src/shared/lib/wikimedia.ts
+++ b/src/shared/lib/wikimedia.ts
@@ -150,6 +150,38 @@ function normalizeSignals(
 }
 
 /**
+ * Attach 30-day pageviews from the Wikimedia Pageviews API.
+ * Falls back to 0 when data is unavailable.
+ */
+export async function withPageviews(sig: WikimediaSignals): Promise<WikimediaSignals> {
+  if (!sig.title || !sig.lang) return { ...sig, pageviews30d: 0 };
+
+  const end = new Date();
+  end.setUTCDate(end.getUTCDate() - 1); // yesterday
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 29); // 30 days inclusive
+
+  const fmt = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, '');
+  const title = encodeURIComponent(sig.title.replace(/ /g, '_'));
+  const url = `https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/${sig.lang}.wikipedia/all-access/all-agents/${title}/daily/${fmt(start)}/${fmt(end)}`;
+
+  try {
+    const res = await fetch(url, {
+      cache: 'force-cache',
+      next: { revalidate: REVALIDATE_6H },
+    });
+    if (!res.ok) throw new Error('Pageviews fetch failed');
+    const data = await res.json();
+    const views = Array.isArray(data?.items)
+      ? data.items.reduce((sum: number, item: { views?: number }) => sum + (item.views ?? 0), 0)
+      : 0;
+    return { ...sig, pageviews30d: views };
+  } catch {
+    return { ...sig, pageviews30d: 0 };
+  }
+}
+
+/**
  * Main API to resolve Wikimedia signals.
  * - Parallelizes geosearch (if coordinates), title and search.
  * - Returns the first result with an image; otherwise the first fulfilled result.
@@ -200,7 +232,7 @@ export async function fetchWikimediaSignals(input: {
     /* noop */
   }
 
-  return chosen;
+  return chosen ? await withPageviews(chosen) : undefined;
 }
 
 /**

--- a/tests/unit/shared/lib/wikimedia.test.ts
+++ b/tests/unit/shared/lib/wikimedia.test.ts
@@ -16,11 +16,12 @@ describe('fetchWikimediaImage', () => {
 
   it('returns image for exact title match', async () => {
     const titleResp = {
-      query: { pages: { 1: { thumbnail: { source: 'exact.jpg' } } } },
+      query: { pages: { 1: { title: 'Eiffel Tower', thumbnail: { source: 'exact.jpg' } } } },
     };
     const searchResp = {
-      query: { pages: { 2: { thumbnail: { source: 'search.jpg' } } } },
+      query: { pages: { 2: { title: 'Eiffel Tower', thumbnail: { source: 'search.jpg' } } } },
     };
+    const pageviewsResp = { items: [{ views: 42 }] };
     global.fetch = vi
       .fn()
       .mockResolvedValueOnce({
@@ -30,12 +31,16 @@ describe('fetchWikimediaImage', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => searchResp,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => pageviewsResp,
       } as unknown as Response);
 
     const url = await fetchWikimediaImage('Eiffel Tower');
 
     expect(url).toBe('exact.jpg');
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
     const fetchMock = global.fetch as unknown as Mock;
     const [firstUrl, secondUrl] = fetchMock.mock.calls.map((c) => c[0] as string);
     expect(firstUrl).toContain('titles=Eiffel+Tower');
@@ -44,16 +49,22 @@ describe('fetchWikimediaImage', () => {
 
   it('falls back to search when title has no image', async () => {
     const missingResp = { query: { pages: { '-1': { missing: true } } } };
-    const wikiResp = { query: { pages: { a: { thumbnail: { source: 'search.jpg' } } } } };
+    const wikiResp = {
+      query: { pages: { a: { title: 'Some Place', thumbnail: { source: 'search.jpg' } } } },
+    };
     global.fetch = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => missingResp } as unknown as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => wikiResp } as unknown as Response);
+      .mockResolvedValueOnce({ ok: true, json: async () => wikiResp } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      } as unknown as Response);
 
     const url = await fetchWikimediaImage('Some Place');
 
     expect(url).toBe('search.jpg');
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
     const fetchMock = global.fetch as unknown as Mock;
     const [firstUrl, secondUrl] = fetchMock.mock.calls.map((c) => c[0] as string);
     expect(firstUrl).toContain('titles=Some+Place');


### PR DESCRIPTION
## Summary
- add `withPageviews` helper to fetch 30-day Wikimedia pageviews with caching
- include pageviews in `fetchWikimediaSignals` results with safe fallback
- export helper and adjust tests for pageview lookups

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689909e3e2a483229ce24dd43e2baf06