### PR TITLE
♻️ Refactor activity card popup controls

### DIFF
--- a/src/features/planner/components/dnd/ActivityCardEditing.tsx
+++ b/src/features/planner/components/dnd/ActivityCardEditing.tsx
@@ -5,8 +5,8 @@ import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { Palette, ArrowLeftRight, Trash2 } from 'lucide-react';
 import type { Activity, DayPlan, CatalogActivity } from '@/shared/types';
-import { Button, CardColorsPopup, DayPickerPopup } from '@/shared/ui';
-import { useCardPopups } from '@/shared/hooks/ui/useCardPopups';
+import { Button } from '@/shared/ui';
+import { useActivityPopupControls } from '@/shared/hooks/ui/useActivityPopupControls';
 import { useElementRect } from '@/shared/hooks/ui/useElementRect';
 import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
 import { cn } from '@/shared/utils';
@@ -44,13 +44,21 @@ export default function ActivityCardEditing({
   const {
     colorButtonRef,
     dateButtonRef,
-    activePopup,
-    setActivePopup,
     handleColorButtonClick,
     handleDateButtonClick,
-  } = useCardPopups();
-  const isColorPickerOpen = activePopup === 'color';
-  const isDatePickerOpen = activePopup === 'date';
+    ColorPopup,
+    DayPopup,
+  } = useActivityPopupControls({
+    activity,
+    availableDays,
+    bgColor,
+    imageUrl: editedImageUrl,
+    onChangeColor,
+    onChangeDay,
+    onChangePosition,
+    onChangeImage: (url: string) => setEditedImageUrl(url),
+    onClearImage: () => setEditedImageUrl(''),
+  });
   const buttonContainerRef = useRef<HTMLDivElement>(null);
   const cardRect = useElementRect(cardRef);
   const buttonRect = useElementRect(buttonContainerRef);
@@ -59,9 +67,6 @@ export default function ActivityCardEditing({
 
   const gap = 8;
   const buttonGroupWidth = buttonRect?.width ?? 160;
-
-  const currentDay = availableDays.find((d) => d.id === activity.dayId);
-  const currentIndex = currentDay?.activities.findIndex((a) => a.id === activity.id) ?? -1;
 
   const position =
     cardRect && window.innerWidth - cardRect.right - gap >= buttonGroupWidth ? 'right' : 'left';
@@ -107,22 +112,7 @@ export default function ActivityCardEditing({
             Move
           </Button>
           <div className="relative mb-1">
-            {isDatePickerOpen && availableDays?.length > 0 && (
-              <div className="absolute top-1 left-full z-50">
-                <DayPickerPopup
-                  days={availableDays}
-                  selected={activity.dayId}
-                  selectedIndex={currentIndex}
-                  onSelect={(dayId: string) => {
-                    onChangeDay(dayId);
-                    setActivePopup(null);
-                  }}
-                  onSelectIndex={(idx: number) => onChangePosition(idx)}
-                  onClose={() => setActivePopup(null)}
-                  triggerRef={dateButtonRef}
-                />
-              </div>
-            )}
+            {DayPopup && <div className="absolute top-1 left-full z-50">{DayPopup}</div>}
           </div>
 
           <Button
@@ -136,22 +126,7 @@ export default function ActivityCardEditing({
             Card Colors
           </Button>
           <div className="relative mb-1">
-            {isColorPickerOpen && (
-              <div className="absolute top-1 left-full z-50">
-                <CardColorsPopup
-                  imageUrl={editedImageUrl}
-                  onChangeImage={(url: string) => setEditedImageUrl(url)}
-                  onClearImage={() => setEditedImageUrl('')}
-                  selectedColor={bgColor}
-                  onChangeColor={(selectedColor: string) => {
-                    onChangeColor(selectedColor);
-                    setActivePopup(null);
-                  }}
-                  onClose={() => setActivePopup(null)}
-                  triggerRef={colorButtonRef}
-                />
-              </div>
-            )}
+            {ColorPopup && <div className="absolute top-1 left-full z-50">{ColorPopup}</div>}
           </div>
 
           <Button size="sm" variant="icon" type="button" onClick={onDelete}>

--- a/src/features/planner/components/modal/ActivityModalHeader.tsx
+++ b/src/features/planner/components/modal/ActivityModalHeader.tsx
@@ -4,8 +4,8 @@
 import React, { useState, useEffect } from 'react';
 import type { Activity, DayPlan, CatalogActivity } from '@/shared/types';
 import Image from 'next/image';
-import { useCardPopups } from '@/shared/hooks/ui/useCardPopups';
 import { useFlexibleRef } from '@/shared/hooks/ui/useFlexibleRef';
+import { useActivityPopupControls } from '@/shared/hooks/ui/useActivityPopupControls';
 import { ChevronDown } from 'lucide-react';
 import { isTouchDevice } from '@/shared/utils';
 
@@ -14,8 +14,6 @@ import {
   RemoveCardButton,
   CloseButton,
   CardColorButton,
-  CardColorsPopup,
-  DayPickerPopup,
   CatalogSearchPopup,
 } from '@/shared/ui';
 
@@ -46,19 +44,34 @@ export default function ActivityModalHeader({
   onCatalogSelect: (item: CatalogActivity) => void;
   onImageChange: (url: string) => void;
 }) {
+  const [editedImageUrl, setEditedImageUrl] = useState(activity.imageUrl ?? '');
+
   const {
     colorButtonRef,
     dateButtonRef,
-    activePopup,
-    setActivePopup,
     handleColorButtonClick,
     handleDateButtonClick,
-  } = useCardPopups();
-  const isColorPickerOpen = activePopup === 'color';
-  const isDatePickerOpen = activePopup === 'date';
+    ColorPopup,
+    DayPopup,
+  } = useActivityPopupControls({
+    activity,
+    availableDays,
+    bgColor,
+    imageUrl: editedImageUrl,
+    onChangeColor: onColorChange,
+    onChangeDay,
+    onChangePosition,
+    onChangeImage: (url: string) => {
+      setEditedImageUrl(url);
+      onImageChange(url);
+    },
+    onClearImage: () => {
+      setEditedImageUrl('');
+      onImageChange('');
+    },
+  });
   const searchButtonRef = useFlexibleRef();
   const [isCatalogOpen, setIsCatalogOpen] = useState(false);
-  const [editedImageUrl, setEditedImageUrl] = useState(activity.imageUrl ?? '');
   const [showRemove, setShowRemove] = useState(false);
 
   // Keep local image state in sync with the selected activity
@@ -67,8 +80,6 @@ export default function ActivityModalHeader({
   }, [activity.imageUrl]);
 
   const currentDayLabel = availableDays.find((d) => d.id === activity.dayId)?.label;
-  const currentDay = availableDays.find((d) => d.id === activity.dayId);
-  const currentIndex = currentDay?.activities.findIndex((a) => a.id === activity.id) ?? -1;
 
   return (
     <>
@@ -128,44 +139,8 @@ export default function ActivityModalHeader({
           </div>
         </div>
 
-        {isColorPickerOpen && (
-          <div className="absolute top-[3rem] right-[1rem] z-50">
-            <CardColorsPopup
-              imageUrl={editedImageUrl}
-              onChangeImage={(url: string) => {
-                setEditedImageUrl(url);
-                onImageChange(url);
-              }}
-              onClearImage={() => {
-                setEditedImageUrl('');
-                onImageChange('');
-              }}
-              selectedColor={bgColor}
-              onChangeColor={(selectedColor: string) => {
-                onColorChange(selectedColor);
-                setActivePopup(null);
-              }}
-              onClose={() => setActivePopup(null)}
-              triggerRef={colorButtonRef}
-            />
-          </div>
-        )}
-        {isDatePickerOpen && availableDays?.length > 0 && (
-          <div className="absolute top-[3rem] left-[1rem] z-50">
-            <DayPickerPopup
-              days={availableDays}
-              selected={activity.dayId}
-              selectedIndex={currentIndex}
-              onSelect={(dayId: string) => {
-                onChangeDay(dayId);
-                setActivePopup(null);
-              }}
-              onSelectIndex={(idx: number) => onChangePosition(idx)}
-              onClose={() => setActivePopup(null)}
-              triggerRef={dateButtonRef}
-            />
-          </div>
-        )}
+        {ColorPopup && <div className="absolute top-[3rem] right-[1rem] z-50">{ColorPopup}</div>}
+        {DayPopup && <div className="absolute top-[3rem] left-[1rem] z-50">{DayPopup}</div>}
         {isCatalogOpen && (
           <div className="absolute top-[3rem] right-[3rem] z-50">
             <CatalogSearchPopup

--- a/src/shared/hooks/ui/useActivityPopupControls.tsx
+++ b/src/shared/hooks/ui/useActivityPopupControls.tsx
@@ -1,0 +1,90 @@
+// src/shared/hooks/ui/useActivityPopupControls.ts
+'use client';
+
+import React from 'react';
+import type { Activity, DayPlan } from '@/shared/types';
+import { CardColorsPopup, DayPickerPopup } from '@/shared/ui';
+import { useCardPopups } from './useCardPopups';
+
+interface Props {
+  activity: Activity & { dayId?: string };
+  availableDays: DayPlan[];
+  bgColor: string;
+  imageUrl?: string;
+  onChangeColor: (color: string) => void;
+  onChangeDay: (dayId: string) => void;
+  onChangePosition: (index: number) => void;
+  onChangeImage?: (url: string) => void;
+  onClearImage?: () => void;
+}
+
+/**
+ * Provides refs and popup components for activity cards.
+ * Encapsulates color and day picker logic to reduce duplication.
+ */
+export function useActivityPopupControls({
+  activity,
+  availableDays,
+  bgColor,
+  imageUrl,
+  onChangeColor,
+  onChangeDay,
+  onChangePosition,
+  onChangeImage,
+  onClearImage,
+}: Props) {
+  const {
+    colorButtonRef,
+    dateButtonRef,
+    activePopup,
+    setActivePopup,
+    handleColorButtonClick,
+    handleDateButtonClick,
+  } = useCardPopups();
+
+  const isColorPickerOpen = activePopup === 'color';
+  const isDatePickerOpen = activePopup === 'date';
+
+  const currentDay = availableDays.find((d) => d.id === activity.dayId);
+  const currentIndex = currentDay?.activities.findIndex((a) => a.id === activity.id) ?? -1;
+
+  const ColorPopup = isColorPickerOpen ? (
+    <CardColorsPopup
+      imageUrl={imageUrl ?? ''}
+      onChangeImage={(url: string) => onChangeImage?.(url)}
+      onClearImage={() => onClearImage?.()}
+      selectedColor={bgColor}
+      onChangeColor={(selectedColor: string) => {
+        onChangeColor(selectedColor);
+        setActivePopup(null);
+      }}
+      onClose={() => setActivePopup(null)}
+      triggerRef={colorButtonRef}
+    />
+  ) : null;
+
+  const DayPopup =
+    isDatePickerOpen && availableDays.length > 0 ? (
+      <DayPickerPopup
+        days={availableDays}
+        selected={activity.dayId}
+        selectedIndex={currentIndex}
+        onSelect={(dayId: string) => {
+          onChangeDay(dayId);
+          setActivePopup(null);
+        }}
+        onSelectIndex={(idx: number) => onChangePosition(idx)}
+        onClose={() => setActivePopup(null)}
+        triggerRef={dateButtonRef}
+      />
+    ) : null;
+
+  return {
+    colorButtonRef,
+    dateButtonRef,
+    handleColorButtonClick,
+    handleDateButtonClick,
+    ColorPopup,
+    DayPopup,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add `useActivityPopupControls` hook to centralize color/day popup state
- integrate popup control hook in `ActivityModalHeader` and `ActivityCardEditing`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7b3595a08322a9958615e93d4ba4