### PR TITLE
✨ Add language-aware Wikimedia enrichment

### DIFF
--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -4,7 +4,7 @@
 
 import type { CatalogActivity, AutocompletePlace } from '@/shared/types';
 import { clientEnv } from './clientEnv';
-import { enrichWithWikimediaImages } from './wikimedia';
+import { enrichWithWikimediaSignals } from './wikimedia';
 
 /* Types */
 type GeoapifyFeature = {
@@ -173,7 +173,7 @@ export async function fetchGeoapifySearch(
   if (!res.ok) throw new Error(`Geoapify request failed: ${res.status}`);
   const data = (await res.json()) as GeoapifyResponse;
   const featuresWithName = data.features.filter((f) => f.properties.name?.trim());
-  const activities = await enrichWithWikimediaImages(
+  const activities = await enrichWithWikimediaSignals(
     featuresWithName.map((f) => mapGeoapifyFeature(f)),
     { lang }
   );

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -11,7 +11,7 @@ export {
 export {
   fetchWikimediaImage,
   fetchWikimediaSignals,
-  enrichWithWikimediaImages,
+  enrichWithWikimediaSignals,
   withPageviews,
 } from './wikimedia';
 export { computeCatalogScore } from './ranking';

--- a/src/shared/lib/wikimedia.ts
+++ b/src/shared/lib/wikimedia.ts
@@ -10,6 +10,7 @@ export type WikimediaSignals = {
   title?: string;
   imageUrl?: string;
   description?: string;
+  pageUrl?: string;
   lang?: string;
   wikidataQid?: string; // pageprops.wikibase_item
   source?: 'geosearch' | 'title' | 'search';
@@ -23,6 +24,7 @@ type ApiPage = {
   thumbnail?: { source: string; width: number; height: number };
   original?: { source: string; width: number; height: number };
   description?: string;
+  extract?: string;
   pageprops?: { wikibase_item?: string };
 };
 
@@ -78,7 +80,7 @@ function pageFromGenerator(query: QueryWithPages): ApiPage | undefined {
 async function byGeoSearch(lang: string, lat: number, lon: number, radius: number) {
   const url = `${wapiBase(lang)}?${paramsToQS({
     action: 'query',
-    prop: 'pageimages|pageprops|description',
+    prop: 'pageimages|pageprops|description|extracts',
     generator: 'geosearch',
     ggscoord: `${lat}|${lon}`,
     ggsradius: radius,
@@ -87,6 +89,8 @@ async function byGeoSearch(lang: string, lat: number, lon: number, radius: numbe
     pithumbsize: 640,
     pilicense: 'any',
     ppprop: 'wikibase_item',
+    exintro: 1,
+    explaintext: 1,
     redirects: 1,
   })}`;
   const data = await fetchJson(url);
@@ -99,12 +103,14 @@ async function byGeoSearch(lang: string, lat: number, lon: number, radius: numbe
 async function byExactTitle(lang: string, title: string) {
   const url = `${wapiBase(lang)}?${paramsToQS({
     action: 'query',
-    prop: 'pageimages|pageprops|description',
+    prop: 'pageimages|pageprops|description|extracts',
     titles: title,
     piprop: 'thumbnail|original',
     pithumbsize: 640,
     pilicense: 'any',
     ppprop: 'wikibase_item',
+    exintro: 1,
+    explaintext: 1,
     redirects: 1,
   })}`;
   const data = await fetchJson(url);
@@ -117,7 +123,7 @@ async function byExactTitle(lang: string, title: string) {
 async function bySearch(lang: string, title: string) {
   const url = `${wapiBase(lang)}?${paramsToQS({
     action: 'query',
-    prop: 'pageimages|pageprops|description',
+    prop: 'pageimages|pageprops|description|extracts',
     generator: 'search',
     gsrlimit: 5,
     gsrsearch: title,
@@ -125,6 +131,8 @@ async function bySearch(lang: string, title: string) {
     pithumbsize: 640,
     pilicense: 'any',
     ppprop: 'wikibase_item',
+    exintro: 1,
+    explaintext: 1,
     redirects: 1,
   })}`;
   const data = await fetchJson(url);
@@ -142,7 +150,10 @@ function normalizeSignals(
     pageid: page.pageid,
     title: page.title,
     imageUrl: pickImageFromPage(page),
-    description: page.description,
+    description: page.extract ?? page.description,
+    pageUrl: `https://${lang}.wikipedia.org/wiki/${encodeURIComponent(
+      page.title.replace(/ /g, '_')
+    )}`,
     lang,
     wikidataQid: page.pageprops?.wikibase_item,
     source,
@@ -254,7 +265,7 @@ export async function fetchWikimediaImage(
 }
 
 // Helper to enrich activities with Wikimedia images. Retained for compatibility.
-export async function enrichWithWikimediaImages(
+export async function enrichWithWikimediaSignals(
   activities: CatalogActivity[],
   opts?: { concurrency?: number; lang?: string }
 ): Promise<CatalogActivity[]> {
@@ -263,14 +274,19 @@ export async function enrichWithWikimediaImages(
   return Promise.all(
     activities.map((a) =>
       limit(async () => {
-        if (a.imageUrl) return a;
         const wiki = await fetchWikimediaSignals({
           title: a.name,
           lat: a.latitude,
           lon: a.longitude,
           lang,
         });
-        return wiki?.imageUrl ? { ...a, imageUrl: wiki.imageUrl } : a;
+        return wiki
+          ? {
+              ...a,
+              ...(wiki.imageUrl && !a.imageUrl ? { imageUrl: wiki.imageUrl } : {}),
+              wiki,
+            }
+          : a;
       })
     )
   );

--- a/tests/integration/shared/wikimedia-lang.spec.ts
+++ b/tests/integration/shared/wikimedia-lang.spec.ts
@@ -1,0 +1,39 @@
+// tests/integration/shared/wikimedia-lang.spec.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchWikimediaSignals } from '@/shared/lib/wikimedia';
+
+const originalFetch = global.fetch;
+
+describe('fetchWikimediaSignals language support', () => {
+  beforeEach(() => {
+    const page = {
+      pageid: 1,
+      title: 'Tour Eiffel',
+      extract: 'La tour Eiffel est une tour...',
+      original: { source: 'https://upload.wikimedia.org/fr.jpg', width: 1, height: 1 },
+      pageprops: { wikibase_item: 'Q243' },
+    };
+    const response = { query: { pages: { '1': page } } };
+    const pv = { items: [] };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => response })
+      .mockResolvedValueOnce({ ok: true, json: async () => response })
+      .mockResolvedValueOnce({ ok: true, json: async () => pv });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('uses domain for non-English articles', async () => {
+    const sig = await fetchWikimediaSignals({ title: 'Eiffel Tower', lang: 'fr' });
+    expect(sig?.title).toBe('Tour Eiffel');
+    expect(sig?.description).toContain('tour Eiffel');
+    expect(sig?.imageUrl).toBe('https://upload.wikimedia.org/fr.jpg');
+    expect(sig?.pageUrl).toBe('https://fr.wikipedia.org/wiki/Tour_Eiffel');
+    const calls = (global.fetch as any).mock.calls;
+    expect(calls[0][0]).toContain('fr.wikipedia.org');
+    expect(calls[1][0]).toContain('fr.wikipedia.org');
+  });
+});

--- a/tests/unit/shared/lib/geoapify.test.ts
+++ b/tests/unit/shared/lib/geoapify.test.ts
@@ -230,8 +230,12 @@ describe('fetchGeoapifySearch', () => {
     vi.resetModules();
     process.env.NEXT_PUBLIC_GEOAPIFY_KEY = 'test-key';
     vi.mock('@/shared/lib/wikimedia', () => ({
-      enrichWithWikimediaImages: vi.fn(async (acts: any) =>
-        acts.map((a: any) => ({ ...a, imageUrl: 'pt.jpg' }))
+      enrichWithWikimediaSignals: vi.fn(async (acts: any) =>
+        acts.map((a: any) => ({
+          ...a,
+          wiki: { lang: 'pt', title: a.name, description: 'Resumo', imageUrl: 'pt.jpg' },
+          imageUrl: 'pt.jpg',
+        }))
       ),
     }));
     ({ fetchGeoapifySearch } = await import('@/shared/lib/geoapify'));
@@ -266,11 +270,12 @@ describe('fetchGeoapifySearch', () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, json: async () => autoResp } as unknown as Response)
       .mockResolvedValueOnce({ ok: true, json: async () => placesResp } as unknown as Response);
-    const { enrichWithWikimediaImages } = await import('@/shared/lib/wikimedia');
+    const { enrichWithWikimediaSignals } = await import('@/shared/lib/wikimedia');
     const res = await fetchGeoapifySearch('torre', 'pt');
     const fetchCalls = (global.fetch as any).mock.calls;
     expect(fetchCalls[1][0]).toContain('&lang=pt');
-    expect(enrichWithWikimediaImages).toHaveBeenCalledWith(expect.any(Array), { lang: 'pt' });
+    expect(enrichWithWikimediaSignals).toHaveBeenCalledWith(expect.any(Array), { lang: 'pt' });
+    expect(res.activities[0].wiki?.lang).toBe('pt');
     expect(res.activities[0].imageUrl).toBe('pt.jpg');
   });
 });


### PR DESCRIPTION
## Summary
- Rename enrichment helper to `enrichWithWikimediaSignals` and return full Wikimedia data
- Add page URL and localized extract handling in Wikimedia fetching
- Cover multilingual Wikimedia lookup with integration tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689944191bd48322a95fe0938edbbc2a