### PR TITLE
Refactor Geoapify query validation into shared helper

### DIFF
--- a/src/server/api/autocomplete/route.ts
+++ b/src/server/api/autocomplete/route.ts
@@ -1,5 +1,6 @@
 // src/server/api/autocomplete/route.ts
 import { NextRequest, NextResponse } from 'next/server';
+import { validateGeoapifyQuery } from '@/server/api/geoapify/validateQuery';
 import { fetchGeoapifyAutocomplete } from '@/shared/lib/geoapify';
 
 /**
@@ -10,15 +11,12 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const text = searchParams.get('text');
+  const text = validateGeoapifyQuery(searchParams, 'text');
+  if (typeof text !== 'string') {
+    return text;
+  }
   const lat = searchParams.get('lat');
   const lon = searchParams.get('lon');
-  if (!text) {
-    return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
-  }
-  if (text.length < 4) {
-    return NextResponse.json({ error: 'Query must be at least 4 characters.' }, { status: 400 });
-  }
 
   try {
     const results = await fetchGeoapifyAutocomplete(

--- a/src/server/api/geoapify/validateQuery.ts
+++ b/src/server/api/geoapify/validateQuery.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Validates that a Geoapify request contains the required query parameter.
+ * Returns the original string when valid or an error response otherwise.
+ */
+export function validateGeoapifyQuery(
+  searchParams: URLSearchParams,
+  param: string
+): string | NextResponse {
+  const value = searchParams.get(param);
+  if (!value) {
+    return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
+  }
+
+  if (value.length < 4) {
+    return NextResponse.json({ error: 'Query must be at least 4 characters.' }, { status: 400 });
+  }
+
+  return value;
+}

--- a/src/server/api/search/route.ts
+++ b/src/server/api/search/route.ts
@@ -1,5 +1,6 @@
 // src/server/api/search/route.ts
 import { NextRequest, NextResponse } from 'next/server';
+import { validateGeoapifyQuery } from '@/server/api/geoapify/validateQuery';
 import { fetchGeoapifySearch } from '@/shared/lib/geoapify';
 
 /**
@@ -10,13 +11,10 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const q = searchParams.get('q');
+  const q = validateGeoapifyQuery(searchParams, 'q');
   const lang = searchParams.get('lang') ?? 'en';
-  if (!q) {
-    return NextResponse.json({ error: 'Query is required.' }, { status: 400 });
-  }
-  if (q.length < 4) {
-    return NextResponse.json({ error: 'Query must be at least 4 characters.' }, { status: 400 });
+  if (typeof q !== 'string') {
+    return q;
   }
 
   try {

--- a/tests/unit/server/api/autocomplete/route.test.ts
+++ b/tests/unit/server/api/autocomplete/route.test.ts
@@ -1,0 +1,60 @@
+import type { NextRequest } from 'next/server';
+import { vi } from 'vitest';
+import { GET } from '@/server/api/autocomplete/route';
+
+const { mockFetchGeoapifyAutocomplete } = vi.hoisted(() => ({
+  mockFetchGeoapifyAutocomplete: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/geoapify', () => ({
+  fetchGeoapifyAutocomplete: mockFetchGeoapifyAutocomplete,
+}));
+
+const createRequest = (search: string): NextRequest => {
+  return { url: `https://example.com/api/autocomplete${search}` } as NextRequest;
+};
+
+describe('GET /api/autocomplete', () => {
+  beforeEach(() => {
+    mockFetchGeoapifyAutocomplete.mockReset();
+  });
+
+  it('returns 400 when the text parameter is missing', async () => {
+    const res = await GET(createRequest(''));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Query is required.' });
+  });
+
+  it('returns 400 when the text parameter is shorter than four characters', async () => {
+    const res = await GET(createRequest('?text=car'));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Query must be at least 4 characters.' });
+  });
+
+  it('proxies Geoapify autocomplete results and parses coordinates', async () => {
+    const results = [{ id: '1', formatted: 'Paris, France' }];
+    mockFetchGeoapifyAutocomplete.mockResolvedValue(results);
+
+    const res = await GET(createRequest('?text=paris&lat=48.8566&lon=2.3522'));
+
+    expect(mockFetchGeoapifyAutocomplete).toHaveBeenCalledWith('paris', 48.8566, 2.3522);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ results });
+  });
+
+  it('logs the error and returns 500 when Geoapify fails', async () => {
+    const error = new Error('network failed');
+    mockFetchGeoapifyAutocomplete.mockRejectedValue(error);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await GET(createRequest('?text=paris'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(error);
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to load suggestions.' });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/server/api/geoapify/validateQuery.test.ts
+++ b/tests/unit/server/api/geoapify/validateQuery.test.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { validateGeoapifyQuery } from '@/server/api/geoapify/validateQuery';
+
+describe('validateGeoapifyQuery', () => {
+  it('returns an error response when the parameter is missing', async () => {
+    const result = validateGeoapifyQuery(new URLSearchParams(), 'text');
+
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Query is required.' });
+  });
+
+  it('returns an error response when the value is shorter than four characters', async () => {
+    const params = new URLSearchParams({ text: 'abc' });
+    const result = validateGeoapifyQuery(params, 'text');
+
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Query must be at least 4 characters.',
+    });
+  });
+
+  it('returns the string when the parameter is valid', () => {
+    const params = new URLSearchParams({ text: 'paris' });
+
+    const result = validateGeoapifyQuery(params, 'text');
+
+    expect(result).toBe('paris');
+  });
+});

--- a/tests/unit/server/api/search/route.test.ts
+++ b/tests/unit/server/api/search/route.test.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from 'next/server';
+import { vi } from 'vitest';
+import { GET } from '@/server/api/search/route';
+
+const { mockFetchGeoapifySearch } = vi.hoisted(() => ({
+  mockFetchGeoapifySearch: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/geoapify', () => ({
+  fetchGeoapifySearch: mockFetchGeoapifySearch,
+}));
+
+const createRequest = (search: string): NextRequest => {
+  return { url: `https://example.com/api/search${search}` } as NextRequest;
+};
+
+describe('GET /api/search', () => {
+  beforeEach(() => {
+    mockFetchGeoapifySearch.mockReset();
+  });
+
+  it('returns 400 when the q parameter is missing', async () => {
+    const res = await GET(createRequest(''));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Query is required.' });
+  });
+
+  it('returns 400 when the q parameter is shorter than four characters', async () => {
+    const res = await GET(createRequest('?q=car'));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'Query must be at least 4 characters.' });
+  });
+
+  it('proxies Geoapify search results with the default language', async () => {
+    const data = { activities: [] };
+    mockFetchGeoapifySearch.mockResolvedValue(data);
+
+    const res = await GET(createRequest('?q=paris'));
+
+    expect(mockFetchGeoapifySearch).toHaveBeenCalledWith('paris', 'en');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(data);
+  });
+
+  it('uses the provided language when present', async () => {
+    const data = { activities: [{ id: '1' }] };
+    mockFetchGeoapifySearch.mockResolvedValue(data);
+
+    const res = await GET(createRequest('?q=paris&lang=fr'));
+
+    expect(mockFetchGeoapifySearch).toHaveBeenCalledWith('paris', 'fr');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(data);
+  });
+
+  it('logs the error and returns 500 when Geoapify fails', async () => {
+    const error = new Error('Geoapify down');
+    mockFetchGeoapifySearch.mockRejectedValue(error);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await GET(createRequest('?q=paris'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(error);
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to search.' });
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared Geoapify query validator for required params and length checks
- reuse the helper in the autocomplete and search API routes
- cover validation, lat/lon parsing, and logging behaviour with new unit tests

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0814d20b48322aa2271141415463a