### PR TITLE
Add centralized logger and refactor createPlan

### DIFF
--- a/src/server/actions/createPlan.ts
+++ b/src/server/actions/createPlan.ts
@@ -3,6 +3,7 @@
 
 import { performance } from 'node:perf_hooks';
 import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { logger } from '@/shared/lib/logger';
 
 interface DestinationInfo {
   name: string;
@@ -17,7 +18,7 @@ export async function createPlan(title: string, dest: DestinationInfo, start: st
   const endDate = end.slice(0, 10);
 
   const totalStart = performance.now();
-  console.time('create_full_plan');
+  logger.time('create_full_plan');
   const { data, error } = await supabase.rpc('create_full_plan', {
     _title: title,
     _dest_name: dest.name,
@@ -26,9 +27,9 @@ export async function createPlan(title: string, dest: DestinationInfo, start: st
     _start_date: startDate,
     _end_date: endDate,
   });
-  console.timeEnd('create_full_plan');
+  logger.timeEnd('create_full_plan');
   const totalMs = performance.now() - totalStart;
-  console.log(`createPlan RPC total ${totalMs.toFixed(1)}ms`);
+  logger.log(`createPlan RPC total ${totalMs.toFixed(1)}ms`);
 
   if (error || !data) throw error ?? new Error('Failed to create plan');
   const row = Array.isArray(data) ? data[0] : data;

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -20,3 +20,4 @@ export { pLimit } from './pLimit';
 export { supabase } from './supabaseClient';
 export { clientEnv } from './clientEnv';
 export type { ClientEnv } from './clientEnv';
+export { logger } from './logger';

--- a/src/shared/lib/logger.ts
+++ b/src/shared/lib/logger.ts
@@ -1,0 +1,18 @@
+// src/shared/lib/logger.ts
+
+/**
+ * Centralized logger that only outputs in non-production environments.
+ */
+const isProd = process.env.NODE_ENV === 'production';
+
+export const logger = {
+  time(label: string) {
+    if (!isProd) console.time(label);
+  },
+  timeEnd(label: string) {
+    if (!isProd) console.timeEnd(label);
+  },
+  log(...args: unknown[]) {
+    if (!isProd) console.log(...args);
+  },
+};

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -151,7 +151,8 @@ describe('fetchWikimediaSignals', () => {
     const searchResp = { query: { pages: {} } };
     const pageviewsResp = { items: [] };
 
-    global.fetch = vi.fn((url: string) => {
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('titles=Foo')) {
         return Promise.resolve({ ok: true, json: async () => titleResp } as unknown as Response);
       }
@@ -280,7 +281,8 @@ describe('fetchWikimediaSignals', () => {
     };
     const pageviewsResp = { items: [{ views: 5 }] };
 
-    global.fetch = vi.fn((url: string) => {
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('generator=geosearch')) {
         return Promise.resolve({
           ok: true,


### PR DESCRIPTION
## Summary
- add centralized logger utility
- route createPlan through central logger
- align Wikimedia signal tests with fetch typings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689de73c32588322a4c8f58281e761b3