### PR TITLE
Update plan creation loading message

### DIFF
--- a/src/features/home/components/PlanForm.tsx
+++ b/src/features/home/components/PlanForm.tsx
@@ -94,7 +94,7 @@ export default function PlanForm() {
   };
 
   if (loading) {
-    return <LoadingScreen text="Loading catalog..." />;
+    return <LoadingScreen text="Creating plan…" />;
   }
 
   return (

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -168,7 +168,7 @@ describe('fetchWikimediaSignals', () => {
         ok: true,
         json: async () => ({ query: { pages: {} } }),
       } as unknown as Response);
-    });
+    }) as unknown as typeof fetch;
 
     const sig = await fetchWikimediaSignals({ title: 'Foo' });
 
@@ -294,7 +294,7 @@ describe('fetchWikimediaSignals', () => {
         return Promise.resolve({ ok: true, json: async () => searchResp } as unknown as Response);
       }
       return Promise.resolve({ ok: true, json: async () => pageviewsResp } as unknown as Response);
-    });
+    }) as unknown as typeof fetch;
 
     const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2, radius: 500 });
 


### PR DESCRIPTION
## Summary
- update PlanForm loading screen text to “Creating plan…”
- cast mocked fetch to satisfy type checks

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c04e08448322becc05b57839438e