### PR TITLE
♻️ Simplify useElementRect hook

### DIFF
--- a/src/features/planner/components/dnd/ActivityCardEditorOverlay.tsx
+++ b/src/features/planner/components/dnd/ActivityCardEditorOverlay.tsx
@@ -20,7 +20,7 @@ export default function ActivityCardEditorOverlay({
   onClose,
   children,
 }: Props) {
-  const rect = useElementRect(cardRef, true);
+  const rect = useElementRect(cardRef);
 
   if (!open || !rect) return null;
 

--- a/src/shared/hooks/ui/useElementRect.ts
+++ b/src/shared/hooks/ui/useElementRect.ts
@@ -7,10 +7,7 @@ import { useState, useEffect, RefObject } from 'react';
  * It updates the rect on window resize or when the element changes.
  */
 
-export function useElementRect<T extends HTMLElement = HTMLElement>(
-  ref: RefObject<T | null>,
-  listenScroll = false
-) {
+export function useElementRect<T extends HTMLElement = HTMLElement>(ref: RefObject<T | null>) {
   const [rect, setRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
@@ -25,16 +22,12 @@ export function useElementRect<T extends HTMLElement = HTMLElement>(
     updateRect();
 
     window.addEventListener('resize', updateRect);
-    if (listenScroll) {
-      window.addEventListener('scroll', updateRect, true);
-    }
+    window.addEventListener('scroll', updateRect, true);
     return () => {
       window.removeEventListener('resize', updateRect);
-      if (listenScroll) {
-        window.removeEventListener('scroll', updateRect, true);
-      }
+      window.removeEventListener('scroll', updateRect, true);
     };
-  }, [ref, listenScroll]);
+  }, [ref]);
 
   return rect;
 }

--- a/src/shared/ui/button-especials/ModeToggleButton.tsx
+++ b/src/shared/ui/button-especials/ModeToggleButton.tsx
@@ -25,7 +25,7 @@ interface ModeToggleButtonProps {
 
 export default function ModeToggleButton({ value, onChange }: ModeToggleButtonProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const containerRect = useElementRect(containerRef, true);
+  const containerRect = useElementRect(containerRef);
   const highlightX = useMotionValue(0);
   const highlightW = useMotionValue(0);
   const isFirst = useRef(true);

--- a/tests/unit/shared/hooks/ui/useElementRect.test.ts
+++ b/tests/unit/shared/hooks/ui/useElementRect.test.ts
@@ -31,7 +31,7 @@ test('returns bounding rect and updates on resize', () => {
   expect(result.current).toEqual(second);
 });
 
-test('updates on scroll when enabled', () => {
+test('updates on scroll', () => {
   const ref = React.createRef<HTMLDivElement>();
   const first = new DOMRect(0, 0, 100, 100);
   const second = new DOMRect(0, 0, 150, 120);
@@ -40,7 +40,7 @@ test('updates on scroll when enabled', () => {
     .mockReturnValueOnce(first)
     .mockReturnValue(second);
 
-  const { result } = renderHook(() => useElementRect(ref, true), {
+  const { result } = renderHook(() => useElementRect(ref), {
     wrapper: ({ children }) => React.createElement('div', { ref }, children),
   });
 


### PR DESCRIPTION
## Summary
- remove `listenScroll` argument from `useElementRect` and always track scroll
- adjust `ModeToggleButton` and `ActivityCardEditorOverlay` to new hook signature
- update tests for the revised hook API

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Error: boom in tests/integration/api/catalog.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7b849fac8322a4f5b2fca08ebb45