### PR TITLE
✨ Add recent plan storage and continue banner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 // src/app/page.tsx
 
-import { Hero, FeaturePreview, InspirationLink } from '@/features/home';
+import { ContinuePlanningBanner, Hero, FeaturePreview, InspirationLink } from '@/features/home';
 
 export default function Home() {
   return (
     <main id="main-content" className="space-y-16">
+      <ContinuePlanningBanner />
       <Hero />
       <FeaturePreview />
       <InspirationLink />

--- a/src/features/home/components/ContinuePlanningBanner.tsx
+++ b/src/features/home/components/ContinuePlanningBanner.tsx
@@ -1,0 +1,31 @@
+// src/features/home/components/ContinuePlanningBanner.tsx
+'use client';
+
+import Link from 'next/link';
+import { differenceInCalendarDays } from 'date-fns';
+
+import { Button } from '@/shared/ui';
+import { useRecentPlan } from '@/shared/lib';
+
+export default function ContinuePlanningBanner() {
+  const { recentPlan } = useRecentPlan();
+  if (!recentPlan) return null;
+
+  const { slug, dest, start, end } = recentPlan;
+  const tripLength = differenceInCalendarDays(new Date(end), new Date(start)) + 1;
+  const query = new URLSearchParams({ dest, start, end }).toString();
+
+  return (
+    <section className="bg-card p-4 text-center">
+      <p className="pb-2">
+        Continue your {tripLength} {tripLength === 1 ? 'day' : 'days'} trip to {dest}
+      </p>
+      <Button
+        asChild
+        className="bg-[var(--accent)] text-[var(--accent-foreground)] hover:bg-[var(--accent)]/90"
+      >
+        <Link href={`/planner/${slug}?${query}`}>Continue Planning</Link>
+      </Button>
+    </section>
+  );
+}

--- a/src/features/home/components/PlanForm.tsx
+++ b/src/features/home/components/PlanForm.tsx
@@ -11,7 +11,7 @@ import LoadingScreen from '@/shared/components/LoadingScreen';
 import { useRouter } from 'next/navigation';
 import { addDays } from 'date-fns';
 import { createPlan } from '@/app/planner/actions/createPlan';
-import { usePlanEditTokens } from '@/shared/lib/planEditToken';
+import { usePlanEditTokens, useRecentPlan } from '@/shared/lib';
 
 export default function PlanForm() {
   const router = useRouter();
@@ -23,6 +23,7 @@ export default function PlanForm() {
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [title, setTitle] = useState('');
   const { saveEditToken } = usePlanEditTokens();
+  const { saveRecentPlan } = useRecentPlan();
 
   // Declare error state
   const [error, setError] = useState<string>('');
@@ -77,6 +78,13 @@ export default function PlanForm() {
       );
 
       saveEditToken(planId, editToken);
+      saveRecentPlan({
+        id: planId,
+        slug: publicSlug,
+        dest: destParam,
+        start: range.from.toISOString(),
+        end: range.to.toISOString(),
+      });
 
       const query = new URLSearchParams({
         dest: destParam,

--- a/src/features/home/components/index.ts
+++ b/src/features/home/components/index.ts
@@ -4,3 +4,4 @@ export { default as Hero } from './Hero';
 export { default as PlanForm } from './PlanForm';
 export { FeaturePreview } from './feature-preview';
 export { default as InspirationLink } from './InspirationLink';
+export { default as ContinuePlanningBanner } from './ContinuePlanningBanner';

--- a/src/features/home/index.ts
+++ b/src/features/home/index.ts
@@ -1,3 +1,9 @@
 // src/features/home/index.ts
 
-export { Hero, PlanForm, FeaturePreview, InspirationLink } from './components';
+export {
+  Hero,
+  PlanForm,
+  FeaturePreview,
+  InspirationLink,
+  ContinuePlanningBanner,
+} from './components';

--- a/src/features/onboarding/hooks/useOnboardingCheck.ts
+++ b/src/features/onboarding/hooks/useOnboardingCheck.ts
@@ -10,12 +10,12 @@ import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
  */
 export function useOnboardingCheck(planId: string) {
   const key = `planner-onboarding-shown-${planId}`;
-  const [stored, setStored] = useLocalStorage<boolean>(key, false);
-  const [showOnboarding, setShowOnboarding] = useState(!stored);
+  const [seen, setSeen] = useLocalStorage<boolean>(key, false);
+  const [showOnboarding, setShowOnboarding] = useState(!seen);
 
   useEffect(() => {
-    setShowOnboarding(!stored);
-    if (!stored) setStored(true);
+    setShowOnboarding(!seen);
+    if (!seen) setSeen(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [planId]);
 

--- a/src/shared/hooks/useRecentPlan.ts
+++ b/src/shared/hooks/useRecentPlan.ts
@@ -1,0 +1,25 @@
+// src/shared/hooks/useRecentPlan.ts
+'use client';
+
+import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
+
+export interface RecentPlan {
+  id: string;
+  slug: string;
+  dest: string;
+  start: string;
+  end: string;
+}
+
+/**
+ * Persists metadata for the most recently created plan.
+ */
+export function useRecentPlan() {
+  const [recentPlan, setRecentPlan] = useLocalStorage<RecentPlan | null>('recent_plan', null);
+
+  const saveRecentPlan = (plan: RecentPlan) => {
+    setRecentPlan(plan);
+  };
+
+  return { recentPlan, saveRecentPlan } as const;
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -21,3 +21,4 @@ export { supabase } from './supabaseClient';
 export { clientEnv } from './clientEnv';
 export type { ClientEnv } from './clientEnv';
 export { usePlanEditTokens } from './planEditToken';
+export { useRecentPlan } from '../hooks/useRecentPlan';


### PR DESCRIPTION
## Summary
- add local-storage-backed recent plan hook
- persist recent plan from the home form
- show banner on homepage to continue planning

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa888ef8d08322868088a54e454001