### PR TITLE
🐛 Improve destination autocomplete error reporting

### DIFF
--- a/src/features/planner/hooks/search/useDestinationAutocomplete.ts
+++ b/src/features/planner/hooks/search/useDestinationAutocomplete.ts
@@ -15,7 +15,16 @@ async function fetchAutocomplete(
     params.set('lon', String(lon));
   }
   const res = await fetch(`/api/autocomplete?${params.toString()}`);
-  if (!res.ok) throw new Error('Failed to load suggestions');
+  if (!res.ok) {
+    let message = 'Failed to load suggestions.';
+    try {
+      const err = (await res.json()) as { error?: string };
+      if (err.error) message = err.error;
+    } catch {
+      // ignore JSON parsing errors
+    }
+    throw new Error(message);
+  }
   const data = (await res.json()) as { results: AutocompletePlace[] };
   return data.results;
 }
@@ -30,7 +39,7 @@ export function useDestinationAutocomplete(
 ) {
   const isEnabled = (options.enabled ?? true) && query.length >= 4;
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, error } = useQuery<AutocompletePlace[], Error>({
     queryKey: ['autocomplete', query, options.latitude, options.longitude],
     queryFn: () => fetchAutocomplete(query, options.latitude, options.longitude),
     enabled: isEnabled,
@@ -41,6 +50,6 @@ export function useDestinationAutocomplete(
   return {
     results: data ?? ([] as AutocompletePlace[]),
     loading: isLoading,
-    error: isError,
+    error: error ? error.message : null,
   };
 }

--- a/src/shared/ui/LocationSearchInput.tsx
+++ b/src/shared/ui/LocationSearchInput.tsx
@@ -101,7 +101,7 @@ export default function LocationSearchInput({
       {loading && <Spinner className="absolute top-2 right-2 size-4" />}
       {error && (
         <p className="text-destructive mt-1 text-sm" role="alert" aria-live="assertive">
-          Failed to load suggestions.
+          {error}
         </p>
       )}
       {open && results.length > 0 && !error && (

--- a/tests/unit/features/planner/components/ActivityModalForm.test.tsx
+++ b/tests/unit/features/planner/components/ActivityModalForm.test.tsx
@@ -32,7 +32,7 @@ describe('ActivityModalForm address autocomplete', () => {
     mockUseDestinationAutocomplete.mockReturnValue({
       results: [{ name: '1 Infinite Loop, CA', latitude: 10, longitude: 20 }],
       loading: false,
-      error: false,
+      error: null,
     });
 
     const activity: Activity = { id: '1', title: 'Test', color: 'bg-[var(--color-0)]' };

--- a/tests/unit/shared/ui/LocationSearchInput.test.tsx
+++ b/tests/unit/shared/ui/LocationSearchInput.test.tsx
@@ -32,7 +32,7 @@ describe('LocationSearchInput', () => {
         { name: 'London, UK', latitude: 1, longitude: 1 },
       ],
       loading: false,
-      error: false,
+      error: null,
     });
 
     const handleChange = vi.fn();
@@ -58,7 +58,7 @@ describe('LocationSearchInput', () => {
         { name: 'London, UK', latitude: 1, longitude: 1 },
       ],
       loading: false,
-      error: false,
+      error: null,
     });
 
     const handleChange = vi.fn();
@@ -82,7 +82,7 @@ describe('LocationSearchInput', () => {
     mockUseDestinationAutocomplete.mockReturnValue({
       results: [],
       loading: false,
-      error: true,
+      error: 'Failed to load suggestions.',
     });
 
     render(<LocationSearchInput value="Paris" onChange={() => {}} />);


### PR DESCRIPTION
## Summary
- Propagate API error messages through destination autocomplete hook
- Display specific errors in LocationSearchInput
- Adjust tests for new error handling

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2a92d260832294e4a1016ca062fa