### PR TITLE
🐛 Fix feature carousel navigation on desktop

### DIFF
--- a/src/shared/hooks/ui/usePointerDragScroll.ts
+++ b/src/shared/hooks/ui/usePointerDragScroll.ts
@@ -24,12 +24,14 @@ export function usePointerDragScroll(
     const nearestIndex = () => {
       const items = Array.from(el.children) as HTMLElement[];
       if (!items.length) return 0;
-      const center = el.scrollLeft + el.clientWidth / 2;
+      const parentRect = el.getBoundingClientRect();
+      const center = parentRect.left + parentRect.width / 2;
       let i = 0;
       let best = Infinity;
       items.forEach((it, idx) => {
-        const c = it.offsetLeft + it.offsetWidth / 2;
-        const d = Math.abs(center - c);
+        const rect = it.getBoundingClientRect();
+        const itemCenter = rect.left + rect.width / 2;
+        const d = Math.abs(center - itemCenter);
         if (d < best) {
           best = d;
           i = idx;


### PR DESCRIPTION
## Summary
- ensure drag scroll computes nearest slide correctly to prevent skipping

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3870d72c832285acc48485e6428e