### PR TITLE
Fix FeatureCarousel hydration class order mismatch

### DIFF
--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -84,22 +84,17 @@ function FeatureCarouselCard({
   interactive,
   onSelect,
 }: FeatureCarouselCardProps) {
-  const baseClassName = cn(
+  const cardClassName = cn(
     'relative w-full overflow-hidden rounded p-6 text-left',
     'focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-0',
     'transition-[transform,box-shadow,background-color] duration-200 ease-out',
     interactive ? 'cursor-pointer' : 'cursor-default',
-    isActive ? 'md:[box-shadow:rgba(9,30,66,0.15)_0px_0.5rem_1rem_0px]' : 'md:[box-shadow:none]'
-  );
-
-  const pseudoElementClasses = [
+    isActive ? 'md:[box-shadow:rgba(9,30,66,0.15)_0px_0.5rem_1rem_0px]' : 'md:[box-shadow:none]',
     'before:absolute before:inset-y-0 before:left-0 before:w-[6px]',
     'before:bg-primary before:content-[""] before:opacity-100',
     'before:transition-opacity before:duration-200 before:ease-out',
-    isActive ? 'md:before:bg-primary md:before:opacity-100' : 'md:before:opacity-0',
-  ].join(' ');
-
-  const cardClassName = `${baseClassName} ${pseudoElementClasses}`;
+    isActive ? 'md:before:bg-primary md:before:opacity-100' : 'md:before:opacity-0'
+  );
 
   const content = (
     <>


### PR DESCRIPTION
## Summary
- build the FeatureCarousel card classes in a single cn() call to keep server and client markup identical

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d840ae2db88322a5683b7fb94e0742