### PR TITLE
🐛 Persist catalog enrichment with upsert

### DIFF
--- a/src/server/api/admin/refresh-pageviews/route.ts
+++ b/src/server/api/admin/refresh-pageviews/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
 
   const { data, error } = await supabase
     .from('catalog')
-    .select('id, name, latitude, longitude, rank_score, wikimedia_fetched_at')
+    .select('id, name, category, latitude, longitude, rank_score, wikimedia_fetched_at')
     .or(`wikimedia_fetched_at.is.null,wikimedia_fetched_at.lt.${cutoff.toISOString()}`)
     .limit(50);
 
@@ -32,6 +32,7 @@ export async function GET() {
   type Row = {
     id: string;
     name: string;
+    category: string;
     latitude: number;
     longitude: number;
     rank_score: number | null;
@@ -48,7 +49,13 @@ export async function GET() {
         });
         if (wiki) {
           await persistWikimediaEnrichment({
-            catalogId: row.id,
+            item: {
+              id: row.id,
+              name: row.name,
+              category: row.category,
+              latitude: row.latitude,
+              longitude: row.longitude,
+            },
             wiki: { ...wiki, rankScore: row.rank_score ?? undefined },
           });
           updated += 1;

--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -55,7 +55,13 @@ export async function GET(req: NextRequest) {
 
           // Persist Wikimedia data with rank score; failures are logged but ignored.
           await persistWikimediaEnrichment({
-            catalogId: p.id,
+            item: {
+              id: p.id,
+              name: p.name,
+              category: p.category,
+              latitude: p.latitude,
+              longitude: p.longitude,
+            },
             wiki: wiki ? { ...wiki, rankScore: score } : { rankScore: score },
           });
 

--- a/src/server/repos/catalog.persist.ts
+++ b/src/server/repos/catalog.persist.ts
@@ -1,6 +1,7 @@
 // src/server/repos/catalog.persist.ts
 
 import { supabaseServer } from '@/shared/lib/supabaseServer';
+import type { CatalogActivity } from '@/shared/types';
 import type { WikimediaSignals } from '@/shared/lib/wikimedia';
 
 /**
@@ -8,34 +9,45 @@ import type { WikimediaSignals } from '@/shared/lib/wikimedia';
  * Errors are logged but do not throw to keep API responses reliable.
  */
 export async function persistWikimediaEnrichment(params: {
-  catalogId: string;
+  item: Pick<CatalogActivity, 'id' | 'name' | 'category' | 'latitude' | 'longitude'>;
   wiki: WikimediaSignals | undefined;
 }) {
-  if (!params?.wiki || !params.catalogId) return;
+  if (!params?.wiki || !params.item?.id) return;
 
   const { title, imageUrl, description, wikidataQid, source, pageid, pageviews30d, rankScore } =
     params.wiki;
+  const { id, name, category, latitude, longitude } = params.item;
 
   const supabase = supabaseServer(); // TODO: consider service role for RLS bypass
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('catalog')
-    .update({
-      wikidata_qid: wikidataQid ?? null,
-      wikimedia_title: title ?? null,
-      wikimedia_source: source ?? null,
-      image_url: imageUrl ?? null,
-      description: description ?? null,
-      wikimedia_pageid: pageid != null ? String(pageid) : null,
-      pageviews_30d: pageviews30d ?? null,
-      rank_score: rankScore ?? null,
-      wikimedia_fetched_at: new Date().toISOString(),
-      // image_confidence: left null for future "confidence gate" work
-    })
-    .eq('id', params.catalogId);
+    .upsert(
+      {
+        id,
+        name,
+        category,
+        latitude,
+        longitude,
+        wikidata_qid: wikidataQid ?? null,
+        wikimedia_title: title ?? null,
+        wikimedia_source: source ?? null,
+        image_url: imageUrl ?? null,
+        description: description ?? null,
+        wikimedia_pageid: pageid != null ? String(pageid) : null,
+        pageviews_30d: pageviews30d ?? null,
+        rank_score: rankScore ?? null,
+        wikimedia_fetched_at: new Date().toISOString(),
+        // image_confidence: left null for future "confidence gate" work
+      },
+      { onConflict: 'id' }
+    )
+    .select('id');
 
   if (error) {
     // Fail silently; enrichment persistence should not break catalog reads
     console.warn('persistWikimediaEnrichment error', error);
+  } else if (!data?.length) {
+    console.warn('persistWikimediaEnrichment affected 0 rows');
   }
 }

--- a/tests/integration/api/catalog.spec.ts
+++ b/tests/integration/api/catalog.spec.ts
@@ -6,9 +6,9 @@ import { GET } from '@/server/api/catalog/route';
 vi.mock('@/shared/lib/geoapify', () => ({
   fetchGeoapifyCatalog: vi.fn().mockResolvedValue({
     activities: [
-      { id: '1', name: 'A', latitude: 0, longitude: 0 },
-      { id: '2', name: 'B', latitude: 0, longitude: 0 },
-      { id: '3', name: 'C', latitude: 0, longitude: 0 },
+      { id: '1', name: 'A', category: 'sight', latitude: 0, longitude: 0 },
+      { id: '2', name: 'B', category: 'sight', latitude: 0, longitude: 0 },
+      { id: '3', name: 'C', category: 'sight', latitude: 0, longitude: 0 },
     ],
   }),
 }));

--- a/tests/integration/api/refresh-pageviews.spec.ts
+++ b/tests/integration/api/refresh-pageviews.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it, beforeAll, vi } from 'vitest';
 import { GET } from '@/server/api/admin/refresh-pageviews/route';
 
 const rows = [
-  { id: '1', name: 'A', latitude: 0, longitude: 0, rank_score: 0.5 },
-  { id: '2', name: 'B', latitude: 1, longitude: 1, rank_score: null },
+  { id: '1', name: 'A', category: 'sight', latitude: 0, longitude: 0, rank_score: 0.5 },
+  { id: '2', name: 'B', category: 'sight', latitude: 1, longitude: 1, rank_score: null },
 ];
 
 vi.mock('@/shared/lib/supabaseServer', () => ({


### PR DESCRIPTION
## Summary
- use upsert and basic item fields when persisting catalog enrichment
- update API routes and tests for new persistence shape
- warn if no rows affected during enrichment persistence

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68992ca5a0b883229dc343593b25e541