### PR TITLE
🌐 Add language support for Geoapify and Wikimedia requests

### DIFF
--- a/src/server/api/admin/refresh-pageviews/route.ts
+++ b/src/server/api/admin/refresh-pageviews/route.ts
@@ -1,6 +1,6 @@
 // src/server/api/admin/refresh-pageviews/route.ts
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { pLimit } from '@/shared/lib/pLimit';
 import { supabaseServer } from '@/shared/lib/supabaseServer';
 import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
@@ -10,7 +10,9 @@ import { persistWikimediaEnrichment } from '@/server/repos/catalog.persist';
  * Cron/admin route that refreshes Wikimedia pageviews when data is stale.
  * Re-fetches signals for catalog items whose `wikimedia_fetched_at` exceeds 7 days.
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const lang = searchParams.get('lang') ?? 'en';
   const supabase = supabaseServer();
   const cutoff = new Date();
   cutoff.setUTCDate(cutoff.getUTCDate() - 7);
@@ -49,7 +51,7 @@ export async function GET() {
           title: row.name,
           lat: row.latitude,
           lon: row.longitude,
-          lang: 'en',
+          lang,
         });
         if (wiki) {
           await persistWikimediaEnrichment({

--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -19,6 +19,7 @@ export async function GET(req: NextRequest) {
   const latParam = searchParams.get('lat');
   const lonParam = searchParams.get('lon');
   const debug = searchParams.get('debug') === 'true';
+  const lang = searchParams.get('lang') ?? 'en';
 
   if (!dest && !(latParam && lonParam)) {
     return NextResponse.json({ error: 'Missing dest or lat/lon' }, { status: 400 });
@@ -33,10 +34,9 @@ export async function GET(req: NextRequest) {
     if (dest) {
       try {
         const sb = supabaseService();
-        const { data: existing, error: lookupErr } = (await (sb
-          .from('destinations')
-          .select('id')
-          .eq('name', dest) as any).maybeSingle()) as {
+        const { data: existing, error: lookupErr } = (await (
+          sb.from('destinations').select('id').eq('name', dest) as any
+        ).maybeSingle()) as {
           data: { id: string } | null;
           error: unknown;
         };
@@ -45,10 +45,9 @@ export async function GET(req: NextRequest) {
         } else if (existing?.id) {
           destinationId = existing.id;
         } else {
-          const { data: inserted, error: insertErr } = (await (sb
-            .from('destinations')
-            .insert({ name: dest })
-            .select('id') as any).single()) as {
+          const { data: inserted, error: insertErr } = (await (
+            sb.from('destinations').insert({ name: dest }).select('id') as any
+          ).single()) as {
             data: { id: string } | null;
             error: unknown;
           };
@@ -63,7 +62,7 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const { activities } = await fetchGeoapifyCatalog(dest ?? '', lat, lon);
+    const { activities } = await fetchGeoapifyCatalog(dest ?? '', lat, lon, undefined, lang);
 
     if (!clientEnv.NEXT_PUBLIC_WIKIMEDIA_ENRICHMENT) {
       console.info('catalog_route_ms', Date.now() - t0, JSON.stringify({ hadCoords }));
@@ -79,7 +78,7 @@ export async function GET(req: NextRequest) {
             title: p.name,
             lat: p.latitude,
             lon: p.longitude,
-            lang: 'en',
+            lang,
           });
 
           // Compute score combining popularity, distance and category boosts.

--- a/src/server/api/search/route.ts
+++ b/src/server/api/search/route.ts
@@ -8,6 +8,7 @@ import { fetchGeoapifySearch } from '@/shared/lib/geoapify';
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q');
+  const lang = searchParams.get('lang') ?? 'en';
   if (!q) {
     return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
   }
@@ -16,7 +17,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const data = await fetchGeoapifySearch(q);
+    const data = await fetchGeoapifySearch(q, lang);
     return NextResponse.json(data);
   } catch (err) {
     console.error(err);

--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -108,7 +108,8 @@ export async function fetchGeoapifyCatalog(
   dest: string,
   lat?: number,
   lon?: number,
-  categories: string[] = GEOAPIFY_CATEGORIES
+  categories: string[] = GEOAPIFY_CATEGORIES,
+  lang = 'en'
 ): Promise<{ activities: CatalogActivity[] }> {
   const key = getGeoapifyKey();
 
@@ -129,7 +130,7 @@ export async function fetchGeoapifyCatalog(
     }` +
     `&filter=circle:${longitude},${latitude},${DEFAULT_RADIUS_METERS}` +
     `&bias=proximity:${longitude},${latitude}` +
-    `&limit=${CATALOG_LIMIT}&lang=en&apiKey=${key}`;
+    `&limit=${CATALOG_LIMIT}&lang=${encodeURIComponent(lang)}&apiKey=${key}`;
 
   const res = await fetch(url, {
     cache: 'force-cache',
@@ -145,7 +146,8 @@ export async function fetchGeoapifyCatalog(
 
 /* Text search – fallback “quick search” */
 export async function fetchGeoapifySearch(
-  text: string
+  text: string,
+  lang = 'en'
 ): Promise<{ activities: CatalogActivity[] }> {
   const key = getGeoapifyKey();
 
@@ -162,7 +164,7 @@ export async function fetchGeoapifySearch(
     `&categories=${encodeURIComponent(DEFAULT_CATEGORIES)}` +
     `&filter=circle:${lon},${lat},${DEFAULT_RADIUS_METERS}` +
     `&bias=proximity:${lon},${lat}` +
-    `&limit=10&lang=en&apiKey=${key}`;
+    `&limit=10&lang=${encodeURIComponent(lang)}&apiKey=${key}`;
 
   const res = await fetch(url, {
     cache: 'force-cache',
@@ -172,7 +174,8 @@ export async function fetchGeoapifySearch(
   const data = (await res.json()) as GeoapifyResponse;
   const featuresWithName = data.features.filter((f) => f.properties.name?.trim());
   const activities = await enrichWithWikimediaImages(
-    featuresWithName.map((f) => mapGeoapifyFeature(f))
+    featuresWithName.map((f) => mapGeoapifyFeature(f)),
+    { lang }
   );
 
   return { activities };

--- a/tests/integration/api/catalog.spec.ts
+++ b/tests/integration/api/catalog.spec.ts
@@ -17,6 +17,9 @@ vi.mock('@/shared/lib/wikimedia', () => ({
   fetchWikimediaSignals: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { fetchGeoapifyCatalog } from '@/shared/lib/geoapify';
+import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
+
 const scores: Record<string, number> = { '1': 0.2, '2': 0.9, '3': 0.5 };
 vi.mock('@/shared/lib', () => ({
   computeCatalogScore: (
@@ -81,5 +84,24 @@ describe('GET /api/catalog', () => {
         boost: 0.4,
       });
     }
+  });
+
+  it('passes language to downstream services', async () => {
+    vi.mocked(fetchGeoapifyCatalog).mockClear();
+    vi.mocked(fetchWikimediaSignals).mockClear();
+    vi.mocked(fetchWikimediaSignals).mockResolvedValue({ description: 'Descrição', lang: 'pt' });
+    const req = new NextRequest('http://localhost/api/catalog?dest=test&lang=pt');
+    const res = await GET(req);
+    expect(fetchGeoapifyCatalog).toHaveBeenCalledWith(
+      'test',
+      undefined,
+      undefined,
+      undefined,
+      'pt'
+    );
+    const wikiCalls = vi.mocked(fetchWikimediaSignals).mock.calls;
+    expect(wikiCalls.every((c) => c[0].lang === 'pt')).toBe(true);
+    const data = await res.json();
+    expect(data.activities[0].wiki.description).toBe('Descrição');
   });
 });

--- a/tests/integration/api/refresh-pageviews.spec.ts
+++ b/tests/integration/api/refresh-pageviews.spec.ts
@@ -1,5 +1,6 @@
 // tests/integration/api/refresh-pageviews.spec.ts
 import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { NextRequest } from 'next/server.js';
 import { GET } from '@/server/api/admin/refresh-pageviews/route';
 
 const rows = [
@@ -37,12 +38,14 @@ vi.mock('@/shared/lib/supabaseServer', () => ({
 vi.mock('@/shared/lib/wikimedia', () => ({
   fetchWikimediaSignals: vi.fn().mockResolvedValue({
     title: 'X',
-    lang: 'en',
+    lang: 'pt',
     pageid: 1,
     source: 'search',
     pageviews30d: 10,
   }),
 }));
+
+import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
 
 const { persistSpy } = vi.hoisted(() => ({
   persistSpy: vi.fn(),
@@ -58,9 +61,12 @@ describe('GET /api/admin/refresh-pageviews', () => {
   });
 
   it('updates stale entries', async () => {
-    const res = await GET();
+    const req = new NextRequest('http://localhost/api/admin/refresh-pageviews?lang=pt');
+    const res = await GET(req);
     const body = await res.json();
     expect(body.updated).toBe(2);
+    const wikiCalls = vi.mocked(fetchWikimediaSignals).mock.calls;
+    expect(wikiCalls.every((c) => c[0].lang === 'pt')).toBe(true);
     expect(persistSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/shared/lib/geoapify.test.ts
+++ b/tests/unit/shared/lib/geoapify.test.ts
@@ -6,6 +6,7 @@ const originalKey = process.env.NEXT_PUBLIC_GEOAPIFY_KEY;
 let fetchGeoapifyAutocomplete: typeof import('@/shared/lib/geoapify').fetchGeoapifyAutocomplete;
 let fetchGeoapifyCatalog: typeof import('@/shared/lib/geoapify').fetchGeoapifyCatalog;
 let mapGeoapifyFeature: typeof import('@/shared/lib/geoapify').mapGeoapifyFeature;
+let fetchGeoapifySearch: typeof import('@/shared/lib/geoapify').fetchGeoapifySearch;
 
 describe('mapGeoapifyFeature', () => {
   beforeEach(async () => {
@@ -221,5 +222,55 @@ describe('fetchGeoapifyCatalog', () => {
     await fetchGeoapifyCatalog('paris', 1, 2);
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fetchGeoapifySearch', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = 'test-key';
+    vi.mock('@/shared/lib/wikimedia', () => ({
+      enrichWithWikimediaImages: vi.fn(async (acts: any) =>
+        acts.map((a: any) => ({ ...a, imageUrl: 'pt.jpg' }))
+      ),
+    }));
+    ({ fetchGeoapifySearch } = await import('@/shared/lib/geoapify'));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.NEXT_PUBLIC_GEOAPIFY_KEY = originalKey;
+    vi.clearAllMocks();
+  });
+
+  it('passes lang to API and enrichment', async () => {
+    const autoResp = {
+      features: [
+        { properties: { formatted: 'Lisbon, Portugal', result_type: 'city', lat: 1, lon: 2 } },
+      ],
+    };
+    const placesResp = {
+      features: [
+        {
+          properties: {
+            place_id: 1,
+            name: 'Torre de Belém',
+            lat: 1,
+            lon: 2,
+            categories: ['tourism.sights'],
+          },
+        },
+      ],
+    };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => autoResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => placesResp } as unknown as Response);
+    const { enrichWithWikimediaImages } = await import('@/shared/lib/wikimedia');
+    const res = await fetchGeoapifySearch('torre', 'pt');
+    const fetchCalls = (global.fetch as any).mock.calls;
+    expect(fetchCalls[1][0]).toContain('&lang=pt');
+    expect(enrichWithWikimediaImages).toHaveBeenCalledWith(expect.any(Array), { lang: 'pt' });
+    expect(res.activities[0].imageUrl).toBe('pt.jpg');
   });
 });

--- a/tests/unit/shared/lib/wikimedia.test.ts
+++ b/tests/unit/shared/lib/wikimedia.test.ts
@@ -70,4 +70,25 @@ describe('fetchWikimediaImage', () => {
     expect(firstUrl).toContain('titles=Some+Place');
     expect(secondUrl).toContain('gsrsearch=Some+Place');
   });
+
+  it('respects provided language', async () => {
+    const titleResp = {
+      query: { pages: { 1: { title: 'Cristo Redentor', thumbnail: { source: 'pt.jpg' } } } },
+    };
+    const searchResp = { query: { pages: {} } };
+    const pageviewsResp = { items: [] };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => titleResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => searchResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => pageviewsResp } as unknown as Response);
+
+    const url = await fetchWikimediaImage('Cristo Redentor', { lang: 'pt' });
+
+    expect(url).toBe('pt.jpg');
+    const fetchMock = global.fetch as unknown as Mock;
+    const calls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(calls[0]).toContain('pt.wikipedia.org');
+    expect(calls[1]).toContain('pt.wikipedia.org');
+  });
 });


### PR DESCRIPTION
## Summary
- extend Geoapify catalog/search utilities to accept a language
- pipe lang query param through catalog, search and pageview APIs
- test Portuguese landmarks resolve descriptions and images via Wikimedia

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689940393f6c8322b2e6ff88a5cb5288