### PR TITLE
🐛 Guard invalid planner URL coordinates

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,7 +12,7 @@ Tests are discovered from `tests/{unit,integration}/**/*.{test,spec}.{ts,tsx}`.
 
 ## Current strategy
 
-Only component unit tests exist today. Future work may add integration or e2e coverage once the app stabilises. Integration tests will live under `tests/integration`.
+Only component unit tests exist today. Future work may add integration or e2e coverage once the app stabilizes. Integration tests will live under `tests/integration`.
 
 ## Folder and file naming
 

--- a/src/features/planner/hooks/usePlanParams.ts
+++ b/src/features/planner/hooks/usePlanParams.ts
@@ -10,8 +10,16 @@ import { useSearchParams } from 'next/navigation';
 export function usePlanParams() {
   const params = useSearchParams();
   const dest = params.get('dest')?.trim().toLowerCase() ?? '';
-  const lat = params.get('lat');
-  const lng = params.get('lng');
-  const destCoords = lat && lng ? { lat: Number(lat), lng: Number(lng) } : null;
+  const latStr = params.get('lat');
+  const lngStr = params.get('lng');
+  const lat = latStr != null ? Number(latStr) : undefined;
+  const lng = lngStr != null ? Number(lngStr) : undefined;
+  const destCoords =
+    lat != null &&
+    lng != null &&
+    !Number.isNaN(lat) &&
+    !Number.isNaN(lng)
+      ? { lat, lng }
+      : null;
   return { dest, destCoords };
 }

--- a/tests/unit/features/planner/hooks/usePlanParams.test.ts
+++ b/tests/unit/features/planner/hooks/usePlanParams.test.ts
@@ -27,4 +27,11 @@ describe('usePlanParams', () => {
     expect(result.current.dest).toBe('');
     expect(result.current.destCoords).toBeNull();
   });
+
+  test('normalizes destination and ignores invalid coordinates', () => {
+    params = new URLSearchParams({ dest: ' ROME ', lat: 'abc', lng: '2' });
+    const { result } = renderHook(() => usePlanParams());
+    expect(result.current.dest).toBe('rome');
+    expect(result.current.destCoords).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- validate planner URL coordinates to ignore NaN values
- cover invalid coordinates and destination normalization in usePlanParams tests
- fix typo in testing guide

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b798fdfed48322a1e10fefb1d47484