### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,116 @@
+name: Lighthouse
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Disable Next.js telemetry
+        run: npx next telemetry disable
+
+      - name: Build application
+        run: npm run build:prod
+
+      - name: Run Lighthouse CI
+        id: lhci
+        continue-on-error: true
+        run: |
+          set +e
+          npx start-server-and-test "npm run serve:prod" http://127.0.0.1:3000 "npm run warmup && npm run lhci"
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          if [ -f ".lighthouseci/assertion-results.json" ]; then
+            echo "assertion_results=.lighthouseci/assertion-results.json" >> "$GITHUB_OUTPUT"
+          elif [ -f "lhci-reports/assertion-results.json" ]; then
+            echo "assertion_results=lhci-reports/assertion-results.json" >> "$GITHUB_OUTPUT"
+          fi
+          exit $status
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lhci-reports
+          path: lhci-reports
+          if-no-files-found: ignore
+
+      - name: Check Lighthouse assertions
+        if: steps.lhci.outcome == 'failure'
+        env:
+          ASSERTION_RESULTS: ${{ steps.lhci.outputs.assertion_results }}
+        run: |
+          if [ -z "${ASSERTION_RESULTS}" ] || [ ! -f "${ASSERTION_RESULTS}" ]; then
+            echo "::warning::Lighthouse CI failed, but no assertion results file was found. Skipping assertion failure."
+            exit 0
+          fi
+          node <<'NODE'
+          const fs = require('fs');
+
+          const path = process.env.ASSERTION_RESULTS;
+          let data;
+          try {
+            data = JSON.parse(fs.readFileSync(path, 'utf8'));
+          } catch (error) {
+            console.warn(`::warning::Unable to parse Lighthouse assertion results: ${error.message}`);
+            process.exit(0);
+          }
+
+          const results = Array.isArray(data.assertionResults) ? data.assertionResults : [];
+          const failed = results.filter((result) => {
+            const status = String(result.status || result.level || '').toLowerCase();
+            return status === 'fail' || status === 'error';
+          });
+          const summaryFailures = data.summary && typeof data.summary.failed === 'number' ? data.summary.failed : 0;
+
+          if (failed.length === 0 && summaryFailures === 0) {
+            console.warn('::warning::Lighthouse CI exited with a failure but no assertion errors were recorded.');
+            process.exit(0);
+          }
+
+          if (failed.length === 0 && summaryFailures > 0) {
+            const plural = summaryFailures === 1 ? '' : 's';
+            console.error(`Lighthouse reported ${summaryFailures} failing assertion${plural}, but no detailed results were available. Check the LHCI logs for more information.`);
+            process.exit(1);
+          }
+
+          const plural = failed.length === 1 ? '' : 's';
+          console.error(`Found ${failed.length} Lighthouse assertion failure${plural}:`);
+          for (const assertion of failed) {
+            const details = [];
+            if (assertion.auditId) details.push(assertion.auditId);
+            if (assertion.friendlyMessage) details.push(assertion.friendlyMessage);
+            if (assertion.expected !== undefined) details.push(`expected ${assertion.expected}`);
+            if (assertion.operator && assertion.targetValue !== undefined) {
+              details.push(`expected ${assertion.operator} ${assertion.targetValue}`);
+            }
+            if (assertion.actual !== undefined) details.push(`actual ${assertion.actual}`);
+            if (assertion.metricValue !== undefined) details.push(`metric ${assertion.metricValue}`);
+            if (details.length) {
+              console.error(`- ${details.join(' | ')}`);
+            }
+            if (assertion.url) {
+              console.error(`  URL: ${assertion.url}`);
+            }
+          }
+          process.exit(1);
+          NODE

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tsconfig.tsbuildinfo
 
 # Testing / E2E
 coverage/
+lhci-reports/
 playwright-report/
 test-results/
 cypress/videos/

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,21 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://127.0.0.1:3000/",
+        "http://127.0.0.1:3000/inspiration/rome"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {}
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": "./lhci-reports"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "build:prod": "next build",
     "start": "next start",
+    "serve:prod": "next start --hostname 0.0.0.0 --port 3000",
     "clean": "rimraf .next node_modules",
     "setup": "npm install && npm run format && npm run lint && npm run test",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\" \"tests/**/*.{ts,tsx,js,jsx,json,css,md}\"",
@@ -22,6 +24,8 @@
     "test": "vitest run -c config/vitest.config.ts",
     "test:watch": "vitest --watch -c config/vitest.config.ts",
     "test:coverage": "vitest run --coverage -c config/vitest.config.ts",
+    "warmup": "bash ./scripts/warmup.sh",
+    "lhci": "npx --yes @lhci/cli@0.14.0 autorun --config=./lighthouserc.json",
     "prepare": "husky install",
     "gen:types": "supabase gen types typescript --project-id YOUR_ID --schema public > src/types/supabase.ts",
     "vercel:pull": "npx vercel@latest pull --yes --environment=preview",

--- a/scripts/warmup.sh
+++ b/scripts/warmup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://127.0.0.1:3000}"
+ATTEMPTS=${WARMUP_ATTEMPTS:-3}
+PATHS=("/" "/inspiration/rome")
+
+for path in "${PATHS[@]}"; do
+  for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    echo "Warming ${BASE_URL}${path} (attempt ${attempt}/${ATTEMPTS})"
+    curl -sSf -o /dev/null "${BASE_URL}${path}"
+    sleep 0.5
+  done
+  echo "Finished warming ${BASE_URL}${path}"
+  echo
+done


### PR DESCRIPTION
## Summary
- add a Lighthouse GitHub Actions workflow to audit the home and Rome inspiration pages and upload the generated reports
- add a reusable warmup script together with npm helper scripts for build, serve, and lhci execution
- configure Lighthouse CI collection targets and ignore stored reports from version control

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d28ce1d1e08322bc351d83600e7dc2