### PR TITLE
✨ Add debug score option to catalog API

### DIFF
--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -17,6 +17,7 @@ export async function GET(req: NextRequest) {
   const dest = searchParams.get('dest');
   const latParam = searchParams.get('lat');
   const lonParam = searchParams.get('lon');
+  const debug = searchParams.get('debug') === 'true';
 
   if (!dest && !(latParam && lonParam)) {
     return NextResponse.json({ error: 'Missing dest or lat/lon' }, { status: 400 });
@@ -47,7 +48,10 @@ export async function GET(req: NextRequest) {
           });
 
           // Compute score combining popularity, distance and category boosts.
-          const score = computeCatalogScore(p, wiki, center);
+          const scoreResult = debug
+            ? computeCatalogScore(p, wiki, center, { debug: true })
+            : computeCatalogScore(p, wiki, center);
+          const score = typeof scoreResult === 'number' ? scoreResult : scoreResult.value;
 
           // Persist Wikimedia data with rank score; failures are logged but ignored.
           await persistWikimediaEnrichment({
@@ -55,7 +59,21 @@ export async function GET(req: NextRequest) {
             wiki: wiki ? { ...wiki, rankScore: score } : { rankScore: score },
           });
 
-          return { ...p, wiki, score };
+          return {
+            ...p,
+            wiki,
+            score,
+            ...(typeof scoreResult === 'number'
+              ? {}
+              : {
+                  debugScore: {
+                    pvScore: scoreResult.pvScore,
+                    distScore: scoreResult.distScore,
+                    rankScore: scoreResult.rankScore,
+                    boost: scoreResult.boost,
+                  },
+                }),
+          };
         })
       )
     );

--- a/src/shared/lib/ranking.ts
+++ b/src/shared/lib/ranking.ts
@@ -43,7 +43,33 @@ export function computeCatalogScore(
   place: CatalogActivity,
   wiki: WikimediaSignals | undefined,
   center: { lat: number; lon: number }
-): number {
+): number;
+export function computeCatalogScore(
+  place: CatalogActivity,
+  wiki: WikimediaSignals | undefined,
+  center: { lat: number; lon: number },
+  opts: { debug: true }
+): {
+  value: number;
+  pvScore: number;
+  distScore: number;
+  rankScore: number;
+  boost: number;
+};
+export function computeCatalogScore(
+  place: CatalogActivity,
+  wiki: WikimediaSignals | undefined,
+  center: { lat: number; lon: number },
+  opts?: { debug?: boolean }
+):
+  | number
+  | {
+      value: number;
+      pvScore: number;
+      distScore: number;
+      rankScore: number;
+      boost: number;
+    } {
   // Popularity score from Wikipedia pageviews.
   const pvScore = norm(wiki?.pageviews30d ?? 0, PV_P90);
 
@@ -68,5 +94,11 @@ export function computeCatalogScore(
   const boost = categories.reduce((max, c) => Math.max(max, SUBCLASS_BOOST[c] ?? 0), 0);
   score += boost;
 
-  return clamp01(score);
+  const value = clamp01(score);
+
+  if (opts?.debug) {
+    return { value, pvScore, distScore, rankScore, boost };
+  }
+
+  return value;
 }

--- a/tests/integration/api/catalog.spec.ts
+++ b/tests/integration/api/catalog.spec.ts
@@ -19,7 +19,21 @@ vi.mock('@/shared/lib/wikimedia', () => ({
 
 const scores: Record<string, number> = { '1': 0.2, '2': 0.9, '3': 0.5 };
 vi.mock('@/shared/lib', () => ({
-  computeCatalogScore: (p: { id: string }) => scores[p.id],
+  computeCatalogScore: (
+    p: { id: string },
+    _wiki: unknown,
+    _center: unknown,
+    opts?: { debug?: boolean }
+  ) =>
+    opts?.debug
+      ? {
+          value: scores[p.id],
+          pvScore: 0.1,
+          distScore: 0.2,
+          rankScore: 0.3,
+          boost: 0.4,
+        }
+      : scores[p.id],
 }));
 
 vi.mock('@/server/repos/catalog.persist', () => ({
@@ -41,5 +55,19 @@ describe('GET /api/catalog', () => {
     expect(data.activities.map((a: { id: string }) => a.id)).toEqual(['2', '3', '1']);
     const cacheControl = res.headers.get('cache-control');
     expect(cacheControl).toBeNull();
+  });
+
+  it('returns debug scores when requested', async () => {
+    const req = new NextRequest('http://localhost/api/catalog?dest=test&debug=true');
+    const res = await GET(req);
+    const data = await res.json();
+    for (const a of data.activities) {
+      expect(a.debugScore).toEqual({
+        pvScore: 0.1,
+        distScore: 0.2,
+        rankScore: 0.3,
+        boost: 0.4,
+      });
+    }
   });
 });

--- a/tests/unit/shared/lib/ranking.test.ts
+++ b/tests/unit/shared/lib/ranking.test.ts
@@ -30,4 +30,24 @@ describe('computeCatalogScore', () => {
     const score = computeCatalogScore(place, wiki, { lat: 0, lon: 0 });
     expect(score).toBe(1);
   });
+
+  it('returns debug components when requested', () => {
+    const place: CatalogActivity = {
+      id: '1',
+      name: 'Place',
+      category: 'tourism.attraction',
+      latitude: 0,
+      longitude: 0,
+      metadata: { distance: 0 },
+    } as unknown as CatalogActivity;
+    const wiki = { pageviews30d: PV_P90, rankScore: 0.5 };
+    const result = computeCatalogScore(place, wiki, { lat: 0, lon: 0 }, { debug: true });
+    expect(result).toMatchObject({
+      value: expect.any(Number),
+      pvScore: expect.any(Number),
+      distScore: expect.any(Number),
+      rankScore: expect.any(Number),
+      boost: expect.any(Number),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow `computeCatalogScore` to return component scores when debug mode is enabled
- expose `debugScore` in catalog API when `debug=true`
- cover debug score output with unit and integration tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689928283df083229b227b60d7593f6d