### PR TITLE
✨ Add scroll-aware element rect hook and refactor components

### DIFF
--- a/src/features/planner/components/dnd/ActivityCardEditorOverlay.tsx
+++ b/src/features/planner/components/dnd/ActivityCardEditorOverlay.tsx
@@ -1,8 +1,9 @@
 // src/features/planner/components/dnd/ActivityCardEditorOverlay.tsx
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
+import { useElementRect } from '@/shared/hooks/ui/useElementRect';
 
 interface Props {
   open: boolean;
@@ -19,21 +20,7 @@ export default function ActivityCardEditorOverlay({
   onClose,
   children,
 }: Props) {
-  const [rect, setRect] = useState<DOMRect | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const update = () => {
-      if (cardRef.current) setRect(cardRef.current.getBoundingClientRect());
-    };
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-    };
-  }, [open, cardRef]);
+  const rect = useElementRect(cardRef, true);
 
   if (!open || !rect) return null;
 

--- a/src/shared/hooks/ui/useElementRect.ts
+++ b/src/shared/hooks/ui/useElementRect.ts
@@ -7,7 +7,10 @@ import { useState, useEffect, RefObject } from 'react';
  * It updates the rect on window resize or when the element changes.
  */
 
-export function useElementRect<T extends HTMLElement = HTMLElement>(ref: RefObject<T | null>) {
+export function useElementRect<T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T | null>,
+  listenScroll = false
+) {
   const [rect, setRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
@@ -22,10 +25,16 @@ export function useElementRect<T extends HTMLElement = HTMLElement>(ref: RefObje
     updateRect();
 
     window.addEventListener('resize', updateRect);
+    if (listenScroll) {
+      window.addEventListener('scroll', updateRect, true);
+    }
     return () => {
       window.removeEventListener('resize', updateRect);
+      if (listenScroll) {
+        window.removeEventListener('scroll', updateRect, true);
+      }
     };
-  }, [ref]);
+  }, [ref, listenScroll]);
 
   return rect;
 }

--- a/src/shared/ui/button-especials/ModeToggleButton.tsx
+++ b/src/shared/ui/button-especials/ModeToggleButton.tsx
@@ -1,12 +1,13 @@
 // src/shared/ui/button-especials/ModeToggleButton.tsx
 'use client';
 
-import React, { useRef, useState, useLayoutEffect } from 'react';
+import React, { useRef, useState, useLayoutEffect, useEffect } from 'react';
 import { motion, useMotionValue, animate, type ValueAnimationTransition } from 'framer-motion';
 import type { LucideIcon } from 'lucide-react';
 import { List, Map, DollarSign } from 'lucide-react';
 import { TooltipKeyHint } from '@/shared/ui';
 import { KEY_BINDS } from '@/shared/constants';
+import { useElementRect } from '@/shared/hooks/ui/useElementRect';
 
 type Mode = 'planner' | 'map' | 'budget';
 const modes: Mode[] = ['planner', 'map', 'budget'];
@@ -24,48 +25,44 @@ interface ModeToggleButtonProps {
 
 export default function ModeToggleButton({ value, onChange }: ModeToggleButtonProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const containerRect = useElementRect(containerRef, true);
   const highlightX = useMotionValue(0);
   const highlightW = useMotionValue(0);
   const isFirst = useRef(true);
   const [ready, setReady] = useState(false);
 
+  useEffect(() => {
+    if (containerRect) setReady(true);
+  }, [containerRect]);
+
   useLayoutEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el || !containerRect) return;
 
-    const positionIndicator = () => {
-      const btns = Array.from(el.querySelectorAll<HTMLButtonElement>('button'));
-      const idx = modes.indexOf(value);
-      const btn = btns[idx];
-      if (!btn) return;
+    const btns = Array.from(el.querySelectorAll<HTMLButtonElement>('button'));
+    const idx = modes.indexOf(value);
+    const btn = btns[idx];
+    if (!btn) return;
 
-      const { left: cLeft } = el.getBoundingClientRect();
-      const { left: bLeft, width: bWidth } = btn.getBoundingClientRect();
-      const newX = bLeft - cLeft;
-      const newW = bWidth - 8;
+    const { left: bLeft, width: bWidth } = btn.getBoundingClientRect();
+    const newX = bLeft - containerRect.left;
+    const newW = bWidth - 8;
 
-      const spring: ValueAnimationTransition<number> = {
-        type: 'spring',
-        stiffness: 300,
-        damping: 30,
-      };
-
-      if (isFirst.current) {
-        highlightX.set(newX);
-        highlightW.set(newW);
-        isFirst.current = false;
-      } else {
-        animate(highlightX, newX, spring);
-        animate(highlightW, newW, spring);
-      }
+    const spring: ValueAnimationTransition<number> = {
+      type: 'spring',
+      stiffness: 300,
+      damping: 30,
     };
 
-    positionIndicator();
-    setReady(true);
-
-    window.addEventListener('resize', positionIndicator);
-    return () => window.removeEventListener('resize', positionIndicator);
-  }, [value, highlightX, highlightW]);
+    if (isFirst.current) {
+      highlightX.set(newX);
+      highlightW.set(newW);
+      isFirst.current = false;
+    } else {
+      animate(highlightX, newX, spring);
+      animate(highlightW, newW, spring);
+    }
+  }, [value, containerRect, highlightX, highlightW]);
 
   return (
     <div className="inline-flex">

--- a/tests/unit/shared/hooks/ui/useElementRect.test.ts
+++ b/tests/unit/shared/hooks/ui/useElementRect.test.ts
@@ -30,3 +30,25 @@ test('returns bounding rect and updates on resize', () => {
 
   expect(result.current).toEqual(second);
 });
+
+test('updates on scroll when enabled', () => {
+  const ref = React.createRef<HTMLDivElement>();
+  const first = new DOMRect(0, 0, 100, 100);
+  const second = new DOMRect(0, 0, 150, 120);
+
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    .mockReturnValueOnce(first)
+    .mockReturnValue(second);
+
+  const { result } = renderHook(() => useElementRect(ref, true), {
+    wrapper: ({ children }) => React.createElement('div', { ref }, children),
+  });
+
+  expect(result.current).toEqual(first);
+
+  act(() => {
+    window.dispatchEvent(new Event('scroll'));
+  });
+
+  expect(result.current).toEqual(second);
+});


### PR DESCRIPTION
## Summary
- allow `useElementRect` to update on scroll via optional flag
- use the updated hook in `ModeToggleButton` and `ActivityCardEditorOverlay`
- cover scroll updates with a new unit test

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa74fbca9883228d6e948464f2f4ea