### PR TITLE
Add catalog ranking utility

### DIFF
--- a/src/features/planner/components/catalog/DestinationFilterPanel.tsx
+++ b/src/features/planner/components/catalog/DestinationFilterPanel.tsx
@@ -8,6 +8,7 @@ import type { CatalogActivity } from '@/shared/types';
 import { useDestinationCatalog, useActivitiesById, usePlannerContext } from '@/features/planner';
 import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
+import { computeCatalogScore } from '@/shared/lib';
 
 interface DestinationFilterPanelProps {
   isOpen: boolean;
@@ -25,6 +26,7 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
   const addedIds = useMemo(() => new Set<string>(Object.keys(activitiesById)), [activitiesById]);
   const [selectedCats, setSelectedCats] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<'name' | 'score'>('score');
   const { activities, categories, loading, error } = useDestinationCatalog(isOpen, planId, dest);
 
   const toggleCat = (cat: string) =>
@@ -42,9 +44,16 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
         (!selectedCats.size || selectedCats.has(it.category)) &&
         it.name.toLowerCase().includes(searchLower)
     );
-    items = items.sort((a, b) => a.name.localeCompare(b.name));
+    if (sort === 'name') {
+      items = items.sort((a, b) => a.name.localeCompare(b.name));
+    } else {
+      items = items
+        .map((it) => ({ it, score: computeCatalogScore(it, it.wiki, { lat: 0, lon: 0 }) }))
+        .sort((a, b) => b.score - a.score)
+        .map((r) => r.it);
+    }
     return items;
-  }, [activities, search, selectedCats]);
+  }, [activities, search, selectedCats, sort]);
 
   useEscapeKey({ onClose, isActive: isOpen });
   // Preserve scroll position so the list doesn't jump after adding/removing
@@ -106,7 +115,14 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
           placeholder="Search"
           className="w-48 rounded border px-2 py-1 text-sm"
         />
-        {/* Sorting removed; default alphabetical order */}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as 'name' | 'score')}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          <option value="score">Top</option>
+          <option value="name">Name</option>
+        </select>
       </div>
 
       <div ref={scrollRef} className="flex flex-1 overflow-auto">

--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
             title: p.name,
             lat: p.latitude,
             lon: p.longitude,
-            lang: 'pt',
+            lang: 'en',
           });
 
           // Persist Wikimedia data; failures are logged but ignored

--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -129,7 +129,7 @@ export async function fetchGeoapifyCatalog(
     }` +
     `&filter=circle:${longitude},${latitude},${DEFAULT_RADIUS_METERS}` +
     `&bias=proximity:${longitude},${latitude}` +
-    `&limit=${CATALOG_LIMIT}&lang=pt&apiKey=${key}`;
+    `&limit=${CATALOG_LIMIT}&lang=en&apiKey=${key}`;
 
   const res = await fetch(url, {
     cache: 'force-cache',
@@ -162,7 +162,7 @@ export async function fetchGeoapifySearch(
     `&categories=${encodeURIComponent(DEFAULT_CATEGORIES)}` +
     `&filter=circle:${lon},${lat},${DEFAULT_RADIUS_METERS}` +
     `&bias=proximity:${lon},${lat}` +
-    `&limit=10&lang=pt&apiKey=${key}`;
+    `&limit=10&lang=en&apiKey=${key}`;
 
   const res = await fetch(url, {
     cache: 'force-cache',

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -14,6 +14,7 @@ export {
   enrichWithWikimediaImages,
   withPageviews,
 } from './wikimedia';
+export { computeCatalogScore } from './ranking';
 export { fetchJson } from './http';
 export { pLimit } from './pLimit';
 export { supabase } from './supabaseClient';

--- a/src/shared/lib/ranking.ts
+++ b/src/shared/lib/ranking.ts
@@ -1,0 +1,76 @@
+// src/shared/lib/ranking.ts
+
+import type { CatalogActivity } from '@/shared/types';
+import type { WikimediaSignals } from './wikimedia';
+
+/** 90th percentile of 30 day Wikipedia page views used for normalization. */
+export const PV_P90 = 40000;
+
+/** Categories that are considered essential and get a small boost. */
+export const WIKI_ESSENTIAL_CATS = [
+  'tourism.attraction',
+  'tourism.sights',
+  'entertainment.museum',
+  'entertainment.culture.gallery',
+  'natural.protected_area',
+];
+
+/** Extra boost added when a place matches an essential category. */
+export const SUBCLASS_BOOST = 0.1;
+
+export function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+export function norm(value: number, max: number): number {
+  return max > 0 ? clamp01(value / max) : 0;
+}
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371e3; // metres
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+/**
+ * Computes a catalog score for a place mixing popularity, distance and category boosts.
+ * The resulting score is clamped between 0 and 1.
+ */
+export function computeCatalogScore(
+  place: CatalogActivity,
+  wiki: WikimediaSignals | undefined,
+  center: { lat: number; lon: number }
+): number {
+  // Popularity score from Wikipedia pageviews.
+  const pvScore = norm(wiki?.pageviews30d ?? 0, PV_P90);
+
+  // Distance score: closer places rank higher. Distances beyond 50km have no impact.
+  const meta = place.metadata as { distance?: number; categories?: string[] } | undefined;
+  const distance =
+    typeof meta?.distance === 'number'
+      ? meta.distance
+      : place.latitude != null && place.longitude != null
+        ? haversine(place.latitude, place.longitude, center.lat, center.lon)
+        : 0;
+  const distScore = 1 - norm(distance, 50_000);
+
+  // Optional rank score coming from Wikimedia.
+  const rankScore = clamp01(wiki?.rankScore ?? 0);
+
+  // Base weighted combination.
+  let score = pvScore * 0.6 + distScore * 0.3 + rankScore * 0.1;
+
+  // Boost if the place belongs to an essential category.
+  const categories = (meta?.categories ?? []).concat(place.category ? [place.category] : []);
+  if (categories.some((c) => WIKI_ESSENTIAL_CATS.includes(c))) {
+    score += SUBCLASS_BOOST;
+  }
+
+  return clamp01(score);
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,5 +1,7 @@
 // src/shared/types/index.ts
 
+import type { WikimediaSignals } from '@/shared/lib/wikimedia';
+
 /**
  * A single activity/item in the catalog.
  */
@@ -31,6 +33,7 @@ export interface CatalogActivity {
   latitude?: number;
   longitude?: number;
   metadata?: Record<string, unknown>;
+  wiki?: WikimediaSignals;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add ranking helpers to score catalog places using popularity, distance and category boosts
- export computeCatalogScore from shared lib
- restore catalog sorting UI and switch catalog language defaults to English

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68990c945c64832298abf06814b9dd47