### PR TITLE
⚡️ Optimize planner integration tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-This project uses **Vitest** with React Testing Library for unit tests.
+This project uses **Vitest** with React Testing Library for unit and integration tests.
 
 ## Vitest configuration
 
@@ -12,11 +12,11 @@ Tests are discovered from `tests/{unit,integration}/**/*.{test,spec}.{ts,tsx}`.
 
 ## Current strategy
 
-Only component unit tests exist today. Future work may add integration or e2e coverage once the app stabilizes. Integration tests will live under `tests/integration`.
+Component unit tests live under `tests/unit` and focus on isolated modules. Integration tests reside in `tests/integration` and exercise interactions across features. Additional e2e coverage may be added once the app stabilizes.
 
 ## Folder and file naming
 
-Test files use the `*.test.ts` or `*.test.tsx` pattern and live under `tests/unit`, mirroring the source directory structure.
+Test files use the `*.test.ts` or `*.test.tsx` pattern in `tests/unit` and the `*.spec.ts` or `*.spec.tsx` pattern in `tests/integration`, mirroring the source directory structure.
 
 ## Mocking guidelines
 

--- a/tests/integration/onboarding/onboardingModal.spec.tsx
+++ b/tests/integration/onboarding/onboardingModal.spec.tsx
@@ -1,0 +1,71 @@
+// tests/integration/onboarding/onboardingModal.spec.tsx
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('@/features/planner', async () => {
+  const React = await import('react');
+  return {
+    PlannerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    usePlannerContext: () => ({
+      planId: 'p1',
+      dest: 'rome',
+      days: [],
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+    }),
+    usePlanTitle: () => ({ title: 'Trip', setTitle: vi.fn(), saveTitle: vi.fn() }),
+    ActivityModal: () => null,
+    PlannerControls: () => <div />,
+  };
+});
+
+vi.mock('@/features/onboarding', () => {
+  const React = require('react');
+  const Ctx = React.createContext({ showOnboarding: true, setShowOnboarding: () => {} });
+  const OnboardingProvider = ({ children }: { children: React.ReactNode }) => {
+    const [showOnboarding, setShowOnboarding] = React.useState(true);
+    return <Ctx.Provider value={{ showOnboarding, setShowOnboarding }}>{children}</Ctx.Provider>;
+  };
+  const OnboardingModal = () => {
+    const { showOnboarding, setShowOnboarding } = React.useContext(Ctx);
+    if (!showOnboarding) return null;
+    return (
+      <div role="dialog">
+        <button onClick={() => setShowOnboarding(false)}>Close</button>
+      </div>
+    );
+  };
+  return { OnboardingModal, OnboardingProvider };
+});
+
+vi.mock('@/app/planner/PlannerBoard', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/app/planner/MapView', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/app/planner/BudgetPanel', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import PlannerClient from '@/app/planner/PlannerClient';
+
+describe('onboarding modal visibility', () => {
+  it('shows modal initially and hides after finish', async () => {
+    render(<PlannerClient planId="p1" hideOnboarding={false} />);
+
+    const modal = await screen.findByRole('dialog');
+    expect(modal).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/tests/integration/planner/budgetPanel.spec.tsx
+++ b/tests/integration/planner/budgetPanel.spec.tsx
@@ -1,0 +1,87 @@
+// tests/integration/planner/budgetPanel.spec.tsx
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { DayPlan } from '@/shared/types';
+
+let mockDays: DayPlan[] = [];
+
+const mockFrom = vi.fn();
+vi.mock('@/shared/lib/supabaseClient', () => ({
+  supabase: { from: (table: string) => mockFrom(table) },
+}));
+
+vi.mock('@/features/planner', async () => {
+  const actual = await vi.importActual<typeof import('@/features/planner')>('@/features/planner');
+  return {
+    ...actual,
+    PlannerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    usePlannerContext: () => ({
+      planId: 'p1',
+      days: mockDays,
+      updateActivity: vi.fn(),
+    }),
+  };
+});
+
+import { PlannerProvider } from '@/features/planner';
+import BudgetPanel from '@/app/planner/BudgetPanel';
+
+describe('budget panel', () => {
+  beforeEach(() => {
+    mockFrom.mockReset();
+  });
+
+  it('adds expenses and updates totals', async () => {
+    const selectBudget = vi.fn().mockResolvedValue({ data: { budget: 0 }, error: null });
+    const selectEntries = vi.fn().mockResolvedValue({ data: [], error: null });
+    const updateBudget = vi.fn().mockResolvedValue({ error: null });
+    const insertEntry = vi.fn().mockResolvedValue({ data: { id: 'e1' }, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'plans') {
+        return {
+          select: () => ({ eq: () => ({ single: () => selectBudget() }) }),
+          update: () => ({ eq: () => updateBudget() }),
+        } as unknown;
+      }
+      if (table === 'budget_entries') {
+        return {
+          select: () => ({ eq: () => selectEntries() }),
+          insert: () => ({ select: () => ({ single: () => insertEntry() }) }),
+        } as unknown;
+      }
+      return {} as unknown;
+    });
+
+    mockDays = [
+      {
+        id: 'd1',
+        label: 'Day 1',
+        activities: [{ id: 'a1', title: 'Act', color: 'bg-[var(--color-1)]', budget: 25 }],
+      },
+    ];
+
+    render(
+      <PlannerProvider planId="p1">
+        <BudgetPanel />
+      </PlannerProvider>
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Total spent: $25.00')).toBeInTheDocument());
+    expect(updateBudget).not.toHaveBeenCalled();
+    expect(screen.queryByText('Failed to persist budget')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Description'), {
+      target: { value: 'Taxi' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Amount'), {
+      target: { value: '50' },
+    });
+    fireEvent.click(screen.getByLabelText('Add expense'));
+
+    await waitFor(() => expect(insertEntry).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByLabelText('Total spent: $75.00')).toBeInTheDocument());
+  });
+});

--- a/tests/integration/planner/dateRangeChange.spec.tsx
+++ b/tests/integration/planner/dateRangeChange.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { DateRange } from 'react-day-picker';
+import type { DayPlan } from '@/shared/types';
+
+import PlannerClient from '@/app/planner/PlannerClient';
+
+type Bounds = { sw: [number, number]; ne: [number, number] };
+interface PlannerCtx {
+  planId: string;
+  dest: string;
+  days: DayPlan[];
+  currentRange: DateRange | undefined;
+  handleRangeChange: () => void;
+  addBlankAndSelect: () => void;
+  bounds: Bounds;
+}
+
+// Initial and updated planner state
+const initialDays: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
+const updatedDays: DayPlan[] = [{ id: 'd2', label: 'Day 2', activities: [] }];
+const initialBounds: Bounds = { sw: [0, 0], ne: [1, 1] };
+const updatedBounds: Bounds = { sw: [2, 2], ne: [3, 3] };
+
+// Mocks for shared UI components
+vi.mock('@/shared/ui', () => ({
+  ModeToggleButton: () => <div />, // not used in this test
+  DateRangePicker: ({
+    onChange,
+  }: {
+    value: DateRange | undefined;
+    onChange: (r: DateRange | undefined) => void;
+  }) => (
+    <button
+      data-testid="date-picker"
+      onClick={() => onChange({ from: new Date('2025-01-01'), to: new Date('2025-01-02') })}
+    >
+      Pick dates
+    </button>
+  ),
+  DateRangePickerIcon: () => <div />,
+  Button: (props: React.ComponentProps<'button'>) => <button {...props} />,
+}));
+
+let setDays: React.Dispatch<React.SetStateAction<DayPlan[]>>;
+let setBounds: React.Dispatch<React.SetStateAction<Bounds>>;
+var getPlannerContext: () => PlannerCtx;
+export const handleRangeChange = vi.fn(() => {
+  setDays(updatedDays);
+  setBounds(updatedBounds);
+});
+
+// Planner feature mocks
+vi.mock('@/features/planner', async () => {
+  const React = await import('react');
+  const { DateRangePicker } = await import('@/shared/ui');
+  const PlannerContext = React.createContext({
+    planId: '',
+    dest: '',
+    days: [] as DayPlan[],
+    currentRange: undefined as DateRange | undefined,
+    handleRangeChange: () => {},
+    addBlankAndSelect: () => {},
+    bounds: { sw: [0, 0], ne: [1, 1] } as Bounds,
+  });
+
+  function PlannerProvider({
+    children,
+    initialDays,
+  }: {
+    children: React.ReactNode;
+    initialDays: DayPlan[];
+  }) {
+    const [days, _setDays] = React.useState(initialDays);
+    const [bounds, _setBounds] = React.useState(initialBounds);
+    setDays = _setDays;
+    setBounds = _setBounds;
+    const value = {
+      planId: 'p1',
+      dest: 'rome',
+      days,
+      currentRange: undefined as DateRange | undefined,
+      handleRangeChange,
+      addBlankAndSelect: vi.fn(),
+      bounds,
+    };
+    return <PlannerContext.Provider value={value}>{children}</PlannerContext.Provider>;
+  }
+
+  const usePlannerContext = () => React.useContext(PlannerContext);
+  getPlannerContext = usePlannerContext;
+  const usePlanTitle = () => ({ title: 'Trip', setTitle: vi.fn(), saveTitle: vi.fn() });
+  const ActivityModal = () => null;
+  const PlannerControls = () => {
+    const { currentRange, handleRangeChange } = usePlannerContext();
+    return (
+      <div>
+        <DateRangePicker value={currentRange} onChange={handleRangeChange} />
+      </div>
+    );
+  };
+
+  return {
+    PlannerProvider,
+    usePlannerContext,
+    usePlanTitle,
+    ActivityModal,
+    PlannerControls,
+    BudgetProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+// Onboarding mocks
+vi.mock('@/features/onboarding', () => ({
+  OnboardingModal: () => null,
+  OnboardingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Downstream components that read from planner context
+vi.mock('@/app/planner/PlannerBoard', () => {
+  const React = require('react');
+  return {
+    default: function PlannerBoardMock() {
+      const { days } = getPlannerContext();
+      return <div data-testid="planner-board">{days.map((d: DayPlan) => d.id).join(',')}</div>;
+    },
+  };
+});
+
+vi.mock('@/app/planner/MapView', () => {
+  const React = require('react');
+  return {
+    default: function MapViewMock() {
+      const ctx =
+        typeof getPlannerContext === 'function' ? getPlannerContext() : { bounds: initialBounds };
+      return <div data-testid="map-view">{JSON.stringify(ctx.bounds)}</div>;
+    },
+  };
+});
+
+vi.mock('@/app/planner/BudgetPanel', () => ({
+  default: () => <div />,
+}));
+
+// Next.js router mocks
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe('date range change propagation', () => {
+  it('calls handleRangeChange and updates downstream components', async () => {
+    render(<PlannerClient initialDays={initialDays} planId="p1" hideOnboarding />);
+
+    const boardEl = screen.getByTestId('planner-board');
+    expect(boardEl).toHaveTextContent('d1');
+    const mapEl = await screen.findByTestId('map-view');
+    expect(mapEl).toHaveTextContent(JSON.stringify(initialBounds));
+
+    fireEvent.click(screen.getByTestId('date-picker'));
+
+    expect(handleRangeChange).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(boardEl).toHaveTextContent('d2');
+      expect(mapEl).toHaveTextContent(JSON.stringify(updatedBounds));
+    });
+  });
+});

--- a/tests/integration/planner/mapRender.spec.tsx
+++ b/tests/integration/planner/mapRender.spec.tsx
@@ -59,7 +59,17 @@ vi.mock('@/features/planner', () => ({
   }),
 }));
 
-afterEach(() => {
+function renderMapView(days: DayPlan[], destCoords: { lat: number; lng: number } | null = null) {
+  mockDays = days;
+  mockDestCoords = destCoords;
+  return render(
+    <PlannerProvider planId="p1">
+      <MapView />
+    </PlannerProvider>
+  );
+}
+
+beforeEach(() => {
   map.fitBounds.mockClear();
   markers.length = 0;
   containerProps = undefined;
@@ -79,24 +89,13 @@ describe('map render integration', () => {
         ],
       },
     ];
-    mockDays = days;
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(days);
     expect(markers[0].title).toBe('Walk');
   });
 
   it('centers map using provided coordinates', () => {
     const days: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
-    mockDays = days;
-    mockDestCoords = { lat: 3, lng: 4 };
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(days, { lat: 3, lng: 4 });
     expect(containerProps!.center).toEqual([3, 4]);
   });
 
@@ -110,12 +109,7 @@ describe('map render integration', () => {
         ],
       },
     ];
-    mockDays = days;
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(days);
     markers[0].eventHandlers?.click?.();
     expect(setSelectedActivity).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'a1', dayId: 'd1' })
@@ -130,12 +124,7 @@ describe('map render integration', () => {
         activities: [{ id: 'a1', title: 'Walk', color: 'bg-[var(--color-1)]' }],
       },
     ];
-    mockDays = days;
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(days);
     expect(markers.length).toBe(0);
     expect(map.fitBounds).not.toHaveBeenCalled();
   });
@@ -150,20 +139,10 @@ describe('map render integration', () => {
         ],
       },
     ];
-    mockDays = buildDays(1, 1);
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(buildDays(1, 1));
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
     map.fitBounds.mockClear();
-    mockDays = buildDays(2, 2);
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(buildDays(2, 2));
     expect(map.fitBounds).toHaveBeenCalledTimes(1);
   });
 
@@ -177,12 +156,7 @@ describe('map render integration', () => {
         ],
       },
     ];
-    mockDays = days;
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(days);
     const preventDefault = vi.fn();
     markers[0].eventHandlers?.contextmenu?.({
       originalEvent: { preventDefault },
@@ -194,11 +168,7 @@ describe('map render integration', () => {
   });
 
   it('falls back to default center when no coordinates provided', () => {
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView([]);
     expect(containerProps!.center).toEqual([0, 0]);
     expect(map.fitBounds).not.toHaveBeenCalled();
   });
@@ -213,19 +183,9 @@ describe('map render integration', () => {
         ],
       },
     ];
-    mockDays = buildDays('A1', 1, 1);
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(buildDays('A1', 1, 1));
     expect(markers).toHaveLength(1);
-    mockDays = buildDays('A2', 2, 2);
-    render(
-      <PlannerProvider planId="p1">
-        <MapView />
-      </PlannerProvider>
-    );
+    renderMapView(buildDays('A2', 2, 2));
     expect(markers).toHaveLength(2);
     expect(markers[1].title).toBe('A2');
   });

--- a/tests/integration/planner/plannerClientMode.spec.tsx
+++ b/tests/integration/planner/plannerClientMode.spec.tsx
@@ -1,0 +1,101 @@
+// tests/integration/planner/plannerClientMode.spec.tsx
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+
+type Mode = 'planner' | 'map' | 'budget';
+
+vi.mock('@/shared/ui', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/ui')>('@/shared/ui');
+  return {
+    ...actual,
+    ModeToggleButton: ({ onChange }: { value: Mode; onChange: (m: Mode) => void }) => (
+      <div>
+        <button onClick={() => onChange('planner')}>Planner</button>
+        <button onClick={() => onChange('map')}>Map</button>
+        <button onClick={() => onChange('budget')}>Budget</button>
+      </div>
+    ),
+    DateRangePicker: () => <div />,
+    DateRangePickerIcon: () => <div />,
+  };
+});
+
+vi.mock('@/features/planner', async () => {
+  const React = await import('react');
+  const { ModeToggleButton } = await import('@/shared/ui');
+  return {
+    PlannerProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    usePlannerContext: () => ({
+      planId: 'p1',
+      dest: 'rome',
+      days: [],
+      currentRange: undefined,
+      handleRangeChange: vi.fn(),
+      addBlankAndSelect: vi.fn(),
+    }),
+    usePlanTitle: () => ({ title: 'Trip', setTitle: vi.fn(), saveTitle: vi.fn() }),
+    ActivityModal: () => null,
+    PlannerControls: ({ mode, onModeChange }: { mode: Mode; onModeChange: (m: Mode) => void }) => (
+      <div data-testid="planner-controls">
+        <ModeToggleButton value={mode} onChange={onModeChange} />
+      </div>
+    ),
+  };
+});
+
+vi.mock('@/features/onboarding', () => ({
+  OnboardingModal: () => null,
+  OnboardingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/app/planner/PlannerBoard', () => ({
+  default: () => <div data-testid="planner-board" />,
+}));
+vi.mock('@/app/planner/MapView', () => ({
+  default: () => <div data-testid="map-view" />,
+}));
+vi.mock('@/app/planner/BudgetPanel', () => ({
+  default: () => <div data-testid="budget-panel" />,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import PlannerClient from '@/app/planner/PlannerClient';
+
+describe('planner client mode switching', () => {
+  it('shows only the active panel when toggling modes', async () => {
+    render(<PlannerClient planId="p1" hideOnboarding />);
+
+    const plannerBtn = screen.getByRole('button', { name: 'Planner' });
+    const mapBtn = screen.getByRole('button', { name: 'Map' });
+    const budgetBtn = screen.getByRole('button', { name: 'Budget' });
+
+    const board = await screen.findByTestId('planner-board');
+    const map = await screen.findByTestId('map-view');
+    const budget = await screen.findByTestId('budget-panel');
+
+    expect(board.parentElement).toHaveStyle({ pointerEvents: 'auto' });
+    expect(map.parentElement).toHaveStyle({ pointerEvents: 'none' });
+    expect(budget.parentElement).toHaveStyle({ pointerEvents: 'none' });
+
+    fireEvent.click(mapBtn);
+    expect(board.parentElement).toHaveStyle({ pointerEvents: 'none' });
+    expect(map.parentElement).toHaveStyle({ pointerEvents: 'auto' });
+    expect(budget.parentElement).toHaveStyle({ pointerEvents: 'none' });
+
+    fireEvent.click(budgetBtn);
+    expect(board.parentElement).toHaveStyle({ pointerEvents: 'none' });
+    expect(map.parentElement).toHaveStyle({ pointerEvents: 'none' });
+    expect(budget.parentElement).toHaveStyle({ pointerEvents: 'auto' });
+
+    fireEvent.click(plannerBtn);
+    expect(board.parentElement).toHaveStyle({ pointerEvents: 'auto' });
+    expect(map.parentElement).toHaveStyle({ pointerEvents: 'none' });
+    expect(budget.parentElement).toHaveStyle({ pointerEvents: 'none' });
+  });
+});


### PR DESCRIPTION
## Summary
- streamline planner map integration tests with centralized render helper and setup
- document existing integration test strategy
- add integration test for PlannerClient mode switching
- add integration test for onboarding modal visibility
- add integration test for BudgetPanel expense persistence
- add integration test for date range change propagation

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7d11ca2c83229dcfd67c845cd67d