### PR TITLE
Optimize plan day persistence lookup caching

### DIFF
--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -99,9 +99,11 @@ export function usePlanDays(planId: string, enabled = true) {
         actMap.get(a.day_id)!.add(a.id);
       });
 
+      const existingByDate = new Map(existing.map((d) => [d.date, d]));
+
       for (let i = 0; i < state.length; i++) {
         const day = state[i];
-        const found = existing.find((d) => d.date === day.id);
+        const found = existingByDate.get(day.id);
         let dayId = found?.id;
         let destId = found?.destination_id ?? destinationId;
         if (!destId) throw new Error('destination_id missing');
@@ -117,6 +119,7 @@ export function usePlanDays(planId: string, enabled = true) {
           };
           if (inserted.error || !inserted.data) throw inserted.error;
           dayId = inserted.data.id;
+          existingByDate.set(day.id, { id: dayId, destination_id: destId, date: day.id });
         } else {
           const { error: updErr } = (await (supabase.from('plan_days') as QueryBuilder)
             .update({ position: i, date: day.id })

--- a/src/features/planner/hooks/usePlanDaysSupabase.ts
+++ b/src/features/planner/hooks/usePlanDaysSupabase.ts
@@ -61,7 +61,7 @@ export function usePlanDays(planId: string, enabled = true) {
     planId,
     resource: 'plan_days',
     persistFn: async (id, state, signal) => {
-      const existing = await fetchExistingDays(id, signal);
+      const existing = (await fetchExistingDays(id, signal)) ?? [];
       await deleteRemovedDays(existing, state, signal);
 
       let destinationId: string | undefined = existing[0]?.destination_id;
@@ -99,7 +99,10 @@ export function usePlanDays(planId: string, enabled = true) {
         actMap.get(a.day_id)!.add(a.id);
       });
 
-      const existingByDate = new Map(existing.map((d) => [d.date, d]));
+      const existingByDate = new Map<string, (typeof existing)[number]>();
+      for (const row of existing) {
+        existingByDate.set(row.date, row);
+      }
 
       for (let i = 0; i < state.length; i++) {
         const day = state[i];


### PR DESCRIPTION
## Summary
- cache existing plan days by date to eliminate repeated linear lookups during persistence
- refresh the cache after inserting new plan days so subsequent iterations use the inserted row data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7344af6848322804f1ea7f9ebe3bc