### PR TITLE
feat: add closeOnEscape handling to Modal

### DIFF
--- a/src/features/budget/components/activities/ActivitiesBudget.tsx
+++ b/src/features/budget/components/activities/ActivitiesBudget.tsx
@@ -5,7 +5,6 @@ import React, { useMemo, useState, useEffect, useRef } from 'react';
 import { DollarSign } from 'lucide-react';
 
 import { Input, CloseButton, Modal } from '@/shared/ui';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 import { normalizeAmount } from '@/shared/utils';
 import type { DayPlan } from '@/shared/types';
 
@@ -17,8 +16,6 @@ interface ActivitiesBudgetProps {
 }
 
 export default function ActivitiesBudget({ open, days, onUpdate, onClose }: ActivitiesBudgetProps) {
-  useEscapeKey({ onClose, isActive: open });
-
   const activities = useMemo(
     () => days.flatMap((day) => day.activities.map((a) => ({ ...a, dayLabel: day.label }))),
     [days]

--- a/src/features/home/components/Hero.tsx
+++ b/src/features/home/components/Hero.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import PlanForm from './PlanForm';
 import { Button, CloseButton, Modal } from '@/shared/ui';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 
 export default function Hero() {
   const [open, setOpen] = useState(false);
@@ -21,7 +20,6 @@ export default function Hero() {
   }, []);
   const openForm = () => setOpen(true);
   const closeForm = () => setOpen(false);
-  useEscapeKey({ onClose: closeForm, isActive: open });
   return (
     <section className="relative mx-auto w-full max-w-screen-lg overflow-hidden px-6 pt-24 sm:pt-28 lg:pt-32">
       {/* Left column */}

--- a/src/features/onboarding/components/OnboardingModal.tsx
+++ b/src/features/onboarding/components/OnboardingModal.tsx
@@ -4,12 +4,10 @@
 import React from 'react';
 import { OnboardingCarousel, useOnboardingContext } from '@/features/onboarding';
 import { CloseButton, Modal } from '@/shared/ui';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 
 export default function OnboardingModal() {
   const { showOnboarding: open, setShowOnboarding } = useOnboardingContext();
   const onClose = () => setShowOnboarding(false);
-  useEscapeKey({ onClose, isActive: open });
 
   return (
     <Modal

--- a/src/features/planner/components/catalog/DestinationFilterPanel.tsx
+++ b/src/features/planner/components/catalog/DestinationFilterPanel.tsx
@@ -6,7 +6,6 @@ import { DestinationHeader, DestinationResultsList, CategoryFilterBar } from '@/
 import { Modal } from '@/shared/ui';
 import type { CatalogActivity } from '@/shared/types';
 import { useDestinationCatalog, useActivitiesById, usePlannerContext } from '@/features/planner';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
 import { computeCatalogScore } from '@/shared/lib';
 
@@ -55,7 +54,6 @@ export default function DestinationFilterPanel({ isOpen, onClose }: DestinationF
     return items;
   }, [activities, search, selectedCats, sort]);
 
-  useEscapeKey({ onClose, isActive: isOpen });
   // Preserve scroll position so the list doesn't jump after adding/removing
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const scrollPosRef = useRef(0);

--- a/src/features/planner/components/modal/ActivityModal.tsx
+++ b/src/features/planner/components/modal/ActivityModal.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 import { ActivityModalHeader, ActivityModalForm, usePlannerContext } from '@/features/planner';
 import { Modal } from '@/shared/ui';
 import type { Activity, CatalogActivity } from '@/shared/types';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 
 export default function ActivityModal() {
   const {
@@ -19,7 +18,6 @@ export default function ActivityModal() {
     changePosition,
   } = usePlannerContext();
   const open = Boolean(activity);
-  useEscapeKey({ onClose: closeModal, isActive: open });
 
   const [draft, setDraft] = useState(activity ?? ({} as Activity));
 

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -4,6 +4,7 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import FocusTrap from 'focus-trap-react';
+import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 import { cn } from '@/shared/utils';
 
 interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -13,6 +14,8 @@ interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   withOverlay?: boolean;
   /** Called when the user requests to close the modal */
   onClose?: () => void;
+  /** Close the modal when the Escape key is pressed */
+  closeOnEscape?: boolean;
   /** Additional classes for the backdrop element */
   overlayClassName?: string;
   /** Classes for the wrapper that centers the modal */
@@ -23,6 +26,7 @@ export default function Modal({
   open = true,
   withOverlay = true,
   onClose,
+  closeOnEscape = true,
   overlayClassName,
   wrapperClassName,
   className,
@@ -30,6 +34,11 @@ export default function Modal({
   ...props
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEscapeKey({
+    onClose: onClose ?? (() => {}),
+    isActive: Boolean(open && onClose && closeOnEscape),
+  });
 
   if (!open) return null;
 


### PR DESCRIPTION
## Summary
- add `closeOnEscape` prop to Modal and handle Escape key internally
- remove individual `useEscapeKey` usage from modal consumers

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa79465ebc8322b4ccc66eb4850c34