### PR TITLE
♻️ Refactor modal and popup to share overlay container

### DIFF
--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,26 +1,12 @@
 // src/shared/ui/Modal.tsx
 'use client';
 
-import React, { useRef } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import FocusTrap from 'focus-trap-react';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
+import OverlayContainer from './OverlayContainer';
 import { cn } from '@/shared/utils';
 
-interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Control visibility and FocusTrap activation */
-  open?: boolean;
-  /** Render a backdrop element behind the modal */
-  withOverlay?: boolean;
-  /** Called when the user requests to close the modal */
-  onClose?: () => void;
-  /** Close the modal when the Escape key is pressed */
-  closeOnEscape?: boolean;
-  /** Additional classes for the backdrop element */
-  overlayClassName?: string;
-  /** Classes for the wrapper that centers the modal */
-  wrapperClassName?: string;
-}
+interface ModalProps extends React.ComponentProps<typeof OverlayContainer> {}
 
 export default function Modal({
   open = true,
@@ -33,55 +19,24 @@ export default function Modal({
   children,
   ...props
 }: ModalProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEscapeKey({
-    onClose: onClose ?? (() => {}),
-    isActive: Boolean(open && onClose && closeOnEscape),
-  });
-
   if (!open) return null;
 
-  const dialog = (
-    <FocusTrap
-      active={open}
-      focusTrapOptions={{
-        clickOutsideDeactivates: true,
-        escapeDeactivates: false,
-        initialFocus: false,
-        fallbackFocus: () => containerRef.current ?? document.body,
-        tabbableOptions: { displayCheck: 'none' },
-      }}
-    >
-      <div
-        ref={containerRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className={cn(
-          'bg-background focus:ring-primary rounded-lg shadow-xl focus:ring-2 focus:outline-none',
-          className
-        )}
-        onClick={(e) => e.stopPropagation()}
-        {...props}
-      >
-        {children}
-      </div>
-    </FocusTrap>
-  );
-
   return ReactDOM.createPortal(
-    <>
-      {withOverlay && (
-        <div className={cn('backdrop-overlay', overlayClassName)} onClick={onClose} />
+    <OverlayContainer
+      open={open}
+      withOverlay={withOverlay}
+      onClose={onClose}
+      closeOnEscape={closeOnEscape}
+      overlayClassName={overlayClassName}
+      wrapperClassName={wrapperClassName}
+      className={cn(
+        'bg-background focus:ring-primary rounded-lg shadow-xl focus:ring-2 focus:outline-none',
+        className
       )}
-      <div
-        className={cn('fixed inset-0 z-50 flex items-center justify-center', wrapperClassName)}
-        onClick={onClose}
-      >
-        {dialog}
-      </div>
-    </>,
+      {...props}
+    >
+      {children}
+    </OverlayContainer>,
     document.body
   );
 }

--- a/src/shared/ui/OverlayContainer.tsx
+++ b/src/shared/ui/OverlayContainer.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import FocusTrap from 'focus-trap-react';
+import { cn } from '@/shared/utils';
+import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
+
+interface OverlayContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Control visibility and FocusTrap activation */
+  open?: boolean;
+  /** Render a backdrop element behind the content */
+  withOverlay?: boolean;
+  /** Called when the user requests to close the overlay */
+  onClose?: () => void;
+  /** Close when the Escape key is pressed */
+  closeOnEscape?: boolean;
+  /** Ref to the element that triggered the overlay */
+  triggerRef?: React.RefObject<HTMLElement>;
+  /** Additional classes for the overlay element */
+  overlayClassName?: string;
+  /** Classes for the wrapper that centers the content */
+  wrapperClassName?: string;
+}
+
+const OverlayContainer = forwardRef<HTMLDivElement, OverlayContainerProps>(
+  (
+    {
+      open = true,
+      withOverlay = true,
+      onClose,
+      closeOnEscape = true,
+      overlayClassName,
+      wrapperClassName,
+      className,
+      triggerRef,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    useImperativeHandle(ref, () => containerRef.current!);
+
+    useEscapeKey({
+      onClose: onClose ?? (() => {}),
+      isActive: Boolean(open && onClose && closeOnEscape),
+      triggerRef,
+    });
+
+    if (!open) return null;
+
+    const content = (
+      <FocusTrap
+        active={open}
+        focusTrapOptions={{
+          clickOutsideDeactivates: true,
+          escapeDeactivates: false,
+          initialFocus: false,
+          fallbackFocus: () => containerRef.current ?? document.body,
+          tabbableOptions: { displayCheck: 'none' },
+        }}
+      >
+        <div
+          ref={containerRef}
+          role="dialog"
+          aria-modal="true"
+          tabIndex={-1}
+          className={cn(className)}
+          onClick={(e) => e.stopPropagation()}
+          {...props}
+        >
+          {children}
+        </div>
+      </FocusTrap>
+    );
+
+    return withOverlay ? (
+      <>
+        <div className={cn('backdrop-overlay', overlayClassName)} onClick={onClose} />
+        <div
+          className={cn('fixed inset-0 z-50 flex items-center justify-center', wrapperClassName)}
+          onClick={onClose}
+        >
+          {content}
+        </div>
+      </>
+    ) : (
+      content
+    );
+  }
+);
+
+OverlayContainer.displayName = 'OverlayContainer';
+
+export default OverlayContainer;

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -11,6 +11,7 @@ export { default as TooltipKeyHint } from './TooltipKeyHint';
 export { default as Spinner } from './Spinner';
 export { default as Modal } from './Modal';
 export { default as LocationSearchInput } from './LocationSearchInput';
+export { default as OverlayContainer } from './OverlayContainer';
 
 // Icons components
 export { default as CardColorButton } from './button-icons/CardColorButton';

--- a/src/shared/ui/popups/Popup.tsx
+++ b/src/shared/ui/popups/Popup.tsx
@@ -2,11 +2,10 @@
 'use client';
 
 import React, { useRef } from 'react';
-import FocusTrap from 'focus-trap-react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/utils';
 import { usePopupOutsideHandler } from '@/shared/hooks/ui/usePopupOutsideHandler';
-import { useEscapeKey } from '@/shared/hooks/ui/useEscapeKey';
+import OverlayContainer from '../OverlayContainer';
 
 /** Popup style variants */
 export const popupVariants = cva(
@@ -26,21 +25,8 @@ export const popupVariants = cva(
 );
 
 interface PopupProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof popupVariants> {
-  /**
-   * Control visibility and FocusTrap activation.
-   * If undefined the popup is always rendered.
-   */
-  open?: boolean;
-  /** Overlay element shown behind the popup */
-  withOverlay?: boolean;
-  /** Ref to trigger element for outside click handling */
-  triggerRef?: React.RefObject<HTMLElement>;
-  /** Called when user requests to close the popup */
-  onClose?: () => void;
-  overlayClassName?: string;
-}
+  extends React.ComponentProps<typeof OverlayContainer>,
+    VariantProps<typeof popupVariants> {}
 
 export default function Popup({
   open = true,
@@ -56,43 +42,19 @@ export default function Popup({
   const popupRef = useRef<HTMLDivElement>(null);
 
   usePopupOutsideHandler({ popupRef, triggerRef, onClose: onClose ?? (() => {}), isOpen: open });
-  useEscapeKey({ onClose: onClose ?? (() => {}), isActive: open, triggerRef });
 
-  if (!open) return null;
-
-  const popup = (
-    <FocusTrap
-      active={open}
-      focusTrapOptions={{
-        clickOutsideDeactivates: true,
-        escapeDeactivates: false,
-        initialFocus: false,
-        fallbackFocus: () => popupRef.current ?? document.body,
-        tabbableOptions: { displayCheck: 'none' },
-      }}
+  return (
+    <OverlayContainer
+      ref={popupRef}
+      open={open}
+      withOverlay={withOverlay}
+      onClose={onClose}
+      overlayClassName={overlayClassName}
+      className={cn(popupVariants({ size }), className)}
+      triggerRef={triggerRef}
+      {...props}
     >
-      <div
-        ref={popupRef}
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className={cn(popupVariants({ size }), className)}
-        onClick={(e) => e.stopPropagation()}
-        {...props}
-      >
-        {children}
-      </div>
-    </FocusTrap>
-  );
-
-  return withOverlay ? (
-    <div
-      className={cn('backdrop-overlay flex items-center justify-center', overlayClassName)}
-      onClick={onClose}
-    >
-      {popup}
-    </div>
-  ) : (
-    popup
+      {children}
+    </OverlayContainer>
   );
 }


### PR DESCRIPTION
## Summary
- extract reusable OverlayContainer with focus trap, escape key and optional backdrop
- refactor Modal and Popup to leverage OverlayContainer and remove duplicate logic

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7fe381648322936d10edd81cc1e8