### PR TITLE
Fix continue planning banner button markup

### DIFF
--- a/src/features/home/components/ContinuePlanningBanner.tsx
+++ b/src/features/home/components/ContinuePlanningBanner.tsx
@@ -21,7 +21,7 @@ export default function ContinuePlanningBanner() {
       <p className="my-auto">
         Continue your {tripLength} {tripLength === 1 ? 'day' : 'days'} trip to {dest}
       </p>
-      <Button variant="accent" size="sm">
+      <Button asChild variant="accent" size="sm">
         <Link href={`/planner/${slug}?${query}`}>Continue Planning</Link>
       </Button>
     </section>


### PR DESCRIPTION
## Summary
- render the continue planning link through the shared Button component using its `asChild` prop
- prevent nested interactive elements by letting the anchor receive the button styling directly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d803f249f48322a813ac2434a052b6