### PR TITLE
✨ Monitor element size with ResizeObserver

### DIFF
--- a/src/shared/hooks/ui/useElementRect.ts
+++ b/src/shared/hooks/ui/useElementRect.ts
@@ -4,14 +4,15 @@ import { useState, useEffect, RefObject } from 'react';
 
 /**
  * Hook that tracks the bounding client rect of a DOM element.
- * It updates the rect on window resize or when the element changes.
+ * It updates the rect on element resize and scroll to track position.
  */
 
 export function useElementRect<T extends HTMLElement = HTMLElement>(ref: RefObject<T | null>) {
   const [rect, setRect] = useState<DOMRect | null>(null);
 
   useEffect(() => {
-    if (!ref.current) return;
+    const element = ref.current;
+    if (!element) return;
 
     const updateRect = () => {
       if (ref.current) {
@@ -21,10 +22,13 @@ export function useElementRect<T extends HTMLElement = HTMLElement>(ref: RefObje
 
     updateRect();
 
-    window.addEventListener('resize', updateRect);
+    const resizeObserver = new ResizeObserver(updateRect);
+    resizeObserver.observe(element);
+
     window.addEventListener('scroll', updateRect, true);
+
     return () => {
-      window.removeEventListener('resize', updateRect);
+      resizeObserver.disconnect();
       window.removeEventListener('scroll', updateRect, true);
     };
   }, [ref]);

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -7,6 +7,15 @@ process.env.NEXT_PUBLIC_GEOAPIFY_KEY =
 import '@testing-library/jest-dom';
 import React from 'react';
 
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver =
+  ResizeObserverMock;
+
 vi.mock('focus-trap-react', () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));


### PR DESCRIPTION
## Summary
- observe element size with ResizeObserver
- mock ResizeObserver for tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7e8cdd98832294bded08e2ff8e68