### PR TITLE
✨ Add key listener hook and refactor keyboard utilities

### DIFF
--- a/src/shared/hooks/ui/useEscapeKey.ts
+++ b/src/shared/hooks/ui/useEscapeKey.ts
@@ -1,7 +1,8 @@
 // src/shared/hooks/ui/useEscapeKey.ts
 'use client';
 
-import { useEffect, useRef, RefObject } from 'react';
+import { useEffect, useRef, RefObject, useMemo } from 'react';
+import { useKeyListener } from './useKeyListener';
 
 /**
  * Attaches a keydown listener for the Escape key while the popup is open.
@@ -26,17 +27,17 @@ export function useEscapeKey({
     prevFocusedRef.current =
       (triggerRef?.current ?? (document.activeElement as HTMLElement)) || null;
 
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown);
     return () => {
-      document.removeEventListener('keydown', handleKeyDown);
       prevFocusedRef.current?.focus?.();
     };
-  }, [isActive, onClose, triggerRef]);
+  }, [isActive, triggerRef]);
+
+  const handlers = useMemo(
+    () => ({
+      Escape: onClose,
+    }),
+    [onClose]
+  );
+
+  useKeyListener({ keys: handlers, isActive });
 }

--- a/src/shared/hooks/ui/useKeyBinds.ts
+++ b/src/shared/hooks/ui/useKeyBinds.ts
@@ -1,8 +1,9 @@
 // src/shared/hooks/ui/useKeyBinds.ts
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 import { KEY_BINDS } from '@/shared/constants';
+import { useKeyListener } from './useKeyListener';
 
 interface KeyBindOptions {
   onPlanner: () => void;
@@ -26,34 +27,25 @@ export function useKeyBinds({
   onCatalog,
   isActive = true,
 }: KeyBindOptions) {
-  useEffect(() => {
-    if (!isActive) return;
-
-    const handlers: Record<string, () => void> = {
+  const handlers = useMemo(
+    () => ({
       [KEY_BINDS.planner]: onPlanner,
       [KEY_BINDS.map]: onMap,
       [KEY_BINDS.budget]: onBudget,
       [KEY_BINDS.newCard]: onNewCard,
       [KEY_BINDS.catalog]: onCatalog,
-    };
+    }),
+    [onPlanner, onMap, onBudget, onNewCard, onCatalog]
+  );
 
-    function handleKeyDown(e: KeyboardEvent) {
-      const active = document.activeElement as HTMLElement | null;
-      const isTextField =
-        active?.tagName === 'INPUT' || active?.tagName === 'TEXTAREA' || active?.isContentEditable;
+  const filter = useCallback((e: KeyboardEvent) => {
+    void e;
+    const active = document.activeElement as HTMLElement | null;
+    const isTextField =
+      active?.tagName === 'INPUT' || active?.tagName === 'TEXTAREA' || active?.isContentEditable;
 
-      if (isTextField) return;
-      const key = e.key.toLowerCase();
-      const handler = handlers[key];
-      if (handler) {
-        e.preventDefault();
-        handler();
-      }
-    }
+    return !isTextField;
+  }, []);
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isActive, onPlanner, onMap, onBudget, onNewCard, onCatalog]);
+  useKeyListener({ keys: handlers, isActive, filter });
 }

--- a/src/shared/hooks/ui/useKeyListener.ts
+++ b/src/shared/hooks/ui/useKeyListener.ts
@@ -1,0 +1,35 @@
+// src/shared/hooks/ui/useKeyListener.ts
+'use client';
+
+import { useEffect } from 'react';
+
+interface KeyListenerOptions {
+  keys: Record<string, () => void>;
+  isActive?: boolean;
+  filter?: (event: KeyboardEvent) => boolean;
+}
+
+/**
+ * Attaches a keydown listener for provided key callbacks.
+ * Normalizes single-character keys to lowercase to avoid shift issues.
+ */
+export function useKeyListener({ keys, isActive = true, filter }: KeyListenerOptions) {
+  useEffect(() => {
+    if (!isActive) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (filter && !filter(e)) return;
+      const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+      const handler = keys[key];
+      if (handler) {
+        e.preventDefault();
+        handler();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isActive, filter, keys]);
+}


### PR DESCRIPTION
## Summary
- add reusable `useKeyListener` for mapping keys to callbacks
- refactor `useEscapeKey` to use `useKeyListener`
- streamline `useKeyBinds` to delegate to `useKeyListener`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa87c74a7c83229d14beb4facccb2c