### PR TITLE
Refactor FeaturePreview location and update copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 // src/app/page.tsx
 
 import ContinuePlanningBanner from '@/features/home/components/ContinuePlanningBanner';
-import FeaturePreview from '@/features/home/components/feature-preview/FeaturePreview';
+import FeaturePreview from '@/features/home/components/FeaturePreview';
 import FinalCta from '@/features/home/components/FinalCta';
 import Hero from '@/features/home/components/Hero';
 import HomeFooter from '@/features/home/ui/HomeFooter';

--- a/src/features/home/components/FeaturePreview.tsx
+++ b/src/features/home/components/FeaturePreview.tsx
@@ -1,26 +1,26 @@
-// src/features/home/components/feature-preview/FeaturePreview.tsx
+// src/features/home/components/FeaturePreview.tsx
 'use client';
 
-import FeatureCarousel from '../../ui/feature-preview/FeatureCarousel';
-import type { FeatureCarouselFeature } from '../../ui/feature-preview/FeatureCarousel';
+import FeatureCarousel from '../ui/feature-preview/FeatureCarousel';
+import type { FeatureCarouselFeature } from '../ui/feature-preview/FeatureCarousel';
 
 const features: FeatureCarouselFeature[] = [
   {
     title: 'Drag. Drop. Done.',
     description:
-      'Design each day in minutes. Add what matters, reorder quickly, and swap ideas in place. The board stays clean and fast, so the plan feels like yours.',
+      'Plan days in minutes. Add what matters, reorder fast, and swap ideas without clutter.',
     imgSrc: '/images/home/feature_01.webp',
   },
   {
     title: 'See your trip on the map',
     description:
-      'Preview stops by day and see distance at a glance. Routes are clear and reordering keeps context. Jump between pins and cards without losing your place.',
+      'View stops by day, check distances at a glance, and move between pins and cards with context intact.',
     imgSrc: '/images/home/feature_02.webp',
   },
   {
-    title: 'Built in budget',
+    title: 'Built-in budget',
     description:
-      'Track costs as you plan. See running totals by day and for the whole trip. Adjust with confidence and stay within what you set.',
+      'Track costs as you go. See daily and trip totals, adjust with ease, and stay on budget.',
     imgSrc: '/images/home/feature_03.webp',
   },
 ];

--- a/tests/unit/a11y/home.a11y.test.tsx
+++ b/tests/unit/a11y/home.a11y.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 
 // Stub FeaturePreview group to avoid CSS import side-effects
-vi.mock('@/features/home/components/feature-preview/FeaturePreview', () => ({
+vi.mock('@/features/home/components/FeaturePreview', () => ({
   __esModule: true,
   default: () => <div data-testid="feature-preview" />,
 }));


### PR DESCRIPTION
## Summary
- move the FeaturePreview component alongside other home components and adjust import paths
- update carousel card copy for planning, map, and budget descriptions on the home page
- keep home accessibility tests aligned with the new component location

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d80a63d248832287468de198b2c9a4