### PR TITLE
:memo: Add agent documentation suite for Turistar

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,91 @@
+# Turistar Development Guide for AI Agents
+
+This directory contains comprehensive documentation for AI agents working on the Turistar travel-planner codebase.
+
+## Quick Navigation
+
+- **[Commands](commands.md)** – Build, test, and utility scripts
+- **[Coding Standards](coding-standards.md)** – Formatting, components, and security guidance
+- **[Knowledge Base](knowledge-base.md)** – Domain knowledge, environment, and review expectations
+- **[Architecture Overview](#architecture-overview)** – System structure and patterns
+
+## Getting Started
+
+Turistar is a single Next.js 15 application using the App Router with React 19 and Tailwind CSS. Node.js 20.x and npm 10.x are required for parity with CI.
+
+1. Install dependencies with `npm install`.
+2. Copy `.env.example` to `.env.local` and provide Supabase and Geoapify credentials.
+3. Start the development server via `npm run dev`.
+4. Before committing, run `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run test`.
+
+### Key Directories
+
+- `src/app/` – Next.js App Router entry points, layouts, routes, and metadata
+- `src/features/` – Feature modules (planner, onboarding, home) containing UI, hooks, and services
+- `src/shared/` – Shared UI components, hooks, utilities, constants, and Supabase clients
+- `src/server/` – Server actions, API route handlers, and Geoapify proxy logic
+- `src/data/` – Sample itineraries and seed data bundled with the app
+- `config/` – Tooling configuration for ESLint, Vitest, and security headers
+- `tests/` – Vitest unit and integration suites mirroring the source structure
+
+## Architecture Overview
+
+### Data Layer
+
+- User-generated itineraries persist to Supabase via helpers in `src/shared/lib/`
+- Public demo data lives in `src/data/` and is read-only at runtime
+- Supabase types are generated into `src/types/supabase.ts` (see `npm run gen:types`)
+
+### API Layer
+
+- Server actions and API routes re-export logic from `src/server/`
+- `/api/search` proxies Geoapify; always validate query params before forwarding requests
+- Authentication relies on Supabase session helpers—never expose service role keys to the client
+
+### Frontend
+
+- React 19 functional components with hooks power each feature module
+- Drag-and-drop behavior uses `@dnd-kit` sensors encapsulated in planner hooks
+- Tailwind CSS provides styling; shadcn-derived components live under `src/shared/ui`
+- Metadata, sitemap, and robots handling leverage Next.js metadata APIs and utilities in `src/shared/components/`
+
+## Common Patterns
+
+### Error Handling
+
+- Prefer early returns for null/undefined checks to avoid deep nesting
+- Wrap server interactions with user-friendly error messages and log raw errors only on the server
+- Use Zod schemas to validate incoming data before passing to Supabase or external APIs
+
+### State Management
+
+- Planner state is provided via `PlannerContext` and derived hooks in `src/features/planner/hooks`
+- When sharing values across components, expose typed context hooks instead of prop drilling
+- Use TanStack Query for asynchronous fetching and cache invalidation when integrating new APIs
+
+### Accessibility
+
+- Follow the checklist in `docs/ACCESSIBILITY.md` for every UI change
+- Provide path banner comments and annotate custom hooks per `docs/COMMENTING.md`
+- Use semantic elements first, applying ARIA roles sparingly when semantics are insufficient
+
+### Styling
+
+- Keep styling utility-first with Tailwind; co-locate variants using `class-variance-authority`
+- Extend `src/app/globals.css` tokens when adding new theme variables
+- Only create ad-hoc CSS modules when Tailwind utilities cannot express the layout
+
+## Testing Strategy
+
+- Unit and integration tests use Vitest with React Testing Library (`npm run test`)
+- Tests live under `tests/unit` and `tests/integration` using `*.test.ts(x)` and `*.spec.ts(x)` conventions
+- Global mocks are centralized in `config/vitest.setup.tsx`; prefer local mocks only for test-specific behavior
+- Accessibility assertions rely on `jest-axe`; keep them updated when modifying markup
+
+## Pull Request Guidelines
+
+- Keep documentation, types, and tests in sync with feature work—update relevant files in `docs/`
+- Split large features into reviewable commits and reference related tickets in descriptions
+- Commit messages must start with a Gitmoji followed by a capitalized summary (see `docs/CONTRIBUTING.md`)
+- Ensure `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run test` all pass before requesting review
+- Run `npm run check:vercel` when changes may impact deployment output to confirm preview builds succeed

--- a/.agents/coding-standards.md
+++ b/.agents/coding-standards.md
@@ -1,0 +1,66 @@
+# Coding Standards & Best Practices
+
+## Import Guidelines
+
+### Type Imports
+
+```typescript
+// ✅ Good – Use type-only imports for TypeScript definitions
+import type { Metadata } from 'next';
+import type { Database } from '@/types/supabase';
+
+// ❌ Bad – Value imports for types trigger unnecessary runtime code
+import { Metadata } from 'next';
+import { Database } from '@/types/supabase';
+```
+
+### Module Aliases
+
+- Prefer the `@/` alias instead of long relative paths: `import { PlannerControls } from '@/features/planner';`
+- Keep absolute imports grouped before relative imports; maintain alphabetical ordering within each group.
+
+## Code Structure
+
+### Early Returns
+
+- Guard against missing data (`if (!plan) return null;`) to keep components shallow and readable.
+- When fetching data, validate with Zod and exit early on parsing failures to prevent cascading errors.
+
+### Composition Over Prop Drilling
+
+- Share state through context providers (e.g., `PlannerContext`) and custom hooks.
+- Break complex UI into small components that compose shared primitives from `src/shared/ui`.
+
+### Security Rules
+
+```typescript
+// ❌ NEVER expose service-role secrets or unrestricted Supabase queries to the client
+const supabase = createClient(process.env.SUPABASE_SERVICE_ROLE_KEY!); // ❌ do not instantiate on the client
+
+// ✅ Good – Use the shared server client and select explicit columns
+import { createSupabaseServerClient } from '@/shared/lib/supabaseServer';
+
+const supabase = await createSupabaseServerClient();
+const { data } = await supabase
+  .from('plans')
+  .select('id, title, trip_start, trip_end')
+  .eq('user_id', userId);
+```
+
+## Component Patterns
+
+- Implement new UI with React function components and TypeScript typings for props.
+- Follow `docs/COMMENTING.md`: add path banner comments and document custom hooks with summary blocks.
+- Keep planner-specific logic under `src/features/planner/` and export a single default component per file when possible.
+
+## Styling
+
+- Favor Tailwind utility classes; extend variants with `class-variance-authority` when components need style permutations.
+- Update `src/app/globals.css` tokens if introducing new theme colors or spacing values.
+- Avoid inline styles except for dynamic CSS variables.
+
+## Tooling Requirements
+
+- All documentation, code comments, commit messages, and PR descriptions must be written in English.
+- Run `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run test` before pushing changes.
+- Commit messages must follow the Gitmoji + capitalized summary convention enforced by commitlint.

--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -1,0 +1,66 @@
+# Build, Test & Development Commands
+
+## Development Commands
+
+- `npm run dev` – Start the Next.js development server with Turbopack
+- `npm run warmup` – Prime the development environment by running setup scripts
+- `npm run setup` – Install dependencies and run format, lint, and test in sequence
+- `npm run start` – Serve the production build locally
+
+## Build Commands
+
+- `npm run build` – Build the production bundle
+- `npm run build:prod` – Alias for the production build (used by hosting providers)
+- `npm run serve:prod` – Run the production server on 0.0.0.0:3000
+- `npm run check:vercel` – Execute `vercel pull` + `vercel build` to validate deployment output
+- `npm run vercel:pull` – Fetch the latest Vercel environment configuration
+- `npm run vercel:build` – Run the local Vercel build with debug logs
+
+## Lint & Type Check
+
+- `npm run format` – Format source and test files with Prettier
+- `npm run format:check` – Verify formatting without writing changes
+- `npm run lint` – Run ESLint with the shared config and auto-fixes
+- `npm run typecheck` – Run the TypeScript compiler in strict, no-emit mode
+- `npm run lint:commit` – Validate the most recent commit against Gitmoji commitlint rules
+
+## Testing Commands
+
+### Unit & Integration Tests
+
+- `npm run test` – Execute the Vitest suite once (unit + integration)
+- `npm run test -- tests/unit/<file>.test.tsx` – Run a specific unit test file
+- `npm run test:watch` – Watch mode for iterative unit/integration testing
+- `npm run test:coverage` – Collect coverage with V8 instrumentation
+
+### End-to-End Tests
+
+- Turistar does not yet ship Playwright e2e tests; rely on integration coverage and manual QA flows.
+
+## Supabase Commands
+
+- `npm run gen:types` – Generate Supabase TypeScript types into `src/types/supabase.ts`
+- `supabase start` – Optional local Supabase instance for offline development (requires Supabase CLI)
+- `supabase db reset` – Reset the local database when testing schema changes
+
+## Useful Development Patterns
+
+### Running Single Tests
+
+```bash
+# Run a single integration spec
+npm run test -- tests/integration/planner/drag-and-drop.spec.tsx
+
+# Watch a unit test file while developing a component
+npm run test -- tests/unit/shared/components/map-card.test.tsx -- --watch
+
+# Generate Supabase types after updating the database schema
+npm run gen:types
+```
+
+### Environment Setup
+
+- Copy `.env.example` to `.env.local`
+- Provide `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `NEXT_PUBLIC_GEOAPIFY_KEY`
+- Add optional `SUPABASE_SERVICE_ROLE_KEY` for server-side automation scripts
+- Do not commit environment files—`.env.local` is ignored by Git

--- a/.agents/knowledge-base.md
+++ b/.agents/knowledge-base.md
@@ -1,0 +1,56 @@
+# Knowledge Base - Product & Domain-Specific Information
+
+## Repo note for andre-lmarinho/travel-planner
+
+Turistar is a single Next.js 15 application (React 19, TypeScript, Tailwind) that lives entirely in the `src/` directory. There are no workspaces or sub-packages—focus all changes within this app. Use Node.js 20.x and npm 10.x to match CI.
+
+Linting and Formatting
+- Run `npm run format` to apply Prettier with semicolons, single quotes, and 100-character width
+- Run `npm run lint` to execute ESLint with project rules (auto-fixing is enabled by default)
+- Run `npm run typecheck` to confirm the TypeScript program compiles cleanly
+
+Development
+- Install dependencies via `npm install`
+- Copy `.env.example` to `.env.local`
+- Provide Supabase (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, optional `SUPABASE_SERVICE_ROLE_KEY`) and Geoapify (`NEXT_PUBLIC_GEOAPIFY_KEY`) credentials
+- Start the development server with `npm run dev`
+
+Database Setup
+- The hosted Supabase project powers persistence; local development can use Supabase CLI for an offline database if desired
+- Generate typed bindings after schema updates using `npm run gen:types`
+- Never expose service role keys in client bundles—keep privileged access in server-only utilities inside `src/shared/lib/`
+
+PR Requirements
+- Commit messages must follow the Gitmoji + capitalized summary format enforced by commitlint
+- Every PR must pass `npm run format`, `npm run lint`, `npm run typecheck`, and `npm run test`
+- Update relevant docs in `docs/` when behavior, APIs, or environment variables change
+- Keep Supabase types (`src/types/supabase.ts`) and planner schemas in sync when modifying database tables
+
+Accessibility
+- Adhere to the checklist in `docs/ACCESSIBILITY.md` for each UI change
+- Provide accessible names for map components using `aria-label="Itinerary map"`
+- Ensure drag-and-drop interactions remain keyboard accessible through focus management hooks in `src/features/planner/hooks`
+
+Testing
+- Vitest + React Testing Library cover unit and integration scenarios; add tests under `tests/unit` or `tests/integration` mirroring source paths
+- Global testing utilities live in `config/vitest.setup.tsx` and stub Next.js modules plus Leaflet CSS imports
+- Accessibility assertions leverage `jest-axe`; include or update them when adjusting semantic markup
+
+State & Data Flow
+- Planner data is managed via `PlannerContext` with persistence handled by hooks such as `usePlanDaysSupabase`
+- The drag-and-drop board relies on `useDnDPlanner` and `useDragState`; extend these hooks rather than reimplementing sensors
+- Sample itineraries in `src/data/` should remain read-only; create new fixtures there for demos instead of mutating at runtime
+
+API Integrations
+- `/api/search` proxies Geoapify lookups; sanitize all inputs and limit results using helper functions in `src/server/api`
+- Server actions in `src/server/` centralize Supabase mutations; reuse them from components to keep business logic off the client
+
+Deployment & Observability
+- Use `npm run check:vercel` before shipping changes that influence build output, metadata, or environment configuration
+- Security headers are defined in `config/securityHeaders.ts` and applied in `next.config.ts`; update both together when altering policies
+- Logging should avoid leaking secrets—surface only user-friendly messages to the client and log details server-side via shared utilities
+
+Documentation Expectations
+- Follow `docs/COMMENTING.md` for path banners and hook summaries
+- Keep architecture, testing, and deployment docs up to date alongside code changes
+- All written communication (docs, comments, commit messages, PR summaries) must be in English

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,91 +1,31 @@
-# Project Agents.md Guide
+# Turistar Development Guide for AI Agents
 
-This `Agents.md` file provides comprehensive guidance for any AI agents working with this codebase.
+**📖 Complete documentation is in the [.agents/](.agents/) directory.**
 
-## Project Structure
+## Quick Reference
 
-- `/docs`: Project notes and guidelines
-- `/config`: Centralized tool configs (ESLint, Vitest, etc.)
-- `/src`: Source code to be analyzed and maintained by AI agents
-  - `/app`: Next.js app directory with pages and API routes
-  - `/features`: Feature modules such as planner and onboarding
-  - `/shared`: Shared UI components, hooks, utilities and types
-  - `/server`: Server actions and API handlers
-  - `/data`: Local JSON used for demo itineraries
-- `/public`: Static assets served directly
+### Essential Commands
 
-## Coding Conventions
+- `npm run dev` – Start the Next.js development server with Turbopack
+- `npm run build` – Build the production bundle
+- `npm run lint` – Lint the repository with ESLint (auto-fix enabled)
+- `npm run typecheck` – Run the TypeScript compiler in no-emit mode
+- `npm run test` – Execute the Vitest unit and integration suites
+- `npm run format` – Format source and test files with Prettier
 
-- Language: All documentation, inline code comments, commit messages and PR descriptions must be written in English. Do not use any other language.
-- Formatting: Run `npm run format` before committing. The project uses Prettier with semicolons, single quotes and `printWidth` 100.
-- Linting: Ensure `npm run lint` passes.
-- Type checking: Ensure `npm run typecheck` passes.
-- Tests: Execute `npm run test` and make sure tests succeed.
-- Warnings: Warnings from linting, type checking, testing or any other tools are undesirable and should be resolved.
-- Commit style: Start commits with an appropriate Gitmoji followed by a short, capitalized description in English (e.g., `:sparkles: Add map view`). A commitlint hook enforces this format, and commit suggestions after PR/merge must also use Gitmoji.
+## Tool Preferences
 
-Note: Tailwind and Next configs remain at the repository root for compatibility (`tailwind.config.ts`, `next.config.ts`).
+### Search Tools Priority
 
-## General Conventions for AI Agents
+Use tools in this order of preference:
 
-- Use TypeScript for all new code.
-- Follow the existing code style in each file.
-- Write meaningful variable and function names.
-- Add comments for complex logic.
-- Follow the commenting conventions in [docs/DEVELOPER_GUIDE.md#commenting](docs/DEVELOPER_GUIDE.md#commenting).
-- Keep all documentation up to date after each interaction so changes stay synchronized with the codebase.
+1. **rg (ripgrep)** – Fast codebase-aware text searches
+2. **find** – Directory-aware file discovery when rg is insufficient
+3. **grep** – Fallback text search for edge cases
 
-## React Components Guidelines
+## 📚 Detailed Documentation
 
-- Use functional components with hooks.
-- Keep components small and focused.
-- Always define prop types properly.
-- Use PascalCase for custom component filenames. The `/src/shared/ui` directory intentionally retains the lowercase naming style inherited from shadcn-ui.
-
-### Export Conventions
-
-To keep code clear and maintainable, we recommend:
-
-- React Components
-  - One component per file.
-  - Use `export default` so importers immediately know what the file provides.
-
-- Hooks / Utilities / Constants / Types
-  - Files that export multiple items should use named exports.
-  - Improves tree-shaking and makes available symbols explicit.
-
-- Barrel Files (`index.ts`)
-  - Re-export default component exports as named exports.
-  - Re-export named exports from hooks/util modules.
-
-This approach ensures consistent imports, better IDE support, and safer refactoring when renaming files or symbols.
-
-## CSS/Styling Standards
-
-- Use Tailwind CSS for styling.
-- Follow a utility-first approach.
-- Write custom CSS only when necessary.
-- Use global.css as source code.
-
-## Testing Requirements
-
-Run tests using the following commands:
-
-```bash
-# Run all tests
-npm run test
-
-# Run a specific test file
-npm run test -- path/to/test-file.test.ts
-
-# Run tests with coverage
-npm run test -- --coverage
-```
-
-## Documentation
-
-- [Architecture Overview](docs/ARCHITECTURE.md)
-- [Testing](docs/TESTING.md)
-- [Deployment](docs/DEPLOYMENT.md)
-- [Developer Guide](docs/DEVELOPER_GUIDE.md)
-- [Contributing](docs/CONTRIBUTING.md)
+- **[.agents/README.md](.agents/README.md)** – Complete development guide
+- **[.agents/coding-standards.md](.agents/coding-standards.md)** – Style and implementation conventions
+- **[.agents/commands.md](.agents/commands.md)** – Build, test, and utility scripts
+- **[.agents/knowledge-base.md](.agents/knowledge-base.md)** – Project knowledge base & best practices


### PR DESCRIPTION
## Summary
- rebuild the root AGENTS.md as a quick reference pointing to the detailed docs
- add the `.agents` documentation set with project-specific guidance, coding standards, commands, and knowledge base

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d30459cde883228b8fb40b11a7d2b8