### PR TITLE
✅ Add catalog and Wikimedia unit tests

### DIFF
--- a/tests/integration/api/catalog.spec.ts
+++ b/tests/integration/api/catalog.spec.ts
@@ -1,0 +1,45 @@
+// tests/integration/api/catalog.spec.ts
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { NextRequest } from 'next/server.js';
+import { GET } from '@/server/api/catalog/route';
+
+vi.mock('@/shared/lib/geoapify', () => ({
+  fetchGeoapifyCatalog: vi.fn().mockResolvedValue({
+    activities: [
+      { id: '1', name: 'A', latitude: 0, longitude: 0 },
+      { id: '2', name: 'B', latitude: 0, longitude: 0 },
+      { id: '3', name: 'C', latitude: 0, longitude: 0 },
+    ],
+  }),
+}));
+
+vi.mock('@/shared/lib/wikimedia', () => ({
+  fetchWikimediaSignals: vi.fn().mockResolvedValue(undefined),
+}));
+
+const scores: Record<string, number> = { '1': 0.2, '2': 0.9, '3': 0.5 };
+vi.mock('@/shared/lib', () => ({
+  computeCatalogScore: (p: { id: string }) => scores[p.id],
+}));
+
+vi.mock('@/server/repos/catalog.persist', () => ({
+  persistWikimediaEnrichment: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('GET /api/catalog', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = 'key';
+    process.env.NEXT_PUBLIC_WIKIMEDIA_ENRICHMENT = 'true';
+  });
+
+  it('returns sorted activities and cache headers', async () => {
+    const req = new NextRequest('http://localhost/api/catalog?dest=test');
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.activities.map((a: { id: string }) => a.id)).toEqual(['2', '3', '1']);
+    const cacheControl = res.headers.get('cache-control');
+    expect(cacheControl).toBeNull();
+  });
+});

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -1,0 +1,75 @@
+// tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+import { vi, type Mock } from 'vitest';
+import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+describe('fetchWikimediaSignals', () => {
+  it('prioritizes geosearch over title and search', async () => {
+    const geoResp = {
+      query: {
+        pages: {
+          1: { pageid: 1, title: 'Geo', thumbnail: { source: 'geo.jpg' } },
+        },
+      },
+    };
+    const titleResp = {
+      query: {
+        pages: {
+          2: { pageid: 2, title: 'Title', thumbnail: { source: 'title.jpg' } },
+        },
+      },
+    };
+    const searchResp = {
+      query: {
+        pages: {
+          3: { pageid: 3, title: 'Search', thumbnail: { source: 'search.jpg' } },
+        },
+      },
+    };
+    const pageviewsResp = { items: [{ views: 10 }] };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => geoResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => titleResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => searchResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => pageviewsResp } as unknown as Response);
+
+    const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2 });
+
+    expect(sig).toMatchObject({ source: 'geosearch', imageUrl: 'geo.jpg', pageviews30d: 10 });
+    const calls = (global.fetch as unknown as Mock).mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain('generator=geosearch');
+    expect(calls[1]).toContain('titles=Foo');
+    expect(calls[2]).toContain('gsrsearch=Foo');
+  });
+
+  it('falls back to title then search and sets pageviews to 0 on failure', async () => {
+    const geoResp = { query: { pages: { 1: { pageid: 1, title: 'Geo' } } } };
+    const titleResp = { query: { pages: { 2: { pageid: 2, title: 'Title' } } } };
+    const searchResp = {
+      query: {
+        pages: {
+          3: { pageid: 3, title: 'Search', thumbnail: { source: 'search.jpg' } },
+        },
+      },
+    };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => geoResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => titleResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => searchResp } as unknown as Response)
+      .mockRejectedValueOnce(new Error('pv fail'));
+
+    const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2 });
+
+    expect(sig).toMatchObject({ source: 'search', imageUrl: 'search.jpg', pageviews30d: 0 });
+  });
+});

--- a/tests/unit/shared/lib/ranking.test.ts
+++ b/tests/unit/shared/lib/ranking.test.ts
@@ -1,0 +1,33 @@
+// tests/unit/shared/lib/ranking.test.ts
+import { computeCatalogScore, PV_P90 } from '@/shared/lib/ranking';
+import type { CatalogActivity } from '@/shared/types';
+
+describe('computeCatalogScore', () => {
+  it('combines weighted components and subclass boost', () => {
+    const place: CatalogActivity = {
+      id: '1',
+      name: 'Place',
+      category: 'tourism.attraction',
+      latitude: 0,
+      longitude: 0,
+      metadata: { distance: 5000 },
+    } as unknown as CatalogActivity;
+    const wiki = { pageviews30d: PV_P90 / 2, rankScore: 0.8 };
+    const score = computeCatalogScore(place, wiki, { lat: 0, lon: 0 });
+    expect(score).toBeCloseTo(0.85, 5);
+  });
+
+  it('normalizes inputs and clamps final score', () => {
+    const place: CatalogActivity = {
+      id: '1',
+      name: 'Place',
+      category: 'tourism.attraction',
+      latitude: 0,
+      longitude: 0,
+      metadata: { distance: 0 },
+    } as unknown as CatalogActivity;
+    const wiki = { pageviews30d: PV_P90 * 10, rankScore: 10 };
+    const score = computeCatalogScore(place, wiki, { lat: 0, lon: 0 });
+    expect(score).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- test Wikimedia signals for geosearch priority, fallbacks and pageview errors
- verify catalog scoring weights and normalization
- add `/api/catalog` integration test with sorted results and cache header check

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6899224520248322ae59c8ae3d3c7224