### PR TITLE
✨ Add animated inspiration card

### DIFF
--- a/src/features/home/components/InspirationCard.tsx
+++ b/src/features/home/components/InspirationCard.tsx
@@ -1,0 +1,77 @@
+// src/features/home/components/InspirationCard.tsx
+'use client';
+
+import Image from 'next/image';
+import { useState, useRef, useEffect } from 'react';
+
+const DEFAULT_INTERVAL_MS = 2000;
+
+export type InspirationCardProps = {
+  title: string;
+  imageUrls: string[];
+  intervalMs?: number;
+};
+
+export default function InspirationCard({
+  title,
+  imageUrls,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: InspirationCardProps) {
+  const [index, setIndex] = useState(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const touchStartX = useRef<number | null>(null);
+
+  const startCycle = () => {
+    if (intervalRef.current) return;
+    intervalRef.current = setInterval(() => {
+      setIndex((prev) => (prev + 1) % imageUrls.length);
+    }, intervalMs);
+  };
+
+  const stopCycle = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(deltaX) > 30) {
+      setIndex((prev) => {
+        const next = deltaX < 0 ? prev + 1 : prev - 1;
+        return (next + imageUrls.length) % imageUrls.length;
+      });
+    }
+    touchStartX.current = null;
+  };
+
+  useEffect(() => () => stopCycle(), []);
+
+  return (
+    <div
+      tabIndex={0}
+      className="block w-56 cursor-pointer rounded-lg border bg-white p-6 text-center shadow-sm transition hover:shadow focus:shadow"
+      onMouseEnter={startCycle}
+      onMouseLeave={stopCycle}
+      onFocus={startCycle}
+      onBlur={stopCycle}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <Image
+        src={imageUrls[index]}
+        alt={title}
+        width={200}
+        height={120}
+        className="mx-auto mb-4 h-40 w-full rounded object-cover"
+      />
+      <h3 className="text-lg font-semibold">{title}</h3>
+    </div>
+  );
+}

--- a/src/features/home/components/InspirationLink.tsx
+++ b/src/features/home/components/InspirationLink.tsx
@@ -1,14 +1,22 @@
 // src/features/home/components/InspirationLink.tsx
 'use client';
 
-import Link from 'next/link';
+import InspirationCard from './InspirationCard';
 import rome from '@/data/rome.json';
 import paris from '@/data/paris.json';
 
 export default function InspirationLink() {
   const destinations = [
-    { city: 'rome', label: rome.title_inspiration },
-    { city: 'paris', label: paris.title_inspiration },
+    {
+      city: 'rome',
+      label: rome.title_inspiration,
+      images: rome.itinerary.flatMap((day) => day.activities.map((activity) => activity.imageUrl)),
+    },
+    {
+      city: 'paris',
+      label: paris.title_inspiration,
+      images: paris.itinerary.flatMap((day) => day.activities.map((activity) => activity.imageUrl)),
+    },
   ];
 
   return (
@@ -26,12 +34,7 @@ export default function InspirationLink() {
         <ul className="mx-auto flex flex-wrap justify-center gap-6">
           {destinations.map((d) => (
             <li key={d.city}>
-              <Link
-                href={`/inspiration/${d.city}`}
-                className="block w-56 rounded-lg border bg-white p-6 text-center shadow-sm transition hover:shadow"
-              >
-                {d.label}
-              </Link>
+              <InspirationCard title={d.label} imageUrls={d.images} />
             </li>
           ))}
         </ul>

--- a/src/features/home/components/index.ts
+++ b/src/features/home/components/index.ts
@@ -5,3 +5,4 @@ export { default as PlanForm } from './PlanForm';
 export { FeaturePreview } from './feature-preview';
 export { default as InspirationLink } from './InspirationLink';
 export { default as ContinuePlanningBanner } from './ContinuePlanningBanner';
+export { default as InspirationCard } from './InspirationCard';


### PR DESCRIPTION
## Summary
- add reusable InspirationCard with animated image carousel and swipe support
- replace destination links on home page with new card

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa171437c8322b17e9eba8a71918e