### PR TITLE
✨ Improve geosearch title matching

### DIFF
--- a/src/shared/lib/wikimedia.ts
+++ b/src/shared/lib/wikimedia.ts
@@ -76,8 +76,37 @@ function pageFromGenerator(query: QueryWithPages): ApiPage | undefined {
   return pageFromQuery(query);
 }
 
-/** Geo-first: uses generator=geosearch to fetch properties and images in one request. */
-async function byGeoSearch(lang: string, lat: number, lon: number, radius: number) {
+const TITLE_SIMILARITY_THRESHOLD = 0.5;
+
+function normalizeTitle(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\s*\(.*?\)\s*/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function titleSimilarity(a: string, b: string): number {
+  const setA = new Set(a.split(' ').filter(Boolean));
+  const setB = new Set(b.split(' ').filter(Boolean));
+  const intersection = [...setA].filter((w) => setB.has(w)).length;
+  const union = new Set([...setA, ...setB]).size;
+  return union > 0 ? intersection / union : 0;
+}
+
+/**
+ * Geo-first: uses generator=geosearch to fetch nearby pages.
+ * Evaluates all candidates against the provided query title and picks the
+ * best match if it clears a similarity threshold. Otherwise returns undefined
+ * so that other strategies (exact title, text search) can resolve the page.
+ */
+async function byGeoSearch(
+  lang: string,
+  queryTitle: string,
+  lat: number,
+  lon: number,
+  radius: number
+) {
   const url = `${wapiBase(lang)}?${paramsToQS({
     action: 'query',
     prop: 'pageimages|pageprops|description|extracts',
@@ -94,9 +123,20 @@ async function byGeoSearch(lang: string, lat: number, lon: number, radius: numbe
     redirects: 1,
   })}`;
   const data = await fetchJson(url);
-  const page = pageFromGenerator(data?.query);
-  if (!page) return undefined;
-  return normalizeSignals(page, lang, 'geosearch');
+  const pages = data?.query?.pages;
+  if (!pages) return undefined;
+
+  const normQuery = normalizeTitle(queryTitle);
+  let best: { page: ApiPage; score: number } | undefined;
+
+  for (const page of Object.values(pages) as ApiPage[]) {
+    const score = titleSimilarity(normQuery, normalizeTitle(page.title));
+    if (!best || score > best.score) best = { page, score };
+  }
+
+  if (!best || best.score < TITLE_SIMILARITY_THRESHOLD) return undefined;
+
+  return normalizeSignals(best.page, lang, 'geosearch');
 }
 
 /** Try an exact title lookup (with redirects). */
@@ -211,7 +251,7 @@ export async function fetchWikimediaSignals(input: {
   const tasks: Array<Promise<WikimediaSignals | undefined>> = [];
 
   if (input.lat != null && input.lon != null) {
-    tasks.push(byGeoSearch(lang, input.lat, input.lon, radius).catch(() => undefined));
+    tasks.push(byGeoSearch(lang, input.title, input.lat, input.lon, radius).catch(() => undefined));
   }
   tasks.push(byExactTitle(lang, input.title).catch(() => undefined));
   tasks.push(bySearch(lang, input.title).catch(() => undefined));

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -10,25 +10,25 @@ afterEach(() => {
 });
 
 describe('fetchWikimediaSignals', () => {
-  it('prioritizes geosearch over title and search', async () => {
+  it('prioritizes geosearch over title and search when titles match', async () => {
     const geoResp = {
       query: {
         pages: {
-          1: { pageid: 1, title: 'Geo', thumbnail: { source: 'geo.jpg' } },
+          1: { pageid: 1, title: 'Foo', thumbnail: { source: 'geo.jpg' } },
         },
       },
     };
     const titleResp = {
       query: {
         pages: {
-          2: { pageid: 2, title: 'Title', thumbnail: { source: 'title.jpg' } },
+          2: { pageid: 2, title: 'Foo', thumbnail: { source: 'title.jpg' } },
         },
       },
     };
     const searchResp = {
       query: {
         pages: {
-          3: { pageid: 3, title: 'Search', thumbnail: { source: 'search.jpg' } },
+          3: { pageid: 3, title: 'Foo', thumbnail: { source: 'search.jpg' } },
         },
       },
     };
@@ -43,7 +43,12 @@ describe('fetchWikimediaSignals', () => {
 
     const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2 });
 
-    expect(sig).toMatchObject({ source: 'geosearch', imageUrl: 'geo.jpg', pageviews30d: 10 });
+    expect(sig).toMatchObject({
+      source: 'geosearch',
+      imageUrl: 'geo.jpg',
+      title: 'Foo',
+      pageviews30d: 10,
+    });
     const calls = (global.fetch as unknown as Mock).mock.calls.map((c) => c[0] as string);
     expect(calls[0]).toContain('generator=geosearch');
     expect(calls[1]).toContain('titles=Foo');
@@ -71,5 +76,50 @@ describe('fetchWikimediaSignals', () => {
     const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2 });
 
     expect(sig).toMatchObject({ source: 'search', imageUrl: 'search.jpg', pageviews30d: 0 });
+  });
+
+  it('ignores geosearch when title does not match and returns full signals from the correct page', async () => {
+    const geoResp = {
+      query: {
+        pages: {
+          1: { pageid: 1, title: 'Nearby Landmark', thumbnail: { source: 'near.jpg' } },
+        },
+      },
+    };
+    const titleResp = {
+      query: {
+        pages: {
+          2: {
+            pageid: 2,
+            title: 'Correct Place',
+            extract: 'Extract',
+            pageprops: { wikibase_item: 'Q1' },
+            thumbnail: { source: 'correct.jpg' },
+          },
+        },
+      },
+    };
+    const searchResp = { query: { pages: {} } };
+    const pageviewsResp = { items: [{ views: 5 }] };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => geoResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => titleResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => searchResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => pageviewsResp } as unknown as Response);
+
+    const sig = await fetchWikimediaSignals({ title: 'Correct Place', lat: 1, lon: 2 });
+
+    expect(sig).toMatchObject({
+      source: 'title',
+      pageid: 2,
+      title: 'Correct Place',
+      imageUrl: 'correct.jpg',
+      description: 'Extract',
+      wikidataQid: 'Q1',
+      pageviews30d: 5,
+    });
+    expect(sig?.pageUrl).toContain('Correct_Place');
   });
 });


### PR DESCRIPTION
## Summary
- refine geosearch by comparing normalized titles and picking best match above threshold
- pass query title into geosearch selection and surface complete page signals
- cover mismatched geosearch scenario in unit tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6899488a81b48322a3e52301d169bb6d