### PR TITLE
Refine home page styles and add CSS reset

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -93,7 +93,7 @@
   --chart-5: oklch(0.5 0.05 330);
 
   /* Special Cards Base Colors */
-  --color-0: oklch(1 0 0); /* branco */
+  --color-0: oklch(1 0 0); /* white */
   --color-0-border: oklch(0.7 0 0);
 
   --color-1: oklch(0.98 0.05 75); /* pastel orange */
@@ -112,12 +112,25 @@
   --color-5-border: oklch(0.8 0.1 320);
 }
 
+/* CSS Reset */
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
+  *,
+  *::before,
+  *::after {
+    @apply border-border outline-ring/50 m-0 box-border p-0;
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer components {
+  .section-title {
+    @apply pb-6 text-[36px] leading-[1.1] font-semibold tracking-tight md:text-[42px];
+  }
+
+  .section-description {
+    @apply pb-4 text-xl;
   }
 }
 

--- a/src/features/home/components/Hero.tsx
+++ b/src/features/home/components/Hero.tsx
@@ -6,34 +6,32 @@ import PlanForm from './PlanForm';
 
 export default function Hero() {
   return (
-    <section className="relative overflow-hidden pt-24 sm:pt-28 lg:pt-32">
-      <div className="container mx-auto px-6">
-        <div className="grid items-center gap-10 lg:grid-cols-2 lg:gap-12">
-          {/* Coluna esquerda */}
-          <div className="flex w-full max-w-2xl flex-col items-center text-center lg:items-start lg:text-left">
-            <h1 className="mb-6 text-[48px] leading-[1.1] font-semibold tracking-tight md:text-[52px] lg:text-[56px]">
-              The App for
-              <br />
-              your travel.
-            </h1>
-            <p className="mb-6 text-lg md:text-xl">
-              Escape the clutter and chaos. Organize and plan your adventure from anywhere.
-            </p>
-            <PlanForm />
-          </div>
+    <section className="relative container overflow-hidden px-6 pt-24 sm:pt-28 lg:pt-32">
+      <div className="grid items-center gap-10 lg:grid-cols-2 lg:gap-12">
+        {/* Left column */}
+        <div className="flex w-full flex-col items-center text-center lg:items-start lg:text-left">
+          <h1 className="mb-6 text-[48px] leading-[1.1] font-semibold tracking-tight md:text-[52px] lg:text-[56px]">
+            The App for
+            <br />
+            your travel.
+          </h1>
+          <p className="mb-6 text-lg md:text-xl">
+            Escape the clutter and chaos. Organize and plan your adventure from anywhere.
+          </p>
+          <PlanForm />
+        </div>
 
-          {/* Coluna direita (Mascote) */}
-          <div className="flex w-full justify-center lg:justify-end">
-            <Image
-              src="/images/mascot_1_.webp"
-              alt=""
-              aria-hidden="true"
-              width={800}
-              height={600}
-              className="h-auto w-full max-w-[420px] -scale-x-100 select-none"
-              priority
-            />
-          </div>
+        {/* Right column (Mascot) */}
+        <div className="flex w-full justify-center lg:justify-end">
+          <Image
+            src="/images/mascot_1_.webp"
+            alt=""
+            aria-hidden="true"
+            width={800}
+            height={600}
+            className="h-auto w-full max-w-[420px] -scale-x-100 select-none"
+            priority
+          />
         </div>
       </div>
     </section>

--- a/src/features/home/components/InspirationLink.tsx
+++ b/src/features/home/components/InspirationLink.tsx
@@ -12,13 +12,11 @@ export default function InspirationLink() {
   ];
 
   return (
-    <section className="bg-card p-8 pt-40 sm:pt-16 md:pt-24 lg:pt-32">
-      <div className="container max-w-3xl sm:max-w-lg lg:max-w-[960px]">
+    <section className="bg-card py-40 sm:py-16 md:py-24 lg:py-32">
+      <div className="container px-8">
         <div className="relative mx-auto flex max-w-4xl flex-col items-center pb-4 text-center">
-          <h2 className="pb-6 text-[36px] leading-[1.1] font-semibold tracking-tight md:text-[42px]">
-            Be inspired by fellow travellers
-          </h2>
-          <p className="pb-4 text-xl">
+          <h2 className="section-title">Be inspired by fellow travellers</h2>
+          <p className="section-description">
             Explore a curated list of other travellers trip itineraries and get inspired for your
             next trip. If you like a trip, you can clone it and make it your own.
           </p>

--- a/src/features/home/components/feature-preview/FeaturePreview.tsx
+++ b/src/features/home/components/feature-preview/FeaturePreview.tsx
@@ -58,92 +58,88 @@ export default function FeaturePreview() {
   const handleSelect = (idx: number) => setActiveIdx(idx);
 
   return (
-    <section className="p-8 pt-40 sm:pt-16 md:pt-24 lg:pt-32">
-      <div className="container max-w-3xl sm:max-w-lg lg:max-w-[960px]">
-        <div className="max-w-[100%] md:max-w-[60%]">
-          <h2 className="pb-6 text-[36px] leading-[1.1] font-semibold tracking-tight md:text-[42px]">
-            Planner. Map. Budget.
-          </h2>
-          <p className="pb-4 text-xl">
-            Great trips start with a plan you can see, a map that makes sense, and a budget that
-            keeps choices real. Turistar brings these together so decisions are faster and planning
-            feels simple.
-          </p>
+    <section className="container px-8 pt-40 pb-8 sm:pt-16 md:pt-24 lg:pt-32">
+      <div className="md:max-w-[60%]">
+        <h2 className="section-title">Planner. Map. Budget.</h2>
+        <p className="section-description">
+          Great trips start with a plan you can see, a map that makes sense, and a budget that keeps
+          choices real. Turistar brings these together so decisions are faster and planning feels
+          simple.
+        </p>
+      </div>
+
+      <div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
+        {/* Cards */}
+        <div className="order-2 md:order-1">
+          {/* Desktop: clickable list */}
+          <ul className="hidden flex-col gap-4 md:flex">
+            {features.map((f, idx) => (
+              <li key={f.title}>
+                <FeatureCard
+                  feature={f}
+                  isActive={idx === activeIdx}
+                  onClick={() => handleSelect(idx)}
+                />
+              </li>
+            ))}
+          </ul>
+
+          {/* Mobile/tablet: full-width slides with gap */}
+          <ul
+            ref={cardsRef}
+            className="no-scrollbar m-0 flex w-full cursor-pointer snap-x snap-proximity gap-4 overflow-x-auto p-0 md:hidden"
+          >
+            {features.map((f, idx) => (
+              <li key={f.title} className="min-w-full shrink-0 basis-full snap-start">
+                <FeatureCard feature={f} isActive={idx === activeIdx} asButton={false} />
+              </li>
+            ))}
+          </ul>
+
+          {/* Mobile: dots below the cards */}
+          <NavDots
+            total={features.length}
+            current={activeIdx}
+            onSelect={handleSelect}
+            className="mt-4 justify-center md:hidden"
+          />
         </div>
 
-        <div className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
-          {/* Cards */}
-          <div className="order-2 md:order-1">
-            {/* Desktop: clickable list */}
-            <ul className="hidden flex-col gap-4 md:flex">
-              {features.map((f, idx) => (
-                <li key={f.title}>
-                  <FeatureCard
-                    feature={f}
-                    isActive={idx === activeIdx}
-                    onClick={() => handleSelect(idx)}
+        {/* Images */}
+        <div className="order-1 md:order-2 md:col-span-2">
+          {/* Desktop: dots above the image to the right */}
+          <NavDots
+            total={features.length}
+            current={activeIdx}
+            onSelect={handleSelect}
+            className="mb-3 hidden justify-end md:flex"
+          />
+
+          {/* Image carousel with full width and gap */}
+          <ul
+            ref={imagesRef}
+            tabIndex={-1}
+            aria-hidden="true"
+            className="no-scrollbar m-0 flex w-full cursor-grab [touch-action:pan-y] snap-x snap-proximity gap-4 overflow-x-auto p-0"
+          >
+            {features.map((f, idx) => (
+              <li key={f.title} className="min-w-full shrink-0 basis-full snap-start">
+                <div className="select-none">
+                  <Image
+                    src={f.imgSrc}
+                    alt=""
+                    role="presentation"
+                    width={1600}
+                    height={900}
+                    className="block h-auto w-full overflow-hidden rounded-xl object-contain"
+                    priority={idx === activeIdx}
+                    draggable={false}
+                    onDragStart={(e) => e.preventDefault()}
                   />
-                </li>
-              ))}
-            </ul>
-
-            {/* Mobile/tablet: full-width slides with gap */}
-            <ul
-              ref={cardsRef}
-              className="no-scrollbar m-0 flex w-full cursor-pointer snap-x snap-proximity gap-4 overflow-x-auto p-0 md:hidden"
-            >
-              {features.map((f, idx) => (
-                <li key={f.title} className="min-w-full shrink-0 basis-full snap-start">
-                  <FeatureCard feature={f} isActive={idx === activeIdx} asButton={false} />
-                </li>
-              ))}
-            </ul>
-
-            {/* Mobile: dots below the cards */}
-            <NavDots
-              total={features.length}
-              current={activeIdx}
-              onSelect={handleSelect}
-              className="mt-4 justify-center md:hidden"
-            />
-          </div>
-
-          {/* Images */}
-          <div className="order-1 md:order-2 md:col-span-2">
-            {/* Desktop: dots above the image to the right */}
-            <NavDots
-              total={features.length}
-              current={activeIdx}
-              onSelect={handleSelect}
-              className="mb-3 hidden justify-end md:flex"
-            />
-
-            {/* Image carousel with full width and gap */}
-            <ul
-              ref={imagesRef}
-              tabIndex={-1}
-              aria-hidden="true"
-              className="no-scrollbar m-0 flex w-full cursor-grab [touch-action:pan-y] snap-x snap-proximity gap-4 overflow-x-auto p-0"
-            >
-              {features.map((f, idx) => (
-                <li key={f.title} className="min-w-full shrink-0 basis-full snap-start">
-                  <div className="select-none">
-                    <Image
-                      src={f.imgSrc}
-                      alt=""
-                      role="presentation"
-                      width={1600}
-                      height={900}
-                      className="block h-auto w-full overflow-hidden rounded-xl object-contain"
-                      priority={idx === activeIdx}
-                      draggable={false}
-                      onDragStart={(e) => e.preventDefault()}
-                    />
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add global CSS reset and translate remaining color comment
- simplify home sections and ensure inspiration background spans full width
- translate stray Portuguese comments to English

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa410190548322a3b1b9c17baf4cbb