### PR TITLE
🐛 Prevent modal close on destination autocomplete

### DIFF
--- a/src/shared/hooks/ui/usePopupDismiss.ts
+++ b/src/shared/hooks/ui/usePopupDismiss.ts
@@ -27,11 +27,13 @@ export function usePopupDismiss({
     prevFocusedRef.current = triggerRef?.current ?? (document.activeElement as HTMLElement) ?? null;
 
     function handleMouseDown(e: MouseEvent) {
-      const target = e.target as Node;
-      const clickedOutside = popupRef.current && !popupRef.current.contains(target);
-      const clickedTrigger = triggerRef?.current?.contains?.(target);
+      const path = e.composedPath();
+      const popupEl = popupRef.current;
+      const triggerEl = triggerRef?.current;
+      const clickedInside = popupEl ? path.includes(popupEl) : false;
+      const clickedTrigger = triggerEl ? path.includes(triggerEl) : false;
 
-      if (clickedOutside && !clickedTrigger) {
+      if (!clickedInside && !clickedTrigger) {
         onClose();
       }
     }


### PR DESCRIPTION
## Summary
- use composedPath in popup dismiss hook to detect inside clicks even if target removed

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa1db2408832288c00bc61301721c