### PR TITLE
🔧 Resolve lint warnings and update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This `Agents.md` file provides comprehensive guidance for any AI agents working 
 - **Linting**: Ensure `npm run lint` passes.
 - **Type checking**: Ensure `npm run typecheck` passes.
 - **Tests**: Execute `npm run test` and make sure tests succeed.
+- **Warnings**: Warnings from linting, type checking, testing or any other tools are undesirable and should be resolved.
 - **Commit style**: Start commits with an appropriate Gitmoji followed by a short, capitalized description in English (e.g., `✨ Add map view`). A commitlint hook enforces this format, and commit suggestions after PR/merge must also use Gitmoji.
 
 ## General Conventions for AI Agents

--- a/src/features/budget/hooks/useBudgetSupabase.ts
+++ b/src/features/budget/hooks/useBudgetSupabase.ts
@@ -25,7 +25,7 @@ export function useBudget(
 
   const { data: loaded } = useSupabaseResource<{ budget: number; entries: Entry[] }>({
     queryKey: ['budget', planId],
-    fetcher: async (signal) => {
+    fetcher: async () => {
       const budgetRes = (await supabase
         .from('plans')
         .select('budget')
@@ -60,7 +60,7 @@ export function useBudget(
 
   const { mutate: saveBudget } = useSupabaseResource<number, number>({
     queryKey: ['budget', planId],
-    persistFn: async (b, _signal) => {
+    persistFn: async (b) => {
       const { error } = (await supabase
         .from('plans')
         .update({ budget: b })
@@ -100,7 +100,7 @@ export function useBudget(
     if (budget === initialBudgetRef.current) return;
     setPersistError(null);
     saveBudget(budget);
-  }, [budget, planId, persist]);
+  }, [budget, planId, persist, saveBudget]);
 
   const categoryTotals = useMemo(() => {
     const totals: Record<CategoryKey, number> = {
@@ -131,7 +131,7 @@ export function useBudget(
     }
   >({
     queryKey: ['budget', planId],
-    persistFn: async (payload, _signal) => {
+    persistFn: async (payload) => {
       const res = (await supabase
         .from('budget_entries')
         .insert({
@@ -172,7 +172,7 @@ export function useBudget(
 
   const { mutateAsync: updateEntryMut } = useSupabaseResource<void, Entry>({
     queryKey: ['budget', planId],
-    persistFn: async (updated, _signal) => {
+    persistFn: async (updated) => {
       const { error } = (await supabase
         .from('budget_entries')
         .update({
@@ -198,7 +198,7 @@ export function useBudget(
 
   const { mutateAsync: deleteEntryMut } = useSupabaseResource<void, string>({
     queryKey: ['budget', planId],
-    persistFn: async (id, _signal) => {
+    persistFn: async (id) => {
       const { error } = (await supabase
         .from('budget_entries')
         // @ts-expect-error Supabase typings omit delete, but runtime supports it

--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -46,7 +46,7 @@ interface PlanDayWithActivities {
 export function usePlanDays(planId: string, enabled = true) {
   const days = useSupabaseResource<DayPlan[]>({
     queryKey: ['plan_days', planId],
-    fetcher: async (signal) => {
+    fetcher: async () => {
       const { data, error } = (await (supabase.from('plan_days') as QueryBuilder)
         .select('date, activities(*)')
         .eq('plan_id', planId)
@@ -80,7 +80,7 @@ export function usePlanDays(planId: string, enabled = true) {
 
   const upsertDay = useSupabaseResource<PlanDay, Partial<PlanDay>>({
     queryKey: ['plan_days', planId],
-    persistFn: async (payload, _signal) => {
+    persistFn: async (payload) => {
       const { error, data } = (await (supabase.from('plan_days') as QueryBuilder)
         .upsert(payload)
         .select()

--- a/src/server/api/admin/refresh-pageviews/route.ts
+++ b/src/server/api/admin/refresh-pageviews/route.ts
@@ -1,11 +1,11 @@
 // src/server/api/admin/refresh-pageviews/route.ts
 
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
 /**
  * Dummy admin route kept for compatibility.
  * Always reports zero updated items since catalog support was removed.
  */
-export async function GET(_req: NextRequest) {
+export async function GET() {
   return NextResponse.json({ updated: 0 });
 }


### PR DESCRIPTION
## Summary
- remove unused AbortSignal parameters across hooks and server route
- ensure budget effect depends on `saveBudget`
- document that warnings in checks are discouraged

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9b62a34c832296505d038227d0dc