### PR TITLE
🐛 Stop modal from refocusing title after open

### DIFF
--- a/src/features/planner/components/modal/ActivityModalForm.tsx
+++ b/src/features/planner/components/modal/ActivityModalForm.tsx
@@ -39,13 +39,13 @@ export default function ActivityModalForm({ activity, onSave, color }: ActivityM
     setLongitude(activity.longitude);
   }, [activity]);
 
-  // Automatically focus the title input only once when the initial title is empty.
+  // Automatically scroll to the title input only once when the initial title is empty.
   const titleInputRef = useRef<HTMLInputElement>(null);
   const initialTitle = useRef(editedTitle);
 
   useEffect(() => {
     if (!initialTitle.current.trim()) {
-      titleInputRef.current?.focus();
+      titleInputRef.current?.scrollIntoView({ block: 'center' });
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- prevent activity modal from repeatedly jumping to title input by scrolling to it once

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa24c7adc8322b28a93beacf748ed