### PR TITLE
✨ Add plan resource hook and refactor Supabase hooks

### DIFF
--- a/src/features/budget/hooks/useBudgetSupabase.ts
+++ b/src/features/budget/hooks/useBudgetSupabase.ts
@@ -3,7 +3,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 import { supabase } from '@/shared/lib/supabaseClient';
 import type { CategoryKey } from '@/shared/constants';
 import type { Entry } from '@/features/budget/types';
-import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
+import { usePlanResource } from '@/shared/hooks/usePlanResource';
 
 export function useBudget(
   planId: string,
@@ -23,18 +23,19 @@ export function useBudget(
   const initialBudgetRef = useRef(0);
   const [persistError, setPersistError] = useState<string | null>(null);
 
-  const { data: loaded } = useSupabaseResource<{ budget: number; entries: Entry[] }>({
-    queryKey: ['budget', planId],
-    fetcher: async () => {
+  const { data: loaded } = usePlanResource<{ budget: number; entries: Entry[] }>({
+    planId,
+    resource: 'budget',
+    fetcher: async (id) => {
       const budgetRes = (await supabase
         .from('plans')
         .select('budget')
-        .eq('id', planId)
+        .eq('id', id)
         .single()) as unknown as { data: { budget: number | null } | null };
       const entryRes = (await supabase
         .from('budget_entries')
         .select('*')
-        .eq('plan_id', planId)) as unknown as {
+        .eq('plan_id', id)) as unknown as {
         data:
           | {
               id: string;
@@ -58,16 +59,11 @@ export function useBudget(
     enabled: persist,
   });
 
-  const { mutate: saveBudget } = useSupabaseResource<number, number>({
-    queryKey: ['budget', planId],
-    persistFn: async (b) => {
-      const { error } = (await supabase
-        .from('plans')
-        .update({ budget: b })
-        .eq('id', planId)) as unknown as { error: unknown };
-      if (error) throw error;
-      return b;
-    },
+  const { mutate: saveBudget } = usePlanResource<number, number>({
+    planId,
+    resource: 'budget',
+    table: 'plans',
+    column: 'budget',
     onSuccess: (b) => {
       initialBudgetRef.current = b as number;
     },
@@ -122,7 +118,7 @@ export function useBudget(
     [categoryTotals]
   );
 
-  const { mutateAsync: addEntryMut } = useSupabaseResource<
+  const { mutateAsync: addEntryMut } = usePlanResource<
     string,
     {
       description: string;
@@ -130,18 +126,22 @@ export function useBudget(
       amount: number;
     }
   >({
-    queryKey: ['budget', planId],
-    persistFn: async (payload) => {
+    planId,
+    resource: 'budget',
+    persistFn: async (id, payload) => {
       const res = (await supabase
         .from('budget_entries')
         .insert({
-          plan_id: planId,
+          plan_id: id,
           description: payload.description,
           category: payload.category,
           amount: payload.amount,
         })
         .select('id')
-        .single()) as unknown as { data: { id: string } | null; error: unknown };
+        .single()) as unknown as {
+        data: { id: string } | null;
+        error: unknown;
+      };
       if (res.error || !res.data) throw res.error;
       return res.data.id;
     },
@@ -170,9 +170,10 @@ export function useBudget(
     setAmount(0);
   };
 
-  const { mutateAsync: updateEntryMut } = useSupabaseResource<void, Entry>({
-    queryKey: ['budget', planId],
-    persistFn: async (updated) => {
+  const { mutateAsync: updateEntryMut } = usePlanResource<void, Entry>({
+    planId,
+    resource: 'budget',
+    persistFn: async (_id, updated) => {
       const { error } = (await supabase
         .from('budget_entries')
         .update({
@@ -196,9 +197,10 @@ export function useBudget(
     await updateEntryMut(updated);
   };
 
-  const { mutateAsync: deleteEntryMut } = useSupabaseResource<void, string>({
-    queryKey: ['budget', planId],
-    persistFn: async (id) => {
+  const { mutateAsync: deleteEntryMut } = usePlanResource<void, string>({
+    planId,
+    resource: 'budget',
+    persistFn: async (_id, id) => {
       const { error } = (await supabase
         .from('budget_entries')
         // @ts-expect-error Supabase typings omit delete, but runtime supports it

--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -1,6 +1,6 @@
 // src/features/planner/hooks/usePlanDaysSupabase.ts
 
-import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
+import { usePlanResource } from '@/shared/hooks/usePlanResource';
 import type { SupabaseQueryBuilder } from '@supabase/supabase-js';
 import { supabase } from '@/shared/lib/supabaseClient';
 import type { PlanDay, DayPlan } from '@/shared/types';
@@ -44,12 +44,13 @@ interface PlanDayWithActivities {
 }
 
 export function usePlanDays(planId: string, enabled = true) {
-  const days = useSupabaseResource<DayPlan[]>({
-    queryKey: ['plan_days', planId],
-    fetcher: async () => {
+  const days = usePlanResource<DayPlan[]>({
+    planId,
+    resource: 'plan_days',
+    fetcher: async (id) => {
       const { data, error } = (await (supabase.from('plan_days') as QueryBuilder)
         .select('date, activities(*)')
-        .eq('plan_id', planId)
+        .eq('plan_id', id)
         .order('position')
         .order('position', { foreignTable: 'activities' })) as unknown as {
         data: PlanDayWithActivities[];
@@ -78,22 +79,25 @@ export function usePlanDays(planId: string, enabled = true) {
     enabled,
   });
 
-  const upsertDay = useSupabaseResource<PlanDay, Partial<PlanDay>>({
-    queryKey: ['plan_days', planId],
-    persistFn: async (payload) => {
+  const upsertDay = usePlanResource<PlanDay, Partial<PlanDay>>({
+    planId,
+    resource: 'plan_days',
+    persistFn: async (id, payload, signal) => {
       const { error, data } = (await (supabase.from('plan_days') as QueryBuilder)
         .upsert(payload)
         .select()
+        .abortSignal(signal)
         .single()) as { data: PlanDay; error: unknown };
       if (error) throw error;
       return data;
     },
   });
 
-  const persistDays = useSupabaseResource<unknown, DayPlan[]>({
-    queryKey: ['plan_days', planId],
-    persistFn: async (state, signal) => {
-      const existing = await fetchExistingDays(planId, signal);
+  const persistDays = usePlanResource<unknown, DayPlan[]>({
+    planId,
+    resource: 'plan_days',
+    persistFn: async (id, state, signal) => {
+      const existing = await fetchExistingDays(id, signal);
       await deleteRemovedDays(existing, state, signal);
 
       let destinationId: string | undefined = existing[0]?.destination_id;
@@ -102,7 +106,7 @@ export function usePlanDays(planId: string, enabled = true) {
           supabase.from('plan_destinations') as QueryBuilder
         )
           .select('destination_id')
-          .eq('plan_id', planId)
+          .eq('plan_id', id)
           .order('position')
           .abortSignal(signal)) as unknown as {
           data: { destination_id: string }[] | null;
@@ -139,7 +143,7 @@ export function usePlanDays(planId: string, enabled = true) {
         if (!destId) throw new Error('destination_id missing');
         if (!dayId) {
           const inserted = (await (supabase.from('plan_days') as QueryBuilder)
-            .insert({ plan_id: planId, date: day.id, position: i, destination_id: destId })
+            .insert({ plan_id: id, date: day.id, position: i, destination_id: destId })
             .select('id')
             .single()
             // @ts-expect-error abortSignal exists on the returned object

--- a/src/features/planner/hooks/usePlanTitleSupabase.ts
+++ b/src/features/planner/hooks/usePlanTitleSupabase.ts
@@ -1,39 +1,30 @@
 // src/features/planner/hooks/usePlanTitleSupabase.ts
 import { useEffect, useState } from 'react';
-import { supabase } from '@/shared/lib/supabaseClient';
 import { capitalize } from '@/shared/utils';
 import { usePlanEditTokens } from '@/shared/lib/planEditToken';
 import { updatePlanTitle } from '@/app/planner/actions/updatePlanTitle';
-import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
+import { usePlanResource } from '@/shared/hooks/usePlanResource';
 
 export function usePlanTitle(planId: string, defaultTitle = '', persist = true) {
   const initialTitle = capitalize(defaultTitle);
 
   const { getEditToken } = usePlanEditTokens();
 
-  const { data: fetchedTitle = initialTitle, mutate } = useSupabaseResource<string, string>({
-    queryKey: ['plan_title', planId],
-    fetcher: async () => {
-      const { data, error } = (await supabase
-        .from('plans')
-        .select('title')
-        .eq('id', planId)
-        .single()) as unknown as {
-        data: { title: string } | null;
-        error: unknown;
-      };
-      if (error) throw error;
-      return data?.title ?? initialTitle;
-    },
-    persistFn: async (newTitle: string) => {
-      const token = getEditToken(planId);
+  const { data: fetchedTitleRaw, mutate } = usePlanResource<string, string>({
+    planId,
+    resource: 'plan_title',
+    table: 'plans',
+    column: 'title',
+    enabled: persist,
+    persistFn: async (id, newTitle) => {
+      const token = getEditToken(id);
       if (!token) throw new Error('Missing edit token');
-      await updatePlanTitle(planId, token, newTitle);
+      await updatePlanTitle(id, token, newTitle);
       return newTitle;
     },
-    enabled: persist,
     onSuccess: (t, qc) => qc.setQueryData(['plan_title', planId], t),
   });
+  const fetchedTitle = fetchedTitleRaw ?? initialTitle;
 
   const [localTitle, setLocalTitle] = useState(fetchedTitle);
 

--- a/src/shared/hooks/usePlanResource.ts
+++ b/src/shared/hooks/usePlanResource.ts
@@ -1,0 +1,76 @@
+import { supabase } from '@/shared/lib/supabaseClient';
+import { useSupabaseResource } from './useSupabaseResource';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+interface UsePlanResourceArgs<TData, TPayload> {
+  planId: string;
+  resource: string | QueryKey;
+  table?: string;
+  column?: string;
+  idColumn?: string;
+  fetcher?: (planId: string, signal: AbortSignal) => Promise<TData>;
+  persistFn?: (planId: string, payload: TPayload, signal: AbortSignal) => Promise<unknown>;
+  enabled?: boolean;
+  onSuccess?: (data: unknown, qc: QueryClient) => void;
+  onError?: (error: unknown) => void;
+}
+
+export function usePlanResource<TData = unknown, TPayload = unknown>({
+  planId,
+  resource,
+  table,
+  column,
+  idColumn = table === 'plans' ? 'id' : 'plan_id',
+  fetcher,
+  persistFn,
+  ...rest
+}: UsePlanResourceArgs<TData, TPayload>) {
+  const queryKey = Array.isArray(resource) ? [...resource, planId] : [resource, planId];
+
+  const defaultFetcher = table
+    ? async (id: string, signal: AbortSignal) => {
+        const { data, error } = await supabase
+          .from(table)
+          .select(column ?? '*')
+          .eq(idColumn, id)
+          // @ts-expect-error abortSignal not typed in supabase-js
+          .abortSignal?.(signal)
+          .single();
+        if (error) throw error;
+        return column ? ((data as Record<string, unknown>)[column] as TData) : (data as TData);
+      }
+    : undefined;
+
+  const defaultPersist = table
+    ? async (id: string, payload: TPayload, signal: AbortSignal) => {
+        const changes = column ? { [column]: payload } : (payload as Record<string, unknown>);
+        const { data, error } = await supabase
+          .from(table)
+          .update(changes)
+          .eq(idColumn, id)
+          .select(column ?? '*')
+          // @ts-expect-error abortSignal not typed in supabase-js
+          .abortSignal?.(signal)
+          .single();
+        if (error) throw error;
+        return column ? ((data as Record<string, unknown>)[column] as TData) : (data as TData);
+      }
+    : undefined;
+
+  return useSupabaseResource<TData, TPayload>({
+    queryKey,
+    fetcher: fetcher
+      ? (signal) => fetcher(planId, signal)
+      : table
+        ? (signal) => defaultFetcher!(planId, signal)
+        : undefined,
+    persistFn: persistFn
+      ? (payload, signal) => persistFn(planId, payload, signal)
+      : table
+        ? (payload, signal) => defaultPersist!(planId, payload, signal)
+        : undefined,
+    ...rest,
+  });
+}
+
+export default usePlanResource;


### PR DESCRIPTION
## Summary
- add `usePlanResource` to centralize plan-related Supabase CRUD
- refactor plan title, days and budget hooks to reuse `usePlanResource`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaac558df88322a32c2950301ef2ed