### PR TITLE
♻️ Extract Supabase plan day mapping helper

### DIFF
--- a/src/app/planner/[slug]/page.tsx
+++ b/src/app/planner/[slug]/page.tsx
@@ -2,10 +2,12 @@
 export const dynamic = 'force-dynamic';
 
 import PlannerClient from '../PlannerClient';
+import {
+  mapPlanDaysFromSupabase,
+  type SupabasePlanDayRow,
+} from '@/features/planner/services/supabase/planDaysMapper';
 import { supabaseServer } from '@/shared/lib/supabaseServer';
 import type { DayPlan } from '@/shared/types';
-import { format, parseISO } from 'date-fns';
-import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -48,43 +50,12 @@ export default async function PlannerPlanPage({ params, searchParams }: PageProp
     .select('date, activities(*)')
     .eq('plan_id', planId)
     .order('position')) as unknown as {
-    data: {
-      date: string;
-      activities: {
-        id: string;
-        title: string;
-        color: string | null;
-        category: string;
-        description: string | null;
-        start_time: string | null;
-        duration: number | null;
-        latitude: number | null;
-        longitude: number | null;
-        budget: number | null;
-        image_url: string | null;
-      }[];
-    }[];
+    data: SupabasePlanDayRow[] | null;
     error: unknown;
   };
 
   if (!dayErr && dayRows) {
-    initialDays = dayRows.map((d) => ({
-      id: d.date,
-      label: format(parseISO(d.date), 'EEE, dd MMM'),
-      activities: d.activities.map((a) => ({
-        id: a.id,
-        title: a.title,
-        color: a.color ?? DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
-        category: a.category,
-        description: a.description ?? undefined,
-        startTime: a.start_time ?? undefined,
-        duration: a.duration ?? undefined,
-        latitude: a.latitude ?? undefined,
-        longitude: a.longitude ?? undefined,
-        budget: a.budget ?? undefined,
-        imageUrl: a.image_url ?? undefined,
-      })),
-    })) as DayPlan[];
+    initialDays = mapPlanDaysFromSupabase(dayRows);
   }
 
   if (!destination) {

--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -1,29 +1,15 @@
 // src/features/planner/hooks/usePlanDaysSupabase.ts
 
+import {
+  mapPlanDaysFromSupabase,
+  type SupabaseActivityRow,
+  type SupabasePlanDayRow,
+} from '@/features/planner/services/supabase/planDaysMapper';
 import { usePlanResource } from '@/shared/hooks/usePlanResource';
 import type { SupabaseQueryBuilder } from '@supabase/supabase-js';
 import { supabase } from '@/shared/lib/supabaseClient';
 import type { PlanDay, DayPlan } from '@/shared/types';
-import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
-import { format, parseISO } from 'date-fns';
 import { fetchExistingDays, deleteRemovedDays, upsertDayActivities } from './persistDaysHelpers';
-
-interface ActivityRow {
-  id: string;
-  day_id: string;
-  title: string | null;
-  color: string | null;
-  address: string | null;
-  category: string | null;
-  description: string | null;
-  start_time: string | null;
-  duration: number | null;
-  latitude: number | null;
-  longitude: number | null;
-  budget: number | null;
-  image_url: string | null;
-  position: number | null;
-}
 
 interface QueryBuilder extends SupabaseQueryBuilder {
   select: (...args: unknown[]) => QueryBuilder;
@@ -38,11 +24,6 @@ interface QueryBuilder extends SupabaseQueryBuilder {
   single: () => Promise<{ data: unknown; error: unknown }>;
 }
 
-interface PlanDayWithActivities {
-  date: string;
-  activities: ActivityRow[];
-}
-
 export function usePlanDays(planId: string, enabled = true) {
   const days = usePlanResource<DayPlan[]>({
     planId,
@@ -53,28 +34,11 @@ export function usePlanDays(planId: string, enabled = true) {
         .eq('plan_id', id)
         .order('position')
         .order('position', { foreignTable: 'activities' })) as unknown as {
-        data: PlanDayWithActivities[];
+        data: SupabasePlanDayRow[];
         error: unknown;
       };
       if (error) throw error;
-      return data.map((d) => ({
-        id: d.date,
-        label: format(parseISO(d.date), 'EEE, dd MMM'),
-        activities: d.activities.map((a) => ({
-          id: a.id,
-          title: a.title,
-          color: a.color ?? DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
-          address: a.address ?? undefined,
-          category: a.category,
-          description: a.description ?? undefined,
-          startTime: a.start_time ?? undefined,
-          duration: a.duration ?? undefined,
-          latitude: a.latitude ?? undefined,
-          longitude: a.longitude ?? undefined,
-          budget: a.budget ?? undefined,
-          imageUrl: a.image_url ?? undefined,
-        })),
-      })) as DayPlan[];
+      return mapPlanDaysFromSupabase(data);
     },
     enabled,
   });
@@ -125,7 +89,7 @@ export function usePlanDays(planId: string, enabled = true) {
           existing.map((d) => d.id)
         )
         .abortSignal(signal)) as unknown as {
-        data: Pick<ActivityRow, 'id' | 'day_id'>[] | null;
+        data: Pick<SupabaseActivityRow, 'id' | 'day_id'>[] | null;
         error: unknown;
       };
       if (existingActsErr) throw existingActsErr;

--- a/src/features/planner/services/supabase/planDaysMapper.ts
+++ b/src/features/planner/services/supabase/planDaysMapper.ts
@@ -1,0 +1,56 @@
+// src/features/planner/services/supabase/planDaysMapper.ts
+
+import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
+import type { DayPlan } from '@/shared/types';
+import { format, parseISO } from 'date-fns';
+
+export interface SupabaseActivityRow {
+  id: string;
+  day_id: string;
+  title: string | null;
+  color: string | null;
+  address: string | null;
+  category: string | null;
+  description: string | null;
+  start_time: string | null;
+  duration: number | null;
+  latitude: number | null;
+  longitude: number | null;
+  budget: number | null;
+  image_url: string | null;
+  position: number | null;
+}
+
+export interface SupabasePlanDayRow {
+  date: string;
+  activities: SupabaseActivityRow[] | null;
+}
+
+function mapActivityRow(activity: SupabaseActivityRow) {
+  return {
+    id: activity.id,
+    title: activity.title ?? '',
+    color: activity.color ?? DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
+    address: activity.address ?? undefined,
+    category: activity.category ?? undefined,
+    description: activity.description ?? undefined,
+    startTime: activity.start_time ?? undefined,
+    duration: activity.duration ?? undefined,
+    latitude: activity.latitude ?? undefined,
+    longitude: activity.longitude ?? undefined,
+    budget: activity.budget ?? undefined,
+    imageUrl: activity.image_url ?? undefined,
+  } satisfies DayPlan['activities'][number];
+}
+
+export function mapPlanDaysFromSupabase(rows: SupabasePlanDayRow[] | null | undefined): DayPlan[] {
+  if (!rows?.length) {
+    return [];
+  }
+
+  return rows.map((day) => ({
+    id: day.date,
+    label: format(parseISO(day.date), 'EEE, dd MMM'),
+    activities: (day.activities ?? []).map(mapActivityRow),
+  }));
+}

--- a/tests/unit/features/planner/services/supabase/planDaysMapper.test.ts
+++ b/tests/unit/features/planner/services/supabase/planDaysMapper.test.ts
@@ -1,0 +1,127 @@
+// tests/unit/features/planner/services/supabase/planDaysMapper.test.ts
+
+import {
+  mapPlanDaysFromSupabase,
+  type SupabasePlanDayRow,
+} from '@/features/planner/services/supabase/planDaysMapper';
+import { DEFAULT_COLORS, DEFAULT_NEW_CARD_COLOR_INDEX } from '@/shared/constants';
+
+const DEFAULT_COLOR = DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg;
+
+describe('mapPlanDaysFromSupabase', () => {
+  it('maps supabase rows to day plans with activity details', () => {
+    const rows: SupabasePlanDayRow[] = [
+      {
+        date: '2024-07-05',
+        activities: [
+          {
+            id: 'activity-1',
+            day_id: 'day-1',
+            title: 'Visit the museum',
+            color: '#123456',
+            address: '123 Museum Rd',
+            category: 'culture',
+            description: 'Explore art exhibits',
+            start_time: '09:00',
+            duration: 90,
+            latitude: 51.5014,
+            longitude: -0.1419,
+            budget: 25,
+            image_url: 'https://example.com/museum.jpg',
+            position: 0,
+          },
+        ],
+      },
+    ];
+
+    const result = mapPlanDaysFromSupabase(rows);
+
+    expect(result).toEqual([
+      {
+        id: '2024-07-05',
+        label: 'Fri, 05 Jul',
+        activities: [
+          {
+            id: 'activity-1',
+            title: 'Visit the museum',
+            color: '#123456',
+            address: '123 Museum Rd',
+            category: 'culture',
+            description: 'Explore art exhibits',
+            startTime: '09:00',
+            duration: 90,
+            latitude: 51.5014,
+            longitude: -0.1419,
+            budget: 25,
+            imageUrl: 'https://example.com/museum.jpg',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('converts nullish values to safe defaults and handles empty activity lists', () => {
+    const rows: SupabasePlanDayRow[] = [
+      {
+        date: '2024-07-06',
+        activities: [
+          {
+            id: 'activity-2',
+            day_id: 'day-2',
+            title: null,
+            color: null,
+            address: null,
+            category: null,
+            description: null,
+            start_time: null,
+            duration: null,
+            latitude: null,
+            longitude: null,
+            budget: null,
+            image_url: null,
+            position: 1,
+          },
+        ],
+      },
+      {
+        date: '2024-07-07',
+        activities: null,
+      },
+    ];
+
+    const result = mapPlanDaysFromSupabase(rows);
+
+    expect(result[0]).toEqual({
+      id: '2024-07-06',
+      label: 'Sat, 06 Jul',
+      activities: [
+        {
+          id: 'activity-2',
+          title: '',
+          color: DEFAULT_COLOR,
+          address: undefined,
+          category: undefined,
+          description: undefined,
+          startTime: undefined,
+          duration: undefined,
+          latitude: undefined,
+          longitude: undefined,
+          budget: undefined,
+          imageUrl: undefined,
+        },
+      ],
+    });
+
+    expect(result[1]).toEqual({
+      id: '2024-07-07',
+      label: 'Sun, 07 Jul',
+      activities: [],
+    });
+  });
+
+  it('returns an empty array when no rows are provided', () => {
+    expect(mapPlanDaysFromSupabase(null)).toEqual([]);
+    expect(mapPlanDaysFromSupabase(undefined)).toEqual([]);
+    expect(mapPlanDaysFromSupabase([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the Supabase plan day row mapping into a shared mapper that normalises every activity field
- reuse the mapper in the plan days hook and public planner page to eliminate duplicate transformation logic
- cover the mapper with unit tests to prove consistent behaviour for client and server consumers

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d081829b788322b4477c15403dcd50