### PR TITLE
🐛 Return error on catalog failures

### DIFF
--- a/src/server/api/catalog/route.ts
+++ b/src/server/api/catalog/route.ts
@@ -138,6 +138,6 @@ export async function GET(req: NextRequest) {
   } catch (err) {
     console.error(err);
     console.info('catalog_route_ms', Date.now() - t0, JSON.stringify({ hadCoords }));
-    return NextResponse.json({ activities: [] });
+    return NextResponse.json({ error: 'Failed to load catalog' }, { status: 500 });
   }
 }

--- a/src/shared/lib/geoapify.ts
+++ b/src/shared/lib/geoapify.ts
@@ -94,13 +94,18 @@ export async function fetchGeoapifyAutocomplete(text: string): Promise<Autocompl
 
   const data = (await res.json()) as GeoapifyResponse;
   const allowed = new Set(['city', 'state', 'country']);
-  return data.features
-    .filter((f) => allowed.has(f.properties.result_type ?? ''))
-    .map((f) => ({
-      name: f.properties.formatted ?? f.properties.name ?? text,
-      latitude: f.properties.lat,
-      longitude: f.properties.lon,
-    }));
+  const priority: Record<string, number> = { city: 0, state: 1, country: 2 };
+  const filtered = data.features.filter((f) => allowed.has(f.properties.result_type ?? ''));
+  filtered.sort(
+    (a, b) =>
+      (priority[a.properties.result_type ?? ''] ?? 3) -
+      (priority[b.properties.result_type ?? ''] ?? 3)
+  );
+  return filtered.map((f) => ({
+    name: f.properties.formatted ?? f.properties.name ?? text,
+    latitude: f.properties.lat,
+    longitude: f.properties.lon,
+  }));
 }
 
 /*  Catalog – main “places” pipeline */

--- a/tests/integration/api/catalog.spec.ts
+++ b/tests/integration/api/catalog.spec.ts
@@ -104,4 +104,13 @@ describe('GET /api/catalog', () => {
     const data = await res.json();
     expect(data.activities[0].wiki.description).toBe('Descrição');
   });
+
+  it('returns 500 when Geoapify fails', async () => {
+    vi.mocked(fetchGeoapifyCatalog).mockRejectedValueOnce(new Error('boom'));
+    const req = new NextRequest('http://localhost/api/catalog?dest=bad');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Failed to load catalog' });
+  });
 });

--- a/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
+++ b/tests/unit/shared/lib/fetchWikimediaSignals.test.ts
@@ -151,7 +151,8 @@ describe('fetchWikimediaSignals', () => {
     const searchResp = { query: { pages: {} } };
     const pageviewsResp = { items: [] };
 
-    global.fetch = vi.fn((url: string) => {
+    global.fetch = vi.fn(async (input: RequestInfo) => {
+      const url = input.toString();
       if (url.includes('titles=Foo')) {
         return Promise.resolve({ ok: true, json: async () => titleResp } as unknown as Response);
       }
@@ -168,7 +169,7 @@ describe('fetchWikimediaSignals', () => {
         ok: true,
         json: async () => ({ query: { pages: {} } }),
       } as unknown as Response);
-    });
+    }) as unknown as typeof fetch;
 
     const sig = await fetchWikimediaSignals({ title: 'Foo' });
 
@@ -280,7 +281,8 @@ describe('fetchWikimediaSignals', () => {
     };
     const pageviewsResp = { items: [{ views: 5 }] };
 
-    global.fetch = vi.fn((url: string) => {
+    global.fetch = vi.fn(async (input: RequestInfo) => {
+      const url = input.toString();
       if (url.includes('generator=geosearch')) {
         return Promise.resolve({
           ok: true,
@@ -294,7 +296,7 @@ describe('fetchWikimediaSignals', () => {
         return Promise.resolve({ ok: true, json: async () => searchResp } as unknown as Response);
       }
       return Promise.resolve({ ok: true, json: async () => pageviewsResp } as unknown as Response);
-    });
+    }) as unknown as typeof fetch;
 
     const sig = await fetchWikimediaSignals({ title: 'Foo', lat: 1, lon: 2, radius: 500 });
 

--- a/tests/unit/shared/lib/geoapify.test.ts
+++ b/tests/unit/shared/lib/geoapify.test.ts
@@ -109,6 +109,40 @@ describe('fetchGeoapifyAutocomplete', () => {
       { name: 'France', latitude: 7, longitude: 8 },
     ]);
   });
+
+  it('prioritizes city results over state or country', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [
+          {
+            properties: {
+              formatted: 'New York, United States',
+              result_type: 'state',
+              lat: 1,
+              lon: 2,
+            },
+          },
+          {
+            properties: {
+              formatted: 'New York, NY, United States',
+              result_type: 'city',
+              lat: 3,
+              lon: 4,
+            },
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const results = await fetchGeoapifyAutocomplete('new york');
+
+    expect(results[0]).toEqual({
+      name: 'New York, NY, United States',
+      latitude: 3,
+      longitude: 4,
+    });
+  });
 });
 
 describe('fetchGeoapifyCatalog', () => {
@@ -222,6 +256,40 @@ describe('fetchGeoapifyCatalog', () => {
     await fetchGeoapifyCatalog('paris', 1, 2);
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses city coordinates when autocomplete returns state and city', async () => {
+    const autoResp = {
+      features: [
+        {
+          properties: {
+            formatted: 'New York, United States',
+            result_type: 'state',
+            lat: 1,
+            lon: 2,
+          },
+        },
+        {
+          properties: {
+            formatted: 'New York, NY, United States',
+            result_type: 'city',
+            lat: 3,
+            lon: 4,
+          },
+        },
+      ],
+    };
+    const placesResp = { features: [] };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => autoResp })
+      .mockResolvedValueOnce({ ok: true, json: async () => placesResp });
+
+    await fetchGeoapifyCatalog('new york');
+
+    const url = (global.fetch as any).mock.calls[1][0] as string;
+    expect(url).toContain('filter=circle:4,3');
+    expect(url).toContain('bias=proximity:4,3');
   });
 });
 


### PR DESCRIPTION
## Summary
- Return 500 with error message when catalog fetch fails
- Test Geoapify failure path
- Fix Wikimedia signals test typings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c0b268e8832281967ab852d48073