### PR TITLE
🐛 Prevent hydration mismatch for recent plan banner

### DIFF
--- a/src/features/home/components/ContinuePlanningBanner.tsx
+++ b/src/features/home/components/ContinuePlanningBanner.tsx
@@ -1,6 +1,7 @@
 // src/features/home/components/ContinuePlanningBanner.tsx
 'use client';
 
+import React from 'react';
 import Link from 'next/link';
 import { differenceInCalendarDays } from 'date-fns';
 

--- a/src/features/onboarding/hooks/useOnboardingCheck.ts
+++ b/src/features/onboarding/hooks/useOnboardingCheck.ts
@@ -1,7 +1,7 @@
 // src/features/onboarding/hooks/useOnboardingCheck.ts
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
 
 /**
@@ -10,14 +10,26 @@ import { useLocalStorage } from '@/shared/hooks/useLocalStorage';
  */
 export function useOnboardingCheck(planId: string) {
   const key = `planner-onboarding-shown-${planId}`;
-  const [seen, setSeen] = useLocalStorage<boolean>(key, false);
-  const [showOnboarding, setShowOnboarding] = useState(!seen);
+  const [seen, setSeen, ready] = useLocalStorage<boolean>(key, false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const initialized = useRef(false);
+  const prevKey = useRef(key);
 
   useEffect(() => {
-    setShowOnboarding(!seen);
-    if (!seen) setSeen(true);
+    if (prevKey.current !== key) {
+      initialized.current = false;
+      prevKey.current = key;
+    }
+    if (!ready || initialized.current) return;
+    if (!seen) {
+      setShowOnboarding(true);
+      setSeen(true);
+    } else {
+      setShowOnboarding(false);
+    }
+    initialized.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [planId]);
+  }, [ready, seen, key]);
 
   return { showOnboarding, setShowOnboarding };
 }

--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,25 +1,34 @@
 // src/shared/hooks/useLocalStorage.ts
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 /**
  * Syncs state with localStorage for the given key.
  * Returns the stored value and a setter that persists updates.
  */
 export function useLocalStorage<T>(key: string, initial: T) {
-  const [value, setValue] = useState<T>(() => {
-    if (typeof window === 'undefined') return initial;
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? (JSON.parse(item) as T) : initial;
-    } catch {
-      return initial;
-    }
-  });
+  const [value, setValue] = useState<T>(initial);
+  const [ready, setReady] = useState(false);
+  const initialized = useRef(false);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item !== null) {
+        setValue(JSON.parse(item) as T);
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      initialized.current = true;
+      setReady(true);
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (!initialized.current || typeof window === 'undefined') return;
     try {
       window.localStorage.setItem(key, JSON.stringify(value));
     } catch {
@@ -27,5 +36,5 @@ export function useLocalStorage<T>(key: string, initial: T) {
     }
   }, [key, value]);
 
-  return [value, setValue] as const;
+  return [value, setValue, ready] as const;
 }

--- a/tests/unit/features/home/ContinuePlanningBanner.test.tsx
+++ b/tests/unit/features/home/ContinuePlanningBanner.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot, type Root } from 'react-dom/client';
+import { screen, act } from '@testing-library/react';
+
+import ContinuePlanningBanner from '@/features/home/components/ContinuePlanningBanner';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('ContinuePlanningBanner hydration', () => {
+  afterEach(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('hydrates without warnings and loads banner after effect', async () => {
+    const plan = {
+      id: '1',
+      slug: 'trip',
+      dest: 'Paris',
+      start: '2023-01-01',
+      end: '2023-01-02',
+    };
+
+    const originalWindow = globalThis.window;
+    // @ts-ignore simulate server environment
+    globalThis.window = undefined;
+    const serverHtml = renderToString(<ContinuePlanningBanner />);
+    globalThis.window = originalWindow;
+
+    document.body.innerHTML = `<div id="root">${serverHtml}</div>`;
+    const container = document.getElementById('root')!;
+
+    window.localStorage.setItem('recent_plan', JSON.stringify(plan));
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let root: Root;
+    await act(() => {
+      root = hydrateRoot(container, <ContinuePlanningBanner />);
+      expect(serverHtml).not.toContain('Continue your');
+      expect(container.innerHTML).toBe(serverHtml);
+    });
+
+    expect(await screen.findByText(/Continue your 2 days trip to Paris/)).toBeInTheDocument();
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
## Summary
- defer localStorage hydration and expose readiness flag
- guard onboarding banner until storage hydration completes
- add SSR hydration test for ContinuePlanningBanner

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8d6a95208322933aaa10d78c5132