### PR TITLE
Handle null stored day snapshots in planner context

### DIFF
--- a/src/features/planner/hooks/PlannerContext.tsx
+++ b/src/features/planner/hooks/PlannerContext.tsx
@@ -21,9 +21,10 @@ function usePlannerContextValue({
   dest?: string;
   persist?: boolean;
 }): PlannerCtx {
-  const { data: storedDays, persistDays } = usePlanDays(planId, persist);
+  const { data: storedDaysRaw, persistDays } = usePlanDays(planId, persist);
+  const storedDays = storedDaysRaw ?? undefined;
   const planner = usePlanner({
-    initialDays: (storedDays as unknown as DayPlan[]) ?? initialDays,
+    initialDays: storedDays ?? initialDays,
     planId,
     dest,
     persistDays,
@@ -32,7 +33,7 @@ function usePlannerContextValue({
     planner,
     persistDays,
     persist,
-    storedDays: storedDays as DayPlan[] | undefined,
+    storedDays,
   });
 
   const selected = useSelectedActivity(days, setDays, {

--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -14,7 +14,7 @@ interface UsePersistedPlannerDaysParams {
   planner: Pick<ReturnType<typeof usePlanner>, 'days' | 'setDays'>;
   persistDays: PersistDaysMutation;
   persist?: boolean;
-  storedDays?: DayPlan[] | undefined;
+  storedDays?: DayPlan[] | null;
 }
 
 interface PersistQueue {
@@ -66,7 +66,7 @@ export function usePersistedPlannerDays({
   const queueRef = useRef<PersistQueue | null>(null);
 
   useEffect(() => {
-    if (storedDays === undefined) return;
+    if (storedDays == null) return;
     const snapshot = snapshotDays(storedDays);
     const meta = metaRef.current!;
     meta.ready = true;


### PR DESCRIPTION
## Summary
- normalize stored planner days before initializing the planner context
- guard the persistence hook against null Supabase responses so snapshotting never reads from null

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d73d2cb0b48322a2bfdda77918e4d0