### PR TITLE
⚙️ Add admin route to refresh Wikimedia pageviews

### DIFF
--- a/src/app/api/admin/refresh-pageviews/route.ts
+++ b/src/app/api/admin/refresh-pageviews/route.ts
@@ -1,0 +1,2 @@
+// src/app/api/admin/refresh-pageviews/route.ts
+export { GET } from '@/server/api/admin/refresh-pageviews/route';

--- a/src/server/api/admin/refresh-pageviews/route.ts
+++ b/src/server/api/admin/refresh-pageviews/route.ts
@@ -1,0 +1,61 @@
+// src/server/api/admin/refresh-pageviews/route.ts
+
+import { NextResponse } from 'next/server';
+import { pLimit } from '@/shared/lib/pLimit';
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
+import { persistWikimediaEnrichment } from '@/server/repos/catalog.persist';
+
+/**
+ * Cron/admin route that refreshes Wikimedia pageviews when data is stale.
+ * Re-fetches signals for catalog items whose `wikimedia_fetched_at` exceeds 7 days.
+ */
+export async function GET() {
+  const supabase = supabaseServer();
+  const cutoff = new Date();
+  cutoff.setUTCDate(cutoff.getUTCDate() - 7);
+
+  const { data, error } = await supabase
+    .from('catalog')
+    .select('id, name, latitude, longitude, rank_score, wikimedia_fetched_at')
+    .or(`wikimedia_fetched_at.is.null,wikimedia_fetched_at.lt.${cutoff.toISOString()}`)
+    .limit(50);
+
+  if (error) {
+    console.error('refresh-pageviews select error', error);
+    return NextResponse.json({ updated: 0 }, { status: 500 });
+  }
+
+  const limit = pLimit(4);
+  let updated = 0;
+
+  type Row = {
+    id: string;
+    name: string;
+    latitude: number;
+    longitude: number;
+    rank_score: number | null;
+  };
+
+  await Promise.all(
+    ((data as Row[] | null) ?? []).map((row) =>
+      limit(async () => {
+        const wiki = await fetchWikimediaSignals({
+          title: row.name,
+          lat: row.latitude,
+          lon: row.longitude,
+          lang: 'en',
+        });
+        if (wiki) {
+          await persistWikimediaEnrichment({
+            catalogId: row.id,
+            wiki: { ...wiki, rankScore: row.rank_score ?? undefined },
+          });
+          updated += 1;
+        }
+      })
+    )
+  );
+
+  return NextResponse.json({ updated });
+}

--- a/tests/integration/api/refresh-pageviews.spec.ts
+++ b/tests/integration/api/refresh-pageviews.spec.ts
@@ -1,0 +1,48 @@
+// tests/integration/api/refresh-pageviews.spec.ts
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { GET } from '@/server/api/admin/refresh-pageviews/route';
+
+const rows = [
+  { id: '1', name: 'A', latitude: 0, longitude: 0, rank_score: 0.5 },
+  { id: '2', name: 'B', latitude: 1, longitude: 1, rank_score: null },
+];
+
+vi.mock('@/shared/lib/supabaseServer', () => ({
+  supabaseServer: vi.fn(() => ({
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  })),
+}));
+
+vi.mock('@/shared/lib/wikimedia', () => ({
+  fetchWikimediaSignals: vi.fn().mockResolvedValue({
+    title: 'X',
+    lang: 'en',
+    pageid: 1,
+    source: 'search',
+    pageviews30d: 10,
+  }),
+}));
+
+const { persistSpy } = vi.hoisted(() => ({
+  persistSpy: vi.fn(),
+}));
+vi.mock('@/server/repos/catalog.persist', () => ({
+  persistWikimediaEnrichment: persistSpy,
+}));
+
+describe('GET /api/admin/refresh-pageviews', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+  });
+
+  it('updates stale entries', async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.updated).toBe(2);
+    expect(persistSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add admin endpoint to refresh Wikimedia pageviews when data is older than a week
- test admin refresh endpoint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6899257f7e6c83229ee7a9390c276b91