### PR TITLE
⏪ Revert API routing configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,4 @@
 // next.config.ts
-import path from 'path';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
@@ -7,23 +6,6 @@ const nextConfig: NextConfig = {
   reactStrictMode: false,
   images: {
     remotePatterns: [{ protocol: 'https', hostname: 'upload.wikimedia.org', pathname: '/**' }],
-  },
-  experimental: {
-    /**
-     * Route handlers are colocated in `src/server/api`.
-     * This tells Next.js to resolve API routes from there directly,
-     * removing the need for re-export files under `src/app/api`.
-     */
-    apiDir: path.resolve(__dirname, 'src/server/api'),
-  } as unknown as NextConfig['experimental'],
-  webpack: (config) => {
-    config.resolve.alias['@api'] = path.resolve(__dirname, 'src/server/api');
-    return config;
-  },
-  turbo: {
-    resolveAlias: {
-      '@api': path.resolve(__dirname, 'src/server/api'),
-    },
   },
 };
 

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -1,0 +1,2 @@
+// src/app/api/autocomplete/route.ts
+export { GET } from '@/server/api/autocomplete/route';

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,2 @@
+// src/app/api/search/route.ts
+export { GET } from '@/server/api/search/route';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,10 +19,7 @@
       }
     ],
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"],
-      "@api/*": ["./src/server/api/*"]
-    },
+    "paths": { "@/*": ["./src/*"] },
     "types": ["vitest/globals", "node"]
   },
   "include": [


### PR DESCRIPTION
## Summary
- remove custom API routing settings
- restore search and autocomplete route re-exports

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2e03d27c8322b9c777f425c046da