### PR TITLE
✨ Improve popup dismiss escape handling

### DIFF
--- a/src/shared/hooks/ui/usePopupDismiss.ts
+++ b/src/shared/hooks/ui/usePopupDismiss.ts
@@ -1,16 +1,20 @@
 // src/shared/hooks/ui/usePopupDismiss.ts
 
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef, useMemo } from 'react';
+import { useKeyListener } from './useKeyListener';
 
 interface UsePopupDismissParams {
   popupRef: RefObject<HTMLElement | null>;
   triggerRef?: RefObject<HTMLElement | null>;
   onClose: () => void;
   isOpen?: boolean;
+  /** Optional handler called when Escape is pressed. Defaults to `onClose`. */
+  escapeHandler?: () => void;
 }
 
 /**
  * Handles closing a popup when the user presses Escape or clicks outside.
+ * Optionally runs a custom escape handler before closing.
  * Restores focus to the element that triggered the popup when it closes.
  */
 export function usePopupDismiss({
@@ -18,8 +22,13 @@ export function usePopupDismiss({
   triggerRef,
   onClose,
   isOpen = true,
+  escapeHandler,
 }: UsePopupDismissParams) {
   const prevFocusedRef = useRef<HTMLElement | null>(null);
+
+  const escape = useMemo(() => escapeHandler ?? onClose, [escapeHandler, onClose]);
+
+  useKeyListener({ keys: { Escape: escape }, isActive: isOpen });
 
   useEffect(() => {
     if (!isOpen) return;
@@ -38,18 +47,10 @@ export function usePopupDismiss({
       }
     }
 
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    }
-
     document.addEventListener('mousedown', handleMouseDown);
-    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.removeEventListener('mousedown', handleMouseDown);
-      document.removeEventListener('keydown', handleKeyDown);
       prevFocusedRef.current?.focus?.();
     };
   }, [popupRef, triggerRef, onClose, isOpen]);


### PR DESCRIPTION
## Summary
- use `useKeyListener` for Escape handling in `usePopupDismiss`
- add optional `escapeHandler` to customize Escape key behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaaa5e7c708322b8c5c1f939ac0ce9