### PR TITLE
✨ Add local storage hook for tokens and onboarding

### DIFF
--- a/src/features/home/components/PlanForm.tsx
+++ b/src/features/home/components/PlanForm.tsx
@@ -11,7 +11,7 @@ import LoadingScreen from '@/shared/components/LoadingScreen';
 import { useRouter } from 'next/navigation';
 import { addDays } from 'date-fns';
 import { createPlan } from '@/app/planner/actions/createPlan';
-import { saveEditToken } from '@/shared/lib/planEditToken';
+import { usePlanEditTokens } from '@/shared/lib/planEditToken';
 
 export default function PlanForm() {
   const router = useRouter();
@@ -22,6 +22,7 @@ export default function PlanForm() {
   const [dest, setDest] = useState('');
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [title, setTitle] = useState('');
+  const { saveEditToken } = usePlanEditTokens();
 
   // Declare error state
   const [error, setError] = useState<string>('');

--- a/src/features/onboarding/hooks/useOnboardingCheck.ts
+++ b/src/features/onboarding/hooks/useOnboardingCheck.ts
@@ -2,21 +2,21 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
 
 /**
  * Handles onboarding modal visibility based on localStorage.
  * Shows the modal once per plan ID and persists the flag.
  */
 export function useOnboardingCheck(planId: string) {
-  const [showOnboarding, setShowOnboarding] = useState(false);
+  const key = `planner-onboarding-shown-${planId}`;
+  const [stored, setStored] = useLocalStorage<boolean>(key, false);
+  const [showOnboarding, setShowOnboarding] = useState(!stored);
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const key = `planner-onboarding-shown-${planId}`;
-    if (!localStorage.getItem(key)) {
-      setShowOnboarding(true);
-      localStorage.setItem(key, 'true');
-    }
+    setShowOnboarding(!stored);
+    if (!stored) setStored(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [planId]);
 
   return { showOnboarding, setShowOnboarding };

--- a/src/features/planner/hooks/usePlanTitleSupabase.ts
+++ b/src/features/planner/hooks/usePlanTitleSupabase.ts
@@ -3,13 +3,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/shared/lib/supabaseClient';
 import { capitalize } from '@/shared/utils';
-import { getEditToken } from '@/shared/lib/planEditToken';
+import { usePlanEditTokens } from '@/shared/lib/planEditToken';
 import { updatePlanTitle } from '@/app/planner/actions/updatePlanTitle';
 
 export function usePlanTitle(planId: string, defaultTitle = '', persist = true) {
   const initialTitle = capitalize(defaultTitle);
 
   const qc = useQueryClient();
+  const { getEditToken } = usePlanEditTokens();
 
   const { data: fetchedTitle = initialTitle } = useQuery({
     queryKey: ['plan_title', planId],

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,0 +1,31 @@
+// src/shared/hooks/useLocalStorage.ts
+'use client';
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Syncs state with localStorage for the given key.
+ * Returns the stored value and a setter that persists updates.
+ */
+export function useLocalStorage<T>(key: string, initial: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return initial;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* ignore */
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -20,3 +20,4 @@ export { pLimit } from './pLimit';
 export { supabase } from './supabaseClient';
 export { clientEnv } from './clientEnv';
 export type { ClientEnv } from './clientEnv';
+export { usePlanEditTokens } from './planEditToken';

--- a/src/shared/lib/planEditToken.ts
+++ b/src/shared/lib/planEditToken.ts
@@ -1,19 +1,19 @@
 // src/shared/lib/planEditToken.ts
+import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
 
 const KEY = 'plan_edit_tokens'; // map of plan_id -> token
 
-export function saveEditToken(planId: string, token: string) {
-  if (typeof window === 'undefined') return;
-  const raw = window.localStorage.getItem(KEY);
-  const map = raw ? (JSON.parse(raw) as Record<string, string>) : {};
-  map[planId] = token;
-  window.localStorage.setItem(KEY, JSON.stringify(map));
-}
+/**
+ * Provides helpers to persist and retrieve plan edit tokens.
+ */
+export function usePlanEditTokens() {
+  const [tokens, setTokens] = useLocalStorage<Record<string, string>>(KEY, {});
 
-export function getEditToken(planId: string): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-  const raw = window.localStorage.getItem(KEY);
-  if (!raw) return undefined;
-  const map = JSON.parse(raw) as Record<string, string>;
-  return map[planId];
+  const saveEditToken = (planId: string, token: string) => {
+    setTokens({ ...tokens, [planId]: token });
+  };
+
+  const getEditToken = (planId: string): string | undefined => tokens[planId];
+
+  return { saveEditToken, getEditToken };
 }


### PR DESCRIPTION
## Summary
- add `useLocalStorage` hook to sync state with localStorage
- refactor plan edit token logic into `usePlanEditTokens`
- update onboarding check to use persistent storage

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa837afa248322a10ac3501f40473e