### PR TITLE
Fix FeatureCarousel pseudo opacity handling

### DIFF
--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -84,15 +84,22 @@ function FeatureCarouselCard({
   interactive,
   onSelect,
 }: FeatureCarouselCardProps) {
-  const cardClassName = cn(
-    'relative w-full overflow-hidden rounded p-6 text-left before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-primary before:content-[""] before:opacity-100 before:transition-opacity before:duration-200 before:ease-out md:before:opacity-0',
+  const baseClassName = cn(
+    'relative w-full overflow-hidden rounded p-6 text-left',
     'focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-0',
     'transition-[transform,box-shadow,background-color] duration-200 ease-out',
     interactive ? 'cursor-pointer' : 'cursor-default',
-    isActive
-      ? 'md:[box-shadow:rgba(9,30,66,0.15)_0px_0.5rem_1rem_0px] md:before:bg-primary md:before:opacity-100'
-      : 'md:[box-shadow:none]'
+    isActive ? 'md:[box-shadow:rgba(9,30,66,0.15)_0px_0.5rem_1rem_0px]' : 'md:[box-shadow:none]'
   );
+
+  const pseudoElementClasses = [
+    'before:absolute before:inset-y-0 before:left-0 before:w-[6px]',
+    'before:bg-primary before:content-[""] before:opacity-100',
+    'before:transition-opacity before:duration-200 before:ease-out',
+    isActive ? 'md:before:bg-primary md:before:opacity-100' : 'md:before:opacity-0',
+  ].join(' ');
+
+  const cardClassName = `${baseClassName} ${pseudoElementClasses}`;
 
   const content = (
     <>


### PR DESCRIPTION
## Summary
- prevent FeatureCarousel cards from losing their pseudo-element opacity variants when merged
- keep the pseudo-element highlight logic separate from the base classes so only the indicator fades on desktop

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d834f3df3483228cfd2ccdf5958297