### PR TITLE
Optimize day lookup when syncing trip range

### DIFF
--- a/src/features/planner/services/syncDaysWithTripRange.ts
+++ b/src/features/planner/services/syncDaysWithTripRange.ts
@@ -24,6 +24,7 @@ export function syncDaysWithTripRange(currentDays: DayPlan[], tripDays: Date[]):
   }
 
   const formattedTrip = tripDays.map((d) => formatDayPlan(d));
+  const tripIdSet = new Set(formattedTrip.map((t) => t.id));
   const map = new Map(currentDays.map((d) => [d.id, d]));
 
   const updated: DayPlan[] = formattedTrip.map((tpl) => {
@@ -37,7 +38,7 @@ export function syncDaysWithTripRange(currentDays: DayPlan[], tripDays: Date[]):
   const afterActs: DayPlan['activities'] = [];
 
   currentDays.forEach((day) => {
-    if (formattedTrip.some((t) => t.id === day.id)) return;
+    if (tripIdSet.has(day.id)) return;
     const date = parseISO(day.id);
     if (isBefore(date, first)) {
       beforeActs.push(...day.activities);


### PR DESCRIPTION
## Summary
- cache trip day ids in a Set after formatting the trip range
- reuse the Set when filtering existing days so out-of-range activities remain moved as before

## Testing
- npx vitest run -c config/vitest.config.ts tests/unit/features/planner/services/syncDaysWithTripRange.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7346fbb748322a3b0fcf0617f1b5a