### PR TITLE
🚚 Organize budget tests into component and hook directories

### DIFF
--- a/tests/unit/features/planner/components/budget/activities/ActivitiesBudget.test.tsx
+++ b/tests/unit/features/planner/components/budget/activities/ActivitiesBudget.test.tsx
@@ -1,4 +1,4 @@
-// tests/unit/features/planner/budget/components/activities/ActivitiesBudget.test.tsx
+// tests/unit/features/planner/components/budget/activities/ActivitiesBudget.test.tsx
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';

--- a/tests/unit/features/planner/components/budget/activities/BudgetPanelHeader.test.tsx
+++ b/tests/unit/features/planner/components/budget/activities/BudgetPanelHeader.test.tsx
@@ -1,4 +1,4 @@
-// tests/unit/features/planner/budget/components/activities/BudgetPanelHeader.test.tsx
+// tests/unit/features/planner/components/budget/activities/BudgetPanelHeader.test.tsx
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/tests/unit/features/planner/hooks/budget/useBudgetSupabase.test.ts
+++ b/tests/unit/features/planner/hooks/budget/useBudgetSupabase.test.ts
@@ -1,4 +1,4 @@
-// tests/unit/features/planner/budget/hooks/useBudgetSupabase.test.ts
+// tests/unit/features/planner/hooks/budget/useBudgetSupabase.test.ts
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';


### PR DESCRIPTION
## Summary
- relocate budget component tests under `tests/unit/features/planner/components/budget/activities`
- relocate budget hook test under `tests/unit/features/planner/hooks/budget`
- remove obsolete `budget` test directory

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b45ed3140c8322bfd9aed18baf010b