### PR TITLE
🔗 Link inspiration cards to destination pages

### DIFF
--- a/src/features/home/components/InspirationCard.tsx
+++ b/src/features/home/components/InspirationCard.tsx
@@ -55,8 +55,7 @@ export default function InspirationCard({
 
   return (
     <div
-      tabIndex={0}
-      className="bg-background block w-76 cursor-pointer rounded-md border pb-4 text-center shadow-sm transition hover:shadow focus:shadow"
+      className="bg-background block w-76 rounded-md border pb-4 text-center shadow-sm transition hover:shadow focus:shadow"
       onMouseEnter={startCycle}
       onMouseLeave={stopCycle}
       onFocus={startCycle}

--- a/src/features/home/components/InspirationLink.tsx
+++ b/src/features/home/components/InspirationLink.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import InspirationCard from './InspirationCard';
 import rome from '@/data/rome.json';
 import paris from '@/data/paris.json';
@@ -43,7 +44,9 @@ export default function InspirationLink() {
         <ul className="mx-auto flex flex-wrap justify-center gap-6">
           {destinations.map((d) => (
             <li key={d.city}>
-              <InspirationCard title={d.label} imageUrls={d.images} />
+              <Link href={`/inspiration/${d.city}`} className="block">
+                <InspirationCard title={d.label} imageUrls={d.images} />
+              </Link>
             </li>
           ))}
         </ul>

--- a/tests/unit/features/home/InspirationLink.test.tsx
+++ b/tests/unit/features/home/InspirationLink.test.tsx
@@ -4,13 +4,22 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import InspirationLink from '@/features/home/components/InspirationLink';
+import rome from '@/data/rome.json';
+import paris from '@/data/paris.json';
 import boipeba from '@/data/boipeba.json';
 
 describe('InspirationLink', () => {
-  it('includes Boipeba in the destinations', () => {
+  it('renders destinations as links with correct hrefs', () => {
     render(<InspirationLink />);
 
-    expect(screen.getByText(boipeba.title_inspiration)).toBeInTheDocument();
-    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(
+      screen.getByRole('link', { name: new RegExp(rome.title_inspiration, 'i') })
+    ).toHaveAttribute('href', '/inspiration/rome');
+    expect(
+      screen.getByRole('link', { name: new RegExp(paris.title_inspiration, 'i') })
+    ).toHaveAttribute('href', '/inspiration/paris');
+    expect(
+      screen.getByRole('link', { name: new RegExp(boipeba.title_inspiration, 'i') })
+    ).toHaveAttribute('href', '/inspiration/boipeba');
   });
 });


### PR DESCRIPTION
## Summary
- Wrap inspiration cards in Next.js `Link` to point to destination pages
- Remove `cursor-pointer` from non-link card container
- Test that each destination renders an anchor with the expected `href`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2bd48ce88322a90daa766349d4d3