### PR TITLE
Refactor Supabase hooks with reusable resource wrapper

### DIFF
--- a/src/features/budget/hooks/useBudgetSupabase.ts
+++ b/src/features/budget/hooks/useBudgetSupabase.ts
@@ -1,10 +1,9 @@
 // src/features/budget/hooks/useBudgetSupabase.ts
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { supabase } from '@/shared/lib/supabaseClient';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Database } from '@/shared/types/supabase';
 import type { CategoryKey } from '@/shared/constants';
 import type { Entry } from '@/features/budget/types';
+import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
 
 export function useBudget(
   planId: string,
@@ -23,26 +22,16 @@ export function useBudget(
   const hasLoadedRef = useRef(false);
   const initialBudgetRef = useRef(0);
   const [persistError, setPersistError] = useState<string | null>(null);
-  const sb: SupabaseClient<Database> = supabase;
 
-  useEffect(() => {
-    hasLoadedRef.current = false;
-    setHasLoaded(false);
-    if (!persist) {
-      initialBudgetRef.current = initialBudget;
-      setBudget(initialBudget);
-      setEntries(initialEntries ?? []);
-      hasLoadedRef.current = true;
-      setHasLoaded(true);
-      return;
-    }
-    const load = async () => {
-      const budgetRes = (await sb
+  const { data: loaded } = useSupabaseResource<{ budget: number; entries: Entry[] }>({
+    queryKey: ['budget', planId],
+    fetcher: async (signal) => {
+      const budgetRes = (await supabase
         .from('plans')
         .select('budget')
         .eq('id', planId)
         .single()) as unknown as { data: { budget: number | null } | null };
-      const entryRes = (await sb
+      const entryRes = (await supabase
         .from('budget_entries')
         .select('*')
         .eq('plan_id', planId)) as unknown as {
@@ -55,40 +44,63 @@ export function useBudget(
             }[]
           | null;
       };
-      const loadedBudget = budgetRes.data?.budget ?? 0;
-      setBudget(loadedBudget);
-      initialBudgetRef.current = loadedBudget;
-      setEntries(
-        entryRes.data?.map((e) => ({
-          id: e.id,
-          description: e.description ?? '',
-          category: (e.category as CategoryKey) ?? 'transport',
-          amount: e.amount ?? 0,
-        })) ?? []
-      );
+      return {
+        budget: budgetRes.data?.budget ?? 0,
+        entries:
+          entryRes.data?.map((e) => ({
+            id: e.id,
+            description: e.description ?? '',
+            category: (e.category as CategoryKey) ?? 'transport',
+            amount: e.amount ?? 0,
+          })) ?? [],
+      };
+    },
+    enabled: persist,
+  });
+
+  const { mutate: saveBudget } = useSupabaseResource<number, number>({
+    queryKey: ['budget', planId],
+    persistFn: async (b, _signal) => {
+      const { error } = (await supabase
+        .from('plans')
+        .update({ budget: b })
+        .eq('id', planId)) as unknown as { error: unknown };
+      if (error) throw error;
+      return b;
+    },
+    onSuccess: (b) => {
+      initialBudgetRef.current = b as number;
+    },
+    onError: () => setPersistError('Failed to persist budget'),
+  });
+
+  useEffect(() => {
+    hasLoadedRef.current = false;
+    setHasLoaded(false);
+    if (!persist) {
+      initialBudgetRef.current = initialBudget;
+      setBudget(initialBudget);
+      setEntries(initialEntries ?? []);
       hasLoadedRef.current = true;
       setHasLoaded(true);
-    };
-    void load();
-  }, [planId, sb, persist, initialBudget, initialEntries]);
+      return;
+    }
+    if (loaded) {
+      setBudget(loaded.budget);
+      initialBudgetRef.current = loaded.budget;
+      setEntries(loaded.entries);
+      hasLoadedRef.current = true;
+      setHasLoaded(true);
+    }
+  }, [persist, initialBudget, initialEntries, loaded]);
 
   useEffect(() => {
     if (!persist) return;
     if (!hasLoadedRef.current) return;
     if (budget === initialBudgetRef.current) return;
-    const persistBudget = async () => {
-      setPersistError(null);
-      const { error } = (await sb.from('plans').update({ budget }).eq('id', planId)) as unknown as {
-        error: unknown;
-      };
-      if (error) {
-        setPersistError('Failed to persist budget');
-        return;
-      }
-      initialBudgetRef.current = budget;
-    };
-    void persistBudget();
-  }, [planId, budget, hasLoaded, sb, persist]);
+    setPersistError(null);
+    saveBudget(budget);
+  }, [budget, planId, persist]);
 
   const categoryTotals = useMemo(() => {
     const totals: Record<CategoryKey, number> = {
@@ -110,21 +122,46 @@ export function useBudget(
     [categoryTotals]
   );
 
+  const { mutateAsync: addEntryMut } = useSupabaseResource<
+    string,
+    {
+      description: string;
+      category: CategoryKey;
+      amount: number;
+    }
+  >({
+    queryKey: ['budget', planId],
+    persistFn: async (payload, _signal) => {
+      const res = (await supabase
+        .from('budget_entries')
+        .insert({
+          plan_id: planId,
+          description: payload.description,
+          category: payload.category,
+          amount: payload.amount,
+        })
+        .select('id')
+        .single()) as unknown as { data: { id: string } | null; error: unknown };
+      if (res.error || !res.data) throw res.error;
+      return res.data.id;
+    },
+    onError: () => setPersistError('Failed to persist budget'),
+  });
+
   const handleAdd = async () => {
     if (!desc || amount <= 0) return;
     setPersistError(null);
     if (persist) {
-      const res = (await sb
-        .from('budget_entries')
-        .insert({ plan_id: planId, description: desc, category: cat, amount })
-        .select('id')
-        .single()) as unknown as { data: { id: string } | null; error: unknown };
-      if (res.error || !res.data) {
-        setPersistError('Failed to persist budget');
+      try {
+        const newId = (await addEntryMut({
+          description: desc,
+          category: cat,
+          amount,
+        })) as string;
+        setEntries((prev) => [...prev, { id: newId, description: desc, category: cat, amount }]);
+      } catch {
         return;
       }
-      const newId = res.data!.id;
-      setEntries((prev) => [...prev, { id: newId, description: desc, category: cat, amount }]);
     } else {
       const newId = crypto.randomUUID();
       setEntries((prev) => [...prev, { id: newId, description: desc, category: cat, amount }]);
@@ -133,6 +170,22 @@ export function useBudget(
     setAmount(0);
   };
 
+  const { mutateAsync: updateEntryMut } = useSupabaseResource<void, Entry>({
+    queryKey: ['budget', planId],
+    persistFn: async (updated, _signal) => {
+      const { error } = (await supabase
+        .from('budget_entries')
+        .update({
+          description: updated.description,
+          category: updated.category,
+          amount: updated.amount,
+        })
+        .eq('id', updated.id)) as unknown as { error: unknown };
+      if (error) throw error;
+    },
+    onError: () => setPersistError('Failed to persist budget'),
+  });
+
   const handleUpdateEntry = async (index: number, updated: Entry) => {
     setEntries((prev) => {
       const copy = [...prev];
@@ -140,31 +193,27 @@ export function useBudget(
       return copy;
     });
     if (!persist) return;
-    const { error } = (await sb
-      .from('budget_entries')
-      .update({
-        description: updated.description,
-        category: updated.category,
-        amount: updated.amount,
-      })
-      .eq('id', updated.id)) as unknown as { error: unknown };
-    if (error) {
-      setPersistError('Failed to persist budget');
-    }
+    await updateEntryMut(updated);
   };
+
+  const { mutateAsync: deleteEntryMut } = useSupabaseResource<void, string>({
+    queryKey: ['budget', planId],
+    persistFn: async (id, _signal) => {
+      const { error } = (await supabase
+        .from('budget_entries')
+        // @ts-expect-error Supabase typings omit delete, but runtime supports it
+        .delete()
+        .eq('id', id)) as unknown as { error: unknown };
+      if (error) throw error;
+    },
+    onError: () => setPersistError('Failed to persist budget'),
+  });
 
   const handleDeleteEntry = async (index: number) => {
     const entry = entries[index];
     setEntries((prev) => prev.filter((_, i) => i !== index));
     if (!persist) return;
-    const { error } = (await sb
-      .from('budget_entries')
-      // @ts-expect-error Supabase typings omit delete, but runtime supports it
-      .delete()
-      .eq('id', entry.id)) as unknown as { error: unknown };
-    if (error) {
-      setPersistError('Failed to persist budget');
-    }
+    await deleteEntryMut(entry.id);
   };
 
   return {

--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -1,7 +1,6 @@
 // src/features/planner/hooks/usePlanDaysSupabase.ts
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRef } from 'react';
+import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
 import type { SupabaseQueryBuilder } from '@supabase/supabase-js';
 import { supabase } from '@/shared/lib/supabaseClient';
 import type { PlanDay, DayPlan } from '@/shared/types';
@@ -46,13 +45,10 @@ interface PlanDayWithActivities {
 }
 
 export function usePlanDays(planId: string, enabled = true) {
-  const qc = useQueryClient();
-
-  const days = useQuery({
+  const days = useSupabaseResource<DayPlan[]>({
     queryKey: ['plan_days', planId],
-    queryFn: async () => {
-      const { data, error } = (await supabase
-        .from('plan_days')
+    fetcher: async (signal) => {
+      const { data, error } = (await (supabase.from('plan_days') as QueryBuilder)
         .select('date, activities(*)')
         .eq('plan_id', planId)
         .order('position')
@@ -83,26 +79,21 @@ export function usePlanDays(planId: string, enabled = true) {
     enabled,
   });
 
-  const upsertDay = useMutation({
-    mutationFn: async (payload: Partial<PlanDay>) => {
-      const { error, data } = (await supabase
-        .from('plan_days')
+  const upsertDay = useSupabaseResource<PlanDay, Partial<PlanDay>>({
+    queryKey: ['plan_days', planId],
+    persistFn: async (payload, _signal) => {
+      const { error, data } = (await (supabase.from('plan_days') as QueryBuilder)
         .upsert(payload)
         .select()
         .single()) as { data: PlanDay; error: unknown };
       if (error) throw error;
       return data;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['plan_days', planId] }),
   });
-  const abortRef = useRef<AbortController | null>(null);
 
-  const persistDays = useMutation({
-    mutationFn: async (state: DayPlan[]) => {
-      abortRef.current?.abort();
-      abortRef.current = new AbortController();
-      const { signal } = abortRef.current;
-
+  const persistDays = useSupabaseResource<unknown, DayPlan[]>({
+    queryKey: ['plan_days', planId],
+    persistFn: async (state, signal) => {
       const existing = await fetchExistingDays(planId, signal);
       await deleteRemovedDays(existing, state, signal);
 

--- a/src/features/planner/hooks/usePlanTitleSupabase.ts
+++ b/src/features/planner/hooks/usePlanTitleSupabase.ts
@@ -1,20 +1,19 @@
 // src/features/planner/hooks/usePlanTitleSupabase.ts
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/shared/lib/supabaseClient';
 import { capitalize } from '@/shared/utils';
 import { usePlanEditTokens } from '@/shared/lib/planEditToken';
 import { updatePlanTitle } from '@/app/planner/actions/updatePlanTitle';
+import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
 
 export function usePlanTitle(planId: string, defaultTitle = '', persist = true) {
   const initialTitle = capitalize(defaultTitle);
 
-  const qc = useQueryClient();
   const { getEditToken } = usePlanEditTokens();
 
-  const { data: fetchedTitle = initialTitle } = useQuery({
+  const { data: fetchedTitle = initialTitle, mutate } = useSupabaseResource<string, string>({
     queryKey: ['plan_title', planId],
-    queryFn: async () => {
+    fetcher: async () => {
       const { data, error } = (await supabase
         .from('plans')
         .select('title')
@@ -26,8 +25,14 @@ export function usePlanTitle(planId: string, defaultTitle = '', persist = true) 
       if (error) throw error;
       return data?.title ?? initialTitle;
     },
-    initialData: initialTitle,
+    persistFn: async (newTitle: string) => {
+      const token = getEditToken(planId);
+      if (!token) throw new Error('Missing edit token');
+      await updatePlanTitle(planId, token, newTitle);
+      return newTitle;
+    },
     enabled: persist,
+    onSuccess: (t, qc) => qc.setQueryData(['plan_title', planId], t),
   });
 
   const [localTitle, setLocalTitle] = useState(fetchedTitle);
@@ -36,17 +41,7 @@ export function usePlanTitle(planId: string, defaultTitle = '', persist = true) 
     setLocalTitle(fetchedTitle);
   }, [fetchedTitle]);
 
-  const mutation = useMutation({
-    mutationFn: async (newTitle: string) => {
-      const token = getEditToken(planId);
-      if (!token) throw new Error('Missing edit token');
-      await updatePlanTitle(planId, token, newTitle);
-      return newTitle;
-    },
-    onSuccess: (t) => qc.setQueryData(['plan_title', planId], t),
-  });
-
-  const saveTitle = persist ? () => mutation.mutate(localTitle) : () => {};
+  const saveTitle = persist ? () => mutate(localTitle) : () => {};
 
   return { title: localTitle, setTitle: setLocalTitle, saveTitle };
 }

--- a/src/shared/hooks/useSupabaseResource.ts
+++ b/src/shared/hooks/useSupabaseResource.ts
@@ -1,0 +1,60 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+  type QueryClient,
+  type UseQueryResult,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { useRef } from 'react';
+
+interface UseSupabaseResourceArgs<TData, TPayload> {
+  queryKey: QueryKey;
+  fetcher?: (signal: AbortSignal) => Promise<TData>;
+  persistFn?: (payload: TPayload, signal: AbortSignal) => Promise<unknown>;
+  enabled?: boolean;
+  onSuccess?: (data: unknown, qc: QueryClient) => void;
+  onError?: (error: unknown) => void;
+}
+
+export function useSupabaseResource<TData = unknown, TPayload = unknown>({
+  queryKey,
+  fetcher,
+  persistFn,
+  enabled = true,
+  onSuccess,
+  onError,
+}: UseSupabaseResourceArgs<TData, TPayload>) {
+  const qc = useQueryClient();
+  const abortRef = useRef<AbortController | null>(null);
+
+  const query = useQuery<TData>({
+    queryKey,
+    queryFn: ({ signal }) => (fetcher ? fetcher(signal) : Promise.resolve(null as TData)),
+    enabled: enabled && Boolean(fetcher),
+  }) as UseQueryResult<TData>;
+
+  const mutation = useMutation<unknown, unknown, TPayload>({
+    mutationFn: async (payload: TPayload) => {
+      if (!persistFn) return undefined;
+      abortRef.current?.abort();
+      abortRef.current = new AbortController();
+      return persistFn(payload, abortRef.current.signal);
+    },
+    onSuccess: (data) => {
+      if (onSuccess) onSuccess(data, qc);
+      else qc.invalidateQueries({ queryKey });
+    },
+    onError,
+  }) as UseMutationResult<unknown, unknown, TPayload>;
+
+  return {
+    ...query,
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export default useSupabaseResource;


### PR DESCRIPTION
## Summary
- add `useSupabaseResource` to centralize React Query fetch and persist logic
- refactor planner and budget hooks to use the shared resource hook
- streamline persistence flow and remove duplicated abort/invalidation code

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa896e371c832295ef2f0cbb01ed2f