### PR TITLE
Remove missing lint:commit step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,3 @@ jobs:
         run: npm run build
       - name: Test (coverage)
         run: npm run test:coverage
-      - run: npm run lint:commit


### PR DESCRIPTION
## Summary
- remove the obsolete `npm run lint:commit` step from the CI workflow to match available npm scripts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3510404d4832296e9781880960adf