### PR TITLE
✨ Truncate Wikimedia descriptions to 16 words

### DIFF
--- a/src/shared/lib/wikimedia.ts
+++ b/src/shared/lib/wikimedia.ts
@@ -94,6 +94,12 @@ function titleSimilarity(a: string, b: string): number {
   return union > 0 ? intersection / union : 0;
 }
 
+function truncateWords(str: string | undefined, max = 16): string | undefined {
+  if (!str) return undefined;
+  const words = str.trim().split(/\s+/);
+  return words.length > max ? words.slice(0, max).join(' ') : str.trim();
+}
+
 /**
  * Geo-first: uses generator=geosearch to fetch nearby pages.
  * Evaluates all candidates against the provided query title and picks the
@@ -190,7 +196,7 @@ function normalizeSignals(
     pageid: page.pageid,
     title: page.title,
     imageUrl: pickImageFromPage(page),
-    description: page.extract ?? page.description,
+    description: truncateWords(page.extract ?? page.description),
     pageUrl: `https://${lang}.wikipedia.org/wiki/${encodeURIComponent(
       page.title.replace(/ /g, '_')
     )}`,

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -122,4 +122,36 @@ describe('fetchWikimediaSignals', () => {
     });
     expect(sig?.pageUrl).toContain('Correct_Place');
   });
+
+  it('caps description at 16 words', async () => {
+    const longText =
+      'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen';
+    const titleResp = {
+      query: {
+        pages: {
+          1: {
+            pageid: 1,
+            title: 'Foo',
+            extract: longText,
+            thumbnail: { source: 'img.jpg' },
+          },
+        },
+      },
+    };
+    const searchResp = { query: { pages: {} } };
+    const pageviewsResp = { items: [] };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => titleResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => searchResp } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => pageviewsResp } as unknown as Response);
+
+    const sig = await fetchWikimediaSignals({ title: 'Foo' });
+
+    expect(sig?.description).toBe(
+      'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen'
+    );
+    expect(sig?.description?.split(/\s+/)).toHaveLength(16);
+  });
 });


### PR DESCRIPTION
## Summary
- cap Wikimedia descriptions at 16 words with new `truncateWords` helper
- ensure `fetchWikimediaSignals` applies this limit and add unit test

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68994d35d2448322a7d2283e4b6159e9