### PR TITLE
♻️ Simplify context providers with generator

### DIFF
--- a/src/features/budget/hooks/BudgetContext.tsx
+++ b/src/features/budget/hooks/BudgetContext.tsx
@@ -1,32 +1,25 @@
 // src/features/budget/hooks/BudgetContext.tsx
 'use client';
 
-import React, { ReactNode } from 'react';
-import { createStrictContext } from '@/shared/context/createStrictContext';
+import { createContextProvider } from '@/shared/context/createContextProvider';
 import { useBudget } from './useBudgetSupabase';
 import type { Entry } from '@/features/budget/types';
 
-const [BudgetContextProvider, useBudgetContext] = createStrictContext<ReturnType<typeof useBudget>>(
+const [BudgetProvider, useBudgetContext] = createContextProvider(
+  ({
+    planId,
+    activitiesTotal,
+    initialBudget,
+    initialEntries,
+    persist = true,
+  }: {
+    planId: string;
+    activitiesTotal: number;
+    initialBudget?: number;
+    initialEntries?: Entry[];
+    persist?: boolean;
+  }) => useBudget(planId, activitiesTotal, { initialBudget, initialEntries, persist }),
   'useBudgetContext must be inside BudgetProvider'
 );
 
-export function BudgetProvider({
-  children,
-  planId,
-  activitiesTotal,
-  initialBudget,
-  initialEntries,
-  persist = true,
-}: {
-  children: ReactNode;
-  planId: string;
-  activitiesTotal: number;
-  initialBudget?: number;
-  initialEntries?: Entry[];
-  persist?: boolean;
-}) {
-  const value = useBudget(planId, activitiesTotal, { initialBudget, initialEntries, persist });
-  return <BudgetContextProvider value={value}>{children}</BudgetContextProvider>;
-}
-
-export { useBudgetContext };
+export { BudgetProvider, useBudgetContext };

--- a/src/features/onboarding/hooks/OnboardingContext.tsx
+++ b/src/features/onboarding/hooks/OnboardingContext.tsx
@@ -1,17 +1,12 @@
 // src/features/onboarding/hooks/OnboardingContext.tsx
 'use client';
 
-import React, { ReactNode } from 'react';
-import { createStrictContext } from '@/shared/context/createStrictContext';
+import { createContextProvider } from '@/shared/context/createContextProvider';
 import { useOnboardingCheck } from './useOnboardingCheck';
 
-const [OnboardingContextProvider, useOnboardingContext] = createStrictContext<
-  ReturnType<typeof useOnboardingCheck>
->('useOnboardingContext must be inside OnboardingProvider');
+const [OnboardingProvider, useOnboardingContext] = createContextProvider(
+  ({ planId }: { planId: string }) => useOnboardingCheck(planId),
+  'useOnboardingContext must be inside OnboardingProvider'
+);
 
-export function OnboardingProvider({ planId, children }: { planId: string; children: ReactNode }) {
-  const value = useOnboardingCheck(planId);
-  return <OnboardingContextProvider value={value}>{children}</OnboardingContextProvider>;
-}
-
-export { useOnboardingContext };
+export { OnboardingProvider, useOnboardingContext };

--- a/src/features/planner/hooks/PlannerContext.tsx
+++ b/src/features/planner/hooks/PlannerContext.tsx
@@ -1,31 +1,25 @@
 // src/features/planner/hooks/PlannerContext.tsx
 'use client';
 
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { usePlanner, useSelectedActivity, usePlanDays } from '@/features/planner';
 import { useDebounce } from '@/shared/hooks/useDebounce';
-import { createStrictContext } from '@/shared/context/createStrictContext';
+import { createContextProvider } from '@/shared/context/createContextProvider';
 import type { DayPlan } from '@/shared/types';
 
 type PlannerCtx = ReturnType<typeof usePlanner> & ReturnType<typeof useSelectedActivity>;
 
-const [PlannerContextProvider, usePlannerContext] = createStrictContext<PlannerCtx>(
-  'usePlannerContext must be inside PlannerProvider'
-);
-
-export function PlannerProvider({
-  children,
+function usePlannerContextValue({
   initialDays,
   planId,
   dest,
   persist = true,
 }: {
-  children: ReactNode;
   initialDays?: DayPlan[];
   planId: string;
   dest?: string;
   persist?: boolean;
-}) {
+}): PlannerCtx {
   const { data: storedDays, persistDays } = usePlanDays(planId, persist);
   const planner = usePlanner({
     initialDays: (storedDays as unknown as DayPlan[]) ?? initialDays,
@@ -95,9 +89,13 @@ export function PlannerProvider({
     updateActivity: planner.updateActivity,
     addBlankActivity: planner.addBlankActivity,
   });
-  return (
-    <PlannerContextProvider value={{ ...planner, ...selected }}>{children}</PlannerContextProvider>
-  );
+
+  return { ...planner, ...selected };
 }
 
-export { usePlannerContext };
+const [PlannerProvider, usePlannerContext] = createContextProvider(
+  usePlannerContextValue,
+  'usePlannerContext must be inside PlannerProvider'
+);
+
+export { PlannerProvider, usePlannerContext };

--- a/src/shared/context/createContextProvider.tsx
+++ b/src/shared/context/createContextProvider.tsx
@@ -1,0 +1,20 @@
+import React, { type PropsWithChildren } from 'react';
+import { createStrictContext } from './createStrictContext';
+
+/**
+ * Creates a context provider and hook using the given hook to supply the value.
+ * The hook receives the provider props (excluding `children`) and returns the context value.
+ */
+export function createContextProvider<P extends object, T>(
+  useValue: (props: P) => T,
+  errorMessage: string
+) {
+  const [Provider, useContext] = createStrictContext<T>(errorMessage);
+
+  function ContextProvider({ children, ...props }: PropsWithChildren<P>) {
+    const value = useValue(props as P);
+    return <Provider value={value}>{children}</Provider>;
+  }
+
+  return [ContextProvider, useContext] as const;
+}


### PR DESCRIPTION
## Summary
- add createContextProvider utility
- reduce context boilerplate in onboarding, budget and planner modules

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8006b5c88322ab3336c4eab186c5