### PR TITLE
Finetunnig realtime event-based synchronization for planner

### DIFF
--- a/docs/DB_SCHEMA.sql
+++ b/docs/DB_SCHEMA.sql
@@ -1,24 +1,6 @@
 -- WARNING: This schema is for context only and is not meant to be run.
 -- Table order and constraints may not be valid for execution.
 
-CREATE TABLE public.activities (
-  id uuid NOT NULL DEFAULT uuid_generate_v4(),
-  day_id uuid NOT NULL,
-  title text,
-  category text,
-  description text,
-  start_time time without time zone,
-  duration integer,
-  latitude double precision,
-  longitude double precision,
-  budget numeric,
-  image_url text,
-  color text,
-  address text,
-  position integer DEFAULT 0,
-  CONSTRAINT activities_pkey PRIMARY KEY (id),
-  CONSTRAINT activities_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.plan_days(id)
-);
 CREATE TABLE public.budget_entries (
   id uuid NOT NULL DEFAULT uuid_generate_v4(),
   plan_id uuid NOT NULL,
@@ -36,16 +18,6 @@ CREATE TABLE public.destinations (
   longitude double precision,
   CONSTRAINT destinations_pkey PRIMARY KEY (id)
 );
-CREATE TABLE public.plan_days (
-  id uuid NOT NULL DEFAULT uuid_generate_v4(),
-  plan_id uuid NOT NULL,
-  date date,
-  position integer,
-  destination_id uuid NOT NULL,
-  CONSTRAINT plan_days_pkey PRIMARY KEY (id),
-  CONSTRAINT plan_days_destination_fkey FOREIGN KEY (destination_id) REFERENCES public.destinations(id),
-  CONSTRAINT plan_days_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id)
-);
 CREATE TABLE public.plan_destinations (
   plan_id uuid NOT NULL,
   destination_id uuid NOT NULL,
@@ -54,13 +26,32 @@ CREATE TABLE public.plan_destinations (
   CONSTRAINT plan_destinations_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id),
   CONSTRAINT plan_destinations_destination_id_fkey FOREIGN KEY (destination_id) REFERENCES public.destinations(id)
 );
+CREATE TABLE public.plan_events (
+  event_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  plan_id uuid NOT NULL,
+  version bigint NOT NULL CHECK (version > 0),
+  event_type USER-DEFINED NOT NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  actor_id text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT plan_events_pkey PRIMARY KEY (event_id),
+  CONSTRAINT plan_events_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id)
+);
+CREATE TABLE public.plan_snapshots (
+  plan_id uuid NOT NULL,
+  version bigint NOT NULL DEFAULT 0,
+  state jsonb NOT NULL DEFAULT jsonb_build_object('days', '[]'::jsonb),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT plan_snapshots_pkey PRIMARY KEY (plan_id),
+  CONSTRAINT plan_snapshots_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES public.plans(id)
+);
 CREATE TABLE public.plans (
   id uuid NOT NULL DEFAULT uuid_generate_v4(),
   user_id uuid,
   title text,
   start_date date,
   end_date date,
-  created_at timestamp with time zone DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
   budget numeric,
   is_public boolean NOT NULL DEFAULT true,
   public_slug text NOT NULL DEFAULT translate(encode(gen_random_bytes(9), 'base64'::text), '/+'::text, '_-'::text),
@@ -70,7 +61,7 @@ CREATE TABLE public.plans (
 );
 CREATE TABLE public.profiles (
   id uuid NOT NULL,
-  created_at timestamp with time zone DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
   CONSTRAINT profiles_pkey PRIMARY KEY (id),
   CONSTRAINT profiles_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id)
 );

--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -103,18 +103,17 @@ function FeatureCarouselCard({
     </>
   );
 
-  if (interactive) {
-    return (
-      <button type="button" onClick={onSelect} aria-pressed={isActive} className={cardClassName}>
-        {content}
-      </button>
-    );
-  }
-
   return (
-    <div tabIndex={0} role="button" className={cardClassName}>
+    <button
+      type="button"
+      onClick={interactive ? onSelect : undefined}
+      aria-pressed={interactive ? isActive : undefined}
+      aria-disabled={interactive ? undefined : 'true'}
+      tabIndex={interactive ? 0 : -1}
+      className={cardClassName}
+    >
       {content}
-    </div>
+    </button>
   );
 }
 

--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -108,8 +108,10 @@ function FeatureCarouselCard({
     <button
       type="button"
       onClick={interactive ? onSelect : undefined}
-      aria-pressed={isActive}
-      tabIndex={0}
+      aria-pressed={interactive ? isActive : undefined}
+      aria-disabled={!interactive}
+      disabled={!interactive}
+      tabIndex={interactive ? 0 : -1}
       className={cardClassName}
     >
       {content}

--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -88,7 +88,8 @@ function FeatureCarouselCard({
     'relative w-full overflow-hidden rounded p-6 text-left',
     'focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-0',
     'transition-[transform,box-shadow,background-color] duration-200 ease-out',
-    interactive ? 'cursor-pointer' : 'cursor-default',
+    'cursor-default md:cursor-pointer',
+    'pointer-events-none md:pointer-events-auto',
     isActive ? 'md:[box-shadow:rgba(9,30,66,0.15)_0px_0.5rem_1rem_0px]' : 'md:[box-shadow:none]',
     'before:absolute before:inset-y-0 before:left-0 before:w-[6px]',
     'before:bg-primary before:content-[""] before:opacity-100',
@@ -107,9 +108,8 @@ function FeatureCarouselCard({
     <button
       type="button"
       onClick={interactive ? onSelect : undefined}
-      aria-pressed={interactive ? isActive : undefined}
-      aria-disabled={interactive ? undefined : 'true'}
-      tabIndex={interactive ? 0 : -1}
+      aria-pressed={isActive}
+      tabIndex={0}
       className={cardClassName}
     >
       {content}

--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -110,7 +110,6 @@ function FeatureCarouselCard({
       onClick={interactive ? onSelect : undefined}
       aria-pressed={interactive ? isActive : undefined}
       aria-disabled={!interactive}
-      disabled={!interactive}
       tabIndex={interactive ? 0 : -1}
       className={cardClassName}
     >
@@ -159,11 +158,17 @@ export default function FeatureCarousel({ features }: FeatureCarouselProps) {
   const imagesRef = useRef<HTMLUListElement | null>(null);
   const disabledCardsRef = useRef<HTMLUListElement | null>(null);
 
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
   const carouselRefs = useMemo(() => [cardsRef, imagesRef], [cardsRef, imagesRef]);
   const { activeIndex, select, scrollHandlers } = useSyncedPointerCarousels(carouselRefs);
   const [cardsHandlers, imagesHandlers] = scrollHandlers;
 
   const isDesktop = useIsDesktop();
+  const interactive = hasMounted && isDesktop;
 
   const cardsDragRef = isDesktop ? disabledCardsRef : cardsRef;
   const cardsDragHandlers = isDesktop ? undefined : cardsHandlers;
@@ -173,10 +178,10 @@ export default function FeatureCarousel({ features }: FeatureCarouselProps) {
 
   const handleCardSelect = useCallback(
     (index: number) => {
-      if (!isDesktop) return;
+      if (!interactive) return;
       select(index);
     },
-    [isDesktop, select]
+    [interactive, select]
   );
 
   const handleDotSelect = useCallback(
@@ -199,7 +204,7 @@ export default function FeatureCarousel({ features }: FeatureCarouselProps) {
                 <FeatureCarouselCard
                   feature={feature}
                   isActive={index === activeIndex}
-                  interactive={isDesktop}
+                  interactive={interactive}
                   onSelect={() => handleCardSelect(index)}
                 />
               </li>

--- a/src/features/planner/domain/utils/activityPlaceholders.ts
+++ b/src/features/planner/domain/utils/activityPlaceholders.ts
@@ -12,6 +12,13 @@ export function isPlaceholderActivity(activity: Pick<Activity, 'id' | 'title'>):
   return activity.id.startsWith(BLANK_ACTIVITY_PREFIX) || isBlankActivityTitle(activity.title);
 }
 
+export function generatePlaceholderActivityId(): string {
+  const crypto = globalThis.crypto;
+  if (crypto?.randomUUID) return `${BLANK_ACTIVITY_PREFIX}${crypto.randomUUID()}`;
+  const suffix = Math.random().toString(36).slice(2, 10);
+  return `${BLANK_ACTIVITY_PREFIX}${suffix}`;
+}
+
 export function generateClientActivityId(): string {
   const crypto = globalThis.crypto;
   if (crypto?.randomUUID) return crypto.randomUUID();

--- a/src/features/planner/domain/utils/activityPlaceholders.ts
+++ b/src/features/planner/domain/utils/activityPlaceholders.ts
@@ -1,0 +1,13 @@
+// src/features/planner/domain/utils/activityPlaceholders.ts
+
+import type { Activity } from '@/features/planner/domain/types/PlannerEntities';
+
+export const BLANK_ACTIVITY_PREFIX = 'blank-';
+
+export function isBlankActivityTitle(title: string | undefined | null): boolean {
+  return !title || title.trim().length === 0;
+}
+
+export function isPlaceholderActivity(activity: Pick<Activity, 'id' | 'title'>): boolean {
+  return activity.id.startsWith(BLANK_ACTIVITY_PREFIX) || isBlankActivityTitle(activity.title);
+}

--- a/src/features/planner/domain/utils/activityPlaceholders.ts
+++ b/src/features/planner/domain/utils/activityPlaceholders.ts
@@ -11,3 +11,9 @@ export function isBlankActivityTitle(title: string | undefined | null): boolean 
 export function isPlaceholderActivity(activity: Pick<Activity, 'id' | 'title'>): boolean {
   return activity.id.startsWith(BLANK_ACTIVITY_PREFIX) || isBlankActivityTitle(activity.title);
 }
+
+export function generateClientActivityId(): string {
+  const crypto = globalThis.crypto;
+  if (crypto?.randomUUID) return crypto.randomUUID();
+  return `act-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/features/planner/hooks/PlannerContext.tsx
+++ b/src/features/planner/hooks/PlannerContext.tsx
@@ -40,7 +40,6 @@ function usePlannerContextValue({
     addActivity: planner.addActivity,
     removeActivity: planner.removeActivity,
     updateActivity: planner.updateActivity,
-    addBlankActivity: planner.addBlankActivity,
   });
 
   return { ...planner, days, setDays, ...selected };

--- a/src/features/planner/hooks/useActivityState.ts
+++ b/src/features/planner/hooks/useActivityState.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_NEW_CARD_COLOR_INDEX,
   DEFAULT_COLORS,
 } from '@/features/planner/domain/constants/colors';
-import { BLANK_ACTIVITY_PREFIX } from '@/features/planner/domain/utils/activityPlaceholders';
+import { generatePlaceholderActivityId } from '@/features/planner/domain/utils/activityPlaceholders';
 
 /**
  * Provides helpers for modifying day activities.
@@ -73,7 +73,7 @@ export function useActivityState(setDays: React.Dispatch<React.SetStateAction<Da
 
   function addBlankActivity(dayIndex = 0, insertIndex?: number): Activity {
     const blank: Activity = {
-      id: `${BLANK_ACTIVITY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generatePlaceholderActivityId(),
       title: '',
       description: '',
       duration: 0,

--- a/src/features/planner/hooks/useActivityState.ts
+++ b/src/features/planner/hooks/useActivityState.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_NEW_CARD_COLOR_INDEX,
   DEFAULT_COLORS,
 } from '@/features/planner/domain/constants/colors';
+import { BLANK_ACTIVITY_PREFIX } from '@/features/planner/domain/utils/activityPlaceholders';
 
 /**
  * Provides helpers for modifying day activities.
@@ -65,8 +66,8 @@ export function useActivityState(setDays: React.Dispatch<React.SetStateAction<Da
 
   function addBlankActivity(dayIndex = 0, insertIndex?: number): Activity {
     const blank: Activity = {
-      id: `blank-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-      title: 'Untitled activity',
+      id: `${BLANK_ACTIVITY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      title: '',
       description: '',
       duration: 0,
       color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,

--- a/src/features/planner/hooks/useActivityState.ts
+++ b/src/features/planner/hooks/useActivityState.ts
@@ -15,7 +15,7 @@ import { BLANK_ACTIVITY_PREFIX } from '@/features/planner/domain/utils/activityP
  */
 
 export function useActivityState(setDays: React.Dispatch<React.SetStateAction<DayPlan[]>>) {
-  function addActivity(act: Activity, dayIndex = 0): void {
+  function addActivity(act: Activity, dayIndex = 0, insertIndex?: number): void {
     setDays((prev) => {
       const copy = [...prev];
       if (!copy[dayIndex]) {
@@ -27,10 +27,17 @@ export function useActivityState(setDays: React.Dispatch<React.SetStateAction<Da
         title: sanitizedTitle.length > 0 ? sanitizedTitle : 'Untitled activity',
         color: act.color || DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
       };
-      if (!copy[dayIndex].activities.some((a) => a.id === act.id)) {
-        copy[dayIndex].activities.push({
-          ...nextActivity,
-        });
+      const activities = copy[dayIndex].activities;
+      if (!activities.some((a) => a.id === act.id)) {
+        if (insertIndex == null || insertIndex < 0 || insertIndex > activities.length) {
+          activities.push({
+            ...nextActivity,
+          });
+        } else {
+          activities.splice(insertIndex, 0, {
+            ...nextActivity,
+          });
+        }
       }
       return copy;
     });

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -111,8 +111,8 @@ export function useDragState(initialDays: DayPlan[]) {
     const { active, over } = e;
     if (!over || active.id === over.id) return;
     const now = Date.now();
-    // Avoid rapid re-renders by only updating every 50ms
-    if (now - lastTimeRef.current < 50) return;
+    // Avoid rapid re-renders but keep drag responsive
+    if (now - lastTimeRef.current < 16) return;
     lastTimeRef.current = now;
 
     setDays((prevDays) => {

--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
+import { isBlankActivityTitle } from '@/features/planner/domain/utils/activityPlaceholders';
 import type { usePlanner } from './usePlanner';
 
 interface PersistDaysMutation {
@@ -28,6 +29,13 @@ interface PersistMeta {
   fallback: DayPlan[];
 }
 
+function removeBlankActivities(days: DayPlan[]): DayPlan[] {
+  return days.map((day) => {
+    const filtered = day.activities.filter((activity) => !isBlankActivityTitle(activity.title));
+    return filtered.length === day.activities.length ? day : { ...day, activities: filtered };
+  });
+}
+
 function cloneDays(days: DayPlan[]): DayPlan[] {
   return days.map((day) => ({
     ...day,
@@ -36,7 +44,7 @@ function cloneDays(days: DayPlan[]): DayPlan[] {
 }
 
 function snapshotDays(days: DayPlan[]) {
-  const state = cloneDays(days);
+  const state = cloneDays(removeBlankActivities(days));
   return { state, serialized: JSON.stringify(state) };
 }
 
@@ -101,10 +109,11 @@ export function usePersistedPlannerDays({
     if (!persist || !meta.ready) return;
     if (debouncedDays.length === 0) return;
 
-    const serialized = JSON.stringify(debouncedDays);
+    const cleanedDays = removeBlankActivities(debouncedDays);
+    const serialized = JSON.stringify(cleanedDays);
     if (serialized === meta.lastSaved) return;
 
-    queueRef.current = { state: cloneDays(debouncedDays), serialized };
+    queueRef.current = { state: cloneDays(cleanedDays), serialized };
     void flush();
   }, [debouncedDays, flush, persist]);
 

--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
-import { isBlankActivityTitle } from '@/features/planner/domain/utils/activityPlaceholders';
+import { isPlaceholderActivity } from '@/features/planner/domain/utils/activityPlaceholders';
 import type { usePlanner } from './usePlanner';
 
 interface PersistDaysMutation {
@@ -31,7 +31,7 @@ interface PersistMeta {
 
 function removeBlankActivities(days: DayPlan[]): DayPlan[] {
   return days.map((day) => {
-    const filtered = day.activities.filter((activity) => !isBlankActivityTitle(activity.title));
+    const filtered = day.activities.filter((activity) => !isPlaceholderActivity(activity));
     return filtered.length === day.activities.length ? day : { ...day, activities: filtered };
   });
 }

--- a/src/features/planner/hooks/usePlanner.ts
+++ b/src/features/planner/hooks/usePlanner.ts
@@ -79,20 +79,20 @@ export function usePlanner(options: UsePlannerOptions = {}) {
   async function handleRangeChange(r: DateRange | undefined) {
     setRange(r);
     if (!r?.from || !r?.to) return;
-    if (options.planId) {
-      try {
+    try {
+      if (options.planId) {
         await setPlanDateRange(options.planId, r.from, r.to);
-      } catch (err) {
-        console.error(err);
       }
+      const newTripDays = eachDayOfInterval({ start: r.from, end: r.to });
+      setDays((prev: DayPlan[]) => {
+        const cleaned = dedupeDays(prev);
+        const updated = syncDaysWithTripRange(cleaned, newTripDays);
+        options.persistDays?.mutate(updated);
+        return updated;
+      });
+    } catch (err) {
+      console.error('Failed to update planner range', err);
     }
-    const newTripDays = eachDayOfInterval({ start: r.from, end: r.to });
-    setDays((prev: DayPlan[]) => {
-      const cleaned = dedupeDays(prev);
-      const updated = syncDaysWithTripRange(cleaned, newTripDays);
-      options.persistDays?.mutate(updated);
-      return updated;
-    });
   }
 
   return {

--- a/src/features/planner/hooks/useSelectedActivity.ts
+++ b/src/features/planner/hooks/useSelectedActivity.ts
@@ -5,7 +5,8 @@ import { useState } from 'react';
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
 import {
   BLANK_ACTIVITY_PREFIX,
-  isBlankActivityTitle,
+  generateClientActivityId,
+  isPlaceholderActivity,
 } from '@/features/planner/domain/utils/activityPlaceholders';
 import { moveActivityToDay } from '@/features/planner/services/moveActivityToDay';
 import { moveActivityPosition } from '@/features/planner/services/moveActivityPosition';
@@ -22,7 +23,7 @@ import { moveActivityPosition } from '@/features/planner/services/moveActivityPo
  */
 
 interface UseSelectedActivityOptions {
-  addActivity: (act: Activity, dayIndex?: number) => void;
+  addActivity: (act: Activity, dayIndex?: number, insertIndex?: number) => void;
   removeActivity: (id: string) => void;
   updateActivity: (id: string, patch: Partial<Activity>) => void;
   addBlankActivity: (dayIndex?: number, insertIndex?: number) => Activity;
@@ -60,7 +61,7 @@ export function useSelectedActivity(
             removed = true;
             return false;
           }
-          if (isBlankActivityTitle(activity.title)) {
+          if (isPlaceholderActivity(activity)) {
             removed = true;
             return false;
           }
@@ -74,7 +75,7 @@ export function useSelectedActivity(
   };
 
   const closeModal = () => {
-    if (selectedActivity && isBlankActivityTitle(selectedActivity.title)) {
+    if (selectedActivity && isPlaceholderActivity(selectedActivity)) {
       const { id, dayId } = selectedActivity;
       if (id.startsWith(BLANK_ACTIVITY_PREFIX)) {
         removeActivity(id);
@@ -87,13 +88,30 @@ export function useSelectedActivity(
 
   const save = (patch: Partial<Activity>) => {
     if (!selectedActivity || !patch.title?.trim()) return;
-    if (selectedActivity.id.startsWith('temp-')) {
-      addActivity(
-        { ...selectedActivity, ...patch, duration: Number(patch.duration) },
-        days.findIndex((d) => d.id === selectedActivity.dayId)
+    const dayIndex = days.findIndex((d) => d.id === selectedActivity.dayId);
+    const sanitized = { ...patch, duration: Number(patch.duration) };
+    if (selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+      if (dayIndex === -1) {
+        setSelectedActivity(null);
+        return;
+      }
+      const placeholderIndex = days[dayIndex].activities.findIndex(
+        (activity) => activity.id === selectedActivity.id
       );
+      removeActivity(selectedActivity.id);
+      const { dayId: _omitDayId, ...activityBase } = {
+        ...selectedActivity,
+        ...sanitized,
+        id: generateClientActivityId(),
+      };
+      void _omitDayId;
+      addActivity(activityBase, dayIndex, placeholderIndex === -1 ? undefined : placeholderIndex);
+    } else if (selectedActivity.id.startsWith('temp-')) {
+      const { dayId: _omitDayId, ...activityBase } = { ...selectedActivity, ...sanitized };
+      void _omitDayId;
+      addActivity(activityBase, dayIndex);
     } else {
-      updateActivity(selectedActivity.id, { ...patch, duration: Number(patch.duration) });
+      updateActivity(selectedActivity.id, sanitized);
     }
     setSelectedActivity(null);
   };

--- a/src/features/planner/hooks/useSelectedActivity.ts
+++ b/src/features/planner/hooks/useSelectedActivity.ts
@@ -3,6 +3,10 @@
 
 import { useState } from 'react';
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
+import {
+  BLANK_ACTIVITY_PREFIX,
+  isBlankActivityTitle,
+} from '@/features/planner/domain/utils/activityPlaceholders';
 import { moveActivityToDay } from '@/features/planner/services/moveActivityToDay';
 import { moveActivityPosition } from '@/features/planner/services/moveActivityPosition';
 
@@ -44,13 +48,39 @@ export function useSelectedActivity(
     setSelectedActivity({ ...blank, dayId });
   };
 
+  const removePlaceholderFromDay = (dayId: string, candidateId: string): boolean => {
+    let removed = false;
+    setDays((prev) => {
+      if (removed) return prev;
+      const next = prev.map((day) => {
+        if (day.id !== dayId || removed) return day;
+        const activities = day.activities.filter((activity) => {
+          if (removed) return true;
+          if (activity.id === candidateId) {
+            removed = true;
+            return false;
+          }
+          if (isBlankActivityTitle(activity.title)) {
+            removed = true;
+            return false;
+          }
+          return true;
+        });
+        return removed ? { ...day, activities } : day;
+      });
+      return removed ? next : prev;
+    });
+    return removed;
+  };
+
   const closeModal = () => {
-    if (
-      selectedActivity &&
-      selectedActivity.id.startsWith('blank-') &&
-      !selectedActivity.title.trim()
-    ) {
-      removeActivity(selectedActivity.id);
+    if (selectedActivity && isBlankActivityTitle(selectedActivity.title)) {
+      const { id, dayId } = selectedActivity;
+      if (id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+        removeActivity(id);
+      } else if (!dayId || !removePlaceholderFromDay(dayId, id)) {
+        removeActivity(id);
+      }
     }
     setSelectedActivity(null);
   };

--- a/src/features/planner/hooks/useSelectedActivity.ts
+++ b/src/features/planner/hooks/useSelectedActivity.ts
@@ -1,13 +1,17 @@
 // src/features/planner/hooks/useSelectedActivity.ts
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
 import {
   BLANK_ACTIVITY_PREFIX,
   generateClientActivityId,
   isPlaceholderActivity,
 } from '@/features/planner/domain/utils/activityPlaceholders';
+import {
+  DEFAULT_COLORS,
+  DEFAULT_NEW_CARD_COLOR_INDEX,
+} from '@/features/planner/domain/constants/colors';
 import { moveActivityToDay } from '@/features/planner/services/moveActivityToDay';
 import { moveActivityPosition } from '@/features/planner/services/moveActivityPosition';
 
@@ -26,79 +30,102 @@ interface UseSelectedActivityOptions {
   addActivity: (act: Activity, dayIndex?: number, insertIndex?: number) => void;
   removeActivity: (id: string) => void;
   updateActivity: (id: string, patch: Partial<Activity>) => void;
-  addBlankActivity: (dayIndex?: number, insertIndex?: number) => Activity;
 }
+
+type SelectedActivityState = (Activity & { dayId?: string }) | null;
+
+type NewActivityMeta = { dayId: string; insertIndex?: number } | null;
 
 export function useSelectedActivity(
   days: DayPlan[],
   setDays: React.Dispatch<React.SetStateAction<DayPlan[]>>,
-  { addActivity, removeActivity, updateActivity, addBlankActivity }: UseSelectedActivityOptions
+  { addActivity, removeActivity, updateActivity }: UseSelectedActivityOptions
 ) {
-  const [selectedActivity, setSelectedActivity] = useState<(Activity & { dayId?: string }) | null>(
-    null
-  );
+  const [selectedActivityState, setSelectedActivityState] = useState<SelectedActivityState>(null);
+  const newActivityMetaRef = useRef<NewActivityMeta>(null);
+
+  const setSelectedActivity = (
+    value: SelectedActivityState | ((prev: SelectedActivityState) => SelectedActivityState)
+  ) => {
+    setSelectedActivityState((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value;
+      if (!next || !next.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+        newActivityMetaRef.current = null;
+      }
+      return next;
+    });
+  };
+
+  const selectedActivity = selectedActivityState;
 
   const changeDay = (activityId: string, dayId: string) => {
-    setDays((prev) => moveActivityToDay(prev, activityId, dayId));
+    const pendingMeta = newActivityMetaRef.current;
+    const isPendingNew = pendingMeta && selectedActivity && selectedActivity.id === activityId;
+
+    if (isPendingNew) {
+      const targetDay = days.find((d) => d.id === dayId);
+      newActivityMetaRef.current = {
+        dayId,
+        insertIndex: targetDay ? targetDay.activities.length : undefined,
+      };
+      setSelectedActivity((prev) => (prev ? { ...prev, dayId } : prev));
+      return;
+    }
+
+    const existsInState = days.some((day) =>
+      day.activities.some((activity) => activity.id === activityId)
+    );
+
+    if (existsInState) {
+      setDays((prev) => moveActivityToDay(prev, activityId, dayId));
+    }
     setSelectedActivity((prev) => (prev ? { ...prev, dayId } : prev));
   };
 
   const addBlankAndSelect = (dayId: string, insertIdx?: number) => {
-    const dayIndex = days.findIndex((d) => d.id === dayId);
-    const blank = addBlankActivity(dayIndex, insertIdx);
+    const blank: Activity = {
+      id: `${BLANK_ACTIVITY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      title: '',
+      description: '',
+      duration: 0,
+      color: DEFAULT_COLORS[DEFAULT_NEW_CARD_COLOR_INDEX].bg,
+      budget: 0,
+      category: '',
+    };
+
+    newActivityMetaRef.current = { dayId, insertIndex: insertIdx };
     setSelectedActivity({ ...blank, dayId });
   };
 
-  const removePlaceholderFromDay = (dayId: string, candidateId: string): boolean => {
-    let removed = false;
-    setDays((prev) => {
-      if (removed) return prev;
-      const next = prev.map((day) => {
-        if (day.id !== dayId || removed) return day;
-        const activities = day.activities.filter((activity) => {
-          if (removed) return true;
-          if (activity.id === candidateId) {
-            removed = true;
-            return false;
-          }
-          if (isPlaceholderActivity(activity)) {
-            removed = true;
-            return false;
-          }
-          return true;
-        });
-        return removed ? { ...day, activities } : day;
-      });
-      return removed ? next : prev;
-    });
-    return removed;
-  };
-
   const closeModal = () => {
-    if (selectedActivity && isPlaceholderActivity(selectedActivity)) {
-      const { id, dayId } = selectedActivity;
-      if (id.startsWith(BLANK_ACTIVITY_PREFIX)) {
-        removeActivity(id);
-      } else if (!dayId || !removePlaceholderFromDay(dayId, id)) {
-        removeActivity(id);
-      }
+    const pendingMeta = newActivityMetaRef.current;
+    if (selectedActivity && pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+      newActivityMetaRef.current = null;
+      setSelectedActivity(null);
+      return;
     }
+
+    if (selectedActivity && isPlaceholderActivity(selectedActivity)) {
+      removeActivity(selectedActivity.id);
+    }
+    newActivityMetaRef.current = null;
     setSelectedActivity(null);
   };
 
   const save = (patch: Partial<Activity>) => {
     if (!selectedActivity || !patch.title?.trim()) return;
-    const dayIndex = days.findIndex((d) => d.id === selectedActivity.dayId);
+    const pendingMeta = newActivityMetaRef.current;
     const sanitized = { ...patch, duration: Number(patch.duration) };
-    if (selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+    const dayIndex = days.findIndex((d) => d.id === selectedActivity.dayId);
+    if (pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+      const targetDayId = selectedActivity.dayId ?? pendingMeta.dayId;
+      const dayIndex = days.findIndex((d) => d.id === targetDayId);
       if (dayIndex === -1) {
         setSelectedActivity(null);
+        newActivityMetaRef.current = null;
         return;
       }
-      const placeholderIndex = days[dayIndex].activities.findIndex(
-        (activity) => activity.id === selectedActivity.id
-      );
-      removeActivity(selectedActivity.id);
+      const placeholderIndex = pendingMeta.insertIndex ?? days[dayIndex].activities.length;
       const { dayId: _omitDayId, ...activityBase } = {
         ...selectedActivity,
         ...sanitized,
@@ -106,7 +133,13 @@ export function useSelectedActivity(
       };
       void _omitDayId;
       addActivity(activityBase, dayIndex, placeholderIndex === -1 ? undefined : placeholderIndex);
+      newActivityMetaRef.current = null;
     } else if (selectedActivity.id.startsWith('temp-')) {
+      if (dayIndex === -1) {
+        newActivityMetaRef.current = null;
+        setSelectedActivity(null);
+        return;
+      }
       const { dayId: _omitDayId, ...activityBase } = { ...selectedActivity, ...sanitized };
       void _omitDayId;
       addActivity(activityBase, dayIndex);
@@ -118,7 +151,14 @@ export function useSelectedActivity(
 
   const deleteActivityById = () => {
     if (!selectedActivity) return;
+    const pendingMeta = newActivityMetaRef.current;
+    if (pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+      newActivityMetaRef.current = null;
+      setSelectedActivity(null);
+      return;
+    }
     removeActivity(selectedActivity.id);
+    newActivityMetaRef.current = null;
     setSelectedActivity(null);
   };
 
@@ -126,12 +166,21 @@ export function useSelectedActivity(
     setSelectedActivity((prev) =>
       prev && prev.id === activityId ? { ...prev, color: newColor } : prev
     );
-    if (!activityId.startsWith('temp-')) {
+    const pendingMeta = newActivityMetaRef.current;
+    if ((!pendingMeta || activityId !== selectedActivity?.id) && !activityId.startsWith('temp-')) {
       updateActivity(activityId, { color: newColor });
     }
   };
 
   const changePosition = (activityId: string, newIndex: number) => {
+    const pendingMeta = newActivityMetaRef.current;
+    const isPendingNew = pendingMeta && selectedActivity && selectedActivity.id === activityId;
+
+    if (isPendingNew) {
+      newActivityMetaRef.current = { ...pendingMeta, insertIndex: newIndex };
+      return;
+    }
+
     setDays((prev) => moveActivityPosition(prev, activityId, newIndex));
   };
 

--- a/src/features/planner/hooks/useSelectedActivity.ts
+++ b/src/features/planner/hooks/useSelectedActivity.ts
@@ -99,36 +99,19 @@ export function useSelectedActivity(
     setSelectedActivity({ ...blank, dayId });
   };
 
-  const removePlaceholderFromPlanner = (activityId: string, dayId?: string) => {
-    if (!activityId) return;
+  const removePlaceholderFromPlanner = (activityId: string) => {
+    if (!activityId.startsWith(BLANK_ACTIVITY_PREFIX)) return;
     setDays((prev) => {
-      const removeFromDay = (daysState: DayPlan[], index: number): DayPlan[] | null => {
-        const day = daysState[index];
-        if (!day) return null;
-        const targetIdx = day.activities.findIndex((activity) => activity.id === activityId);
-        if (targetIdx === -1) return null;
-        const nextDays = [...daysState];
-        nextDays[index] = {
+      let removed = false;
+      const next = prev.map((day) => {
+        if (!day.activities.some((activity) => activity.id === activityId)) return day;
+        removed = true;
+        return {
           ...day,
-          activities: day.activities.filter((_, idx) => idx !== targetIdx),
+          activities: day.activities.filter((activity) => activity.id !== activityId),
         };
-        return nextDays;
-      };
-
-      if (dayId) {
-        const preferredIndex = prev.findIndex((day) => day.id === dayId);
-        if (preferredIndex !== -1) {
-          const preferredResult = removeFromDay(prev, preferredIndex);
-          if (preferredResult) return preferredResult;
-        }
-      }
-
-      for (let i = 0; i < prev.length; i += 1) {
-        const result = removeFromDay(prev, i);
-        if (result) return result;
-      }
-
-      return prev;
+      });
+      return removed ? next : prev;
     });
   };
 
@@ -140,8 +123,12 @@ export function useSelectedActivity(
       return;
     }
 
-    if (selectedActivity && isPlaceholderActivity(selectedActivity)) {
-      removePlaceholderFromPlanner(selectedActivity.id, selectedActivity.dayId);
+    if (selectedActivity) {
+      if (selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+        removePlaceholderFromPlanner(selectedActivity.id);
+      } else if (isPlaceholderActivity(selectedActivity)) {
+        removeActivity(selectedActivity.id);
+      }
     }
     newActivityMetaRef.current = null;
     setSelectedActivity(null);
@@ -205,8 +192,8 @@ export function useSelectedActivity(
       setSelectedActivity(null);
       return;
     }
-    if (isPlaceholderActivity(selectedActivity)) {
-      removePlaceholderFromPlanner(selectedActivity.id, selectedActivity.dayId);
+    if (selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+      removePlaceholderFromPlanner(selectedActivity.id);
     } else {
       removeActivity(selectedActivity.id);
     }

--- a/src/features/planner/hooks/useSelectedActivity.ts
+++ b/src/features/planner/hooks/useSelectedActivity.ts
@@ -6,6 +6,7 @@ import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerE
 import {
   BLANK_ACTIVITY_PREFIX,
   generateClientActivityId,
+  generatePlaceholderActivityId,
   isPlaceholderActivity,
 } from '@/features/planner/domain/utils/activityPlaceholders';
 import {
@@ -43,6 +44,7 @@ export function useSelectedActivity(
 ) {
   const [selectedActivityState, setSelectedActivityState] = useState<SelectedActivityState>(null);
   const newActivityMetaRef = useRef<NewActivityMeta>(null);
+  const savingRef = useRef(false);
 
   const setSelectedActivity = (
     value: SelectedActivityState | ((prev: SelectedActivityState) => SelectedActivityState)
@@ -84,7 +86,7 @@ export function useSelectedActivity(
 
   const addBlankAndSelect = (dayId: string, insertIdx?: number) => {
     const blank: Activity = {
-      id: `${BLANK_ACTIVITY_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generatePlaceholderActivityId(),
       title: '',
       description: '',
       duration: 0,
@@ -97,6 +99,39 @@ export function useSelectedActivity(
     setSelectedActivity({ ...blank, dayId });
   };
 
+  const removePlaceholderFromPlanner = (activityId: string, dayId?: string) => {
+    if (!activityId) return;
+    setDays((prev) => {
+      const removeFromDay = (daysState: DayPlan[], index: number): DayPlan[] | null => {
+        const day = daysState[index];
+        if (!day) return null;
+        const targetIdx = day.activities.findIndex((activity) => activity.id === activityId);
+        if (targetIdx === -1) return null;
+        const nextDays = [...daysState];
+        nextDays[index] = {
+          ...day,
+          activities: day.activities.filter((_, idx) => idx !== targetIdx),
+        };
+        return nextDays;
+      };
+
+      if (dayId) {
+        const preferredIndex = prev.findIndex((day) => day.id === dayId);
+        if (preferredIndex !== -1) {
+          const preferredResult = removeFromDay(prev, preferredIndex);
+          if (preferredResult) return preferredResult;
+        }
+      }
+
+      for (let i = 0; i < prev.length; i += 1) {
+        const result = removeFromDay(prev, i);
+        if (result) return result;
+      }
+
+      return prev;
+    });
+  };
+
   const closeModal = () => {
     const pendingMeta = newActivityMetaRef.current;
     if (selectedActivity && pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
@@ -106,7 +141,7 @@ export function useSelectedActivity(
     }
 
     if (selectedActivity && isPlaceholderActivity(selectedActivity)) {
-      removeActivity(selectedActivity.id);
+      removePlaceholderFromPlanner(selectedActivity.id, selectedActivity.dayId);
     }
     newActivityMetaRef.current = null;
     setSelectedActivity(null);
@@ -114,39 +149,52 @@ export function useSelectedActivity(
 
   const save = (patch: Partial<Activity>) => {
     if (!selectedActivity || !patch.title?.trim()) return;
-    const pendingMeta = newActivityMetaRef.current;
-    const sanitized = { ...patch, duration: Number(patch.duration) };
-    const dayIndex = days.findIndex((d) => d.id === selectedActivity.dayId);
-    if (pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
-      const targetDayId = selectedActivity.dayId ?? pendingMeta.dayId;
-      const dayIndex = days.findIndex((d) => d.id === targetDayId);
-      if (dayIndex === -1) {
-        setSelectedActivity(null);
-        newActivityMetaRef.current = null;
+    if (savingRef.current) return;
+
+    savingRef.current = true;
+    try {
+      const pendingMeta = newActivityMetaRef.current;
+      const sanitized = { ...patch, duration: Number(patch.duration) };
+      const currentDayIndex = days.findIndex((d) => d.id === selectedActivity.dayId);
+
+      if (pendingMeta && selectedActivity.id.startsWith(BLANK_ACTIVITY_PREFIX)) {
+        const targetDayId = selectedActivity.dayId ?? pendingMeta.dayId;
+        const resolvedDayIndex = days.findIndex((d) => d.id === targetDayId);
+        if (resolvedDayIndex === -1) {
+          return;
+        }
+        const placeholderIndex =
+          pendingMeta.insertIndex ?? days[resolvedDayIndex].activities.length;
+        const { dayId: _omitDayId, ...activityBase } = {
+          ...selectedActivity,
+          ...sanitized,
+          id: generateClientActivityId(),
+        };
+        void _omitDayId;
+        addActivity(
+          activityBase,
+          resolvedDayIndex,
+          placeholderIndex === -1 ? undefined : placeholderIndex
+        );
         return;
       }
-      const placeholderIndex = pendingMeta.insertIndex ?? days[dayIndex].activities.length;
-      const { dayId: _omitDayId, ...activityBase } = {
-        ...selectedActivity,
-        ...sanitized,
-        id: generateClientActivityId(),
-      };
-      void _omitDayId;
-      addActivity(activityBase, dayIndex, placeholderIndex === -1 ? undefined : placeholderIndex);
-      newActivityMetaRef.current = null;
-    } else if (selectedActivity.id.startsWith('temp-')) {
-      if (dayIndex === -1) {
-        newActivityMetaRef.current = null;
-        setSelectedActivity(null);
+
+      if (selectedActivity.id.startsWith('temp-')) {
+        if (currentDayIndex === -1) {
+          return;
+        }
+        const { dayId: _omitDayId, ...activityBase } = { ...selectedActivity, ...sanitized };
+        void _omitDayId;
+        addActivity(activityBase, currentDayIndex);
         return;
       }
-      const { dayId: _omitDayId, ...activityBase } = { ...selectedActivity, ...sanitized };
-      void _omitDayId;
-      addActivity(activityBase, dayIndex);
-    } else {
+
       updateActivity(selectedActivity.id, sanitized);
+    } finally {
+      savingRef.current = false;
+      newActivityMetaRef.current = null;
+      setSelectedActivity(null);
     }
-    setSelectedActivity(null);
   };
 
   const deleteActivityById = () => {
@@ -157,7 +205,11 @@ export function useSelectedActivity(
       setSelectedActivity(null);
       return;
     }
-    removeActivity(selectedActivity.id);
+    if (isPlaceholderActivity(selectedActivity)) {
+      removePlaceholderFromPlanner(selectedActivity.id, selectedActivity.dayId);
+    } else {
+      removeActivity(selectedActivity.id);
+    }
     newActivityMetaRef.current = null;
     setSelectedActivity(null);
   };

--- a/src/features/planner/services/diffPlanEvents.ts
+++ b/src/features/planner/services/diffPlanEvents.ts
@@ -2,7 +2,7 @@
 
 import { midpoint } from '@/features/planner/domain/events/gapOrdering';
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
-import { BLANK_ACTIVITY_PREFIX } from '@/features/planner/domain/utils/activityPlaceholders';
+import { isPlaceholderActivity } from '@/features/planner/domain/utils/activityPlaceholders';
 import type { PlanEventInsert } from '@/features/planner/domain/types/PlanEvent';
 
 function generateId(): string {
@@ -98,6 +98,7 @@ export function diffPlanEvents(
 
   for (const day of prevDaysWithPositions) {
     for (const activity of ensurePositions(day.activities)) {
+      if (isPlaceholderActivity(activity)) continue;
       prevActivityMap.set(activity.id, { dayId: day.id, activity });
     }
   }
@@ -120,6 +121,14 @@ export function diffPlanEvents(
     ...day,
     activities: ensurePositions(day.activities).map(cloneActivity),
   }));
+
+  const nextActivityMap = new Map<string, { dayId: string; activity: Activity }>();
+  for (const day of nextDaysWithPositions) {
+    for (const activity of day.activities) {
+      if (isPlaceholderActivity(activity)) continue;
+      nextActivityMap.set(activity.id, { dayId: day.id, activity });
+    }
+  }
 
   for (let index = 0; index < nextDaysWithPositions.length; index++) {
     const day = nextDaysWithPositions[index];
@@ -190,11 +199,12 @@ export function diffPlanEvents(
   // Activity diffing
   for (const day of nextDaysWithPositions) {
     const prevDay = prevDayMap.get(day.id);
-    const nextActivityIds = new Set(day.activities.map((a) => a.id));
+    const visibleActivities = day.activities.filter((activity) => !isPlaceholderActivity(activity));
 
     if (prevDay) {
       for (const activity of prevDay.activities) {
-        if (!nextActivityIds.has(activity.id)) {
+        if (isPlaceholderActivity(activity)) continue;
+        if (!nextActivityMap.has(activity.id)) {
           events.push({
             id: generateId(),
             planId,
@@ -206,18 +216,16 @@ export function diffPlanEvents(
       }
     }
 
-    const activityOrder = day.activities.map((a) => a.id);
-    const neighborPositionMap = new Map(day.activities.map((a) => [a.id, a.position]));
+    const activityOrder = visibleActivities.map((a) => a.id);
+    const neighborPositionMap = new Map(visibleActivities.map((a) => [a.id, a.position]));
 
-    day.activities.forEach((activity, index) => {
+    visibleActivities.forEach((activity, index) => {
       const prevActivity = prevActivityMap.get(activity.id);
       if (!prevActivity) {
-        const isPlaceholder = activity.id.startsWith(BLANK_ACTIVITY_PREFIX);
         const position = midpoint(
           index > 0 ? neighborPositionMap.get(activityOrder[index - 1]) : undefined,
           computeRightNeighborPosition(activityOrder, index, neighborPositionMap)
         );
-        const activityId = isPlaceholder ? generateId() : activity.id;
         events.push({
           id: generateId(),
           planId,
@@ -225,8 +233,8 @@ export function diffPlanEvents(
           payload: {
             dayId: day.id,
             activity: {
-              ...sanitizeActivity({ ...activity, id: activityId }),
-              id: activityId,
+              ...sanitizeActivity(activity),
+              id: activity.id,
               position,
             },
             position,

--- a/src/features/planner/services/diffPlanEvents.ts
+++ b/src/features/planner/services/diffPlanEvents.ts
@@ -2,6 +2,7 @@
 
 import { midpoint } from '@/features/planner/domain/events/gapOrdering';
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
+import { BLANK_ACTIVITY_PREFIX } from '@/features/planner/domain/utils/activityPlaceholders';
 import type { PlanEventInsert } from '@/features/planner/domain/types/PlanEvent';
 
 function generateId(): string {
@@ -211,7 +212,7 @@ export function diffPlanEvents(
     day.activities.forEach((activity, index) => {
       const prevActivity = prevActivityMap.get(activity.id);
       if (!prevActivity) {
-        const isPlaceholder = activity.id.startsWith('blank-');
+        const isPlaceholder = activity.id.startsWith(BLANK_ACTIVITY_PREFIX);
         const position = midpoint(
           index > 0 ? neighborPositionMap.get(activityOrder[index - 1]) : undefined,
           computeRightNeighborPosition(activityOrder, index, neighborPositionMap)

--- a/src/server/actions/updatePlan.ts
+++ b/src/server/actions/updatePlan.ts
@@ -13,5 +13,7 @@ export async function setPlanDateRange(planId: string, from: Date, to: Date) {
       end_date: format(to, 'yyyy-MM-dd'),
     })
     .eq('id', planId);
-  if (error) throw error;
+  if (error) {
+    throw new Error(error.message ?? 'Failed to update plan date range');
+  }
 }

--- a/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
+++ b/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
@@ -1,0 +1,92 @@
+// tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
+
+import { useState } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
+import { useActivityState } from '@/features/planner/hooks/useActivityState';
+import { useSelectedActivity } from '@/features/planner/hooks/useSelectedActivity';
+import { usePersistedPlannerDays } from '@/features/planner/hooks/usePersistedPlannerDays';
+
+function usePlannerHarness(initialDays: DayPlan[], mutateAsync: ReturnType<typeof vi.fn>) {
+  const [days, setDays] = useState<DayPlan[]>(initialDays);
+  const activityState = useActivityState(setDays);
+  const selected = useSelectedActivity(days, setDays, activityState);
+
+  usePersistedPlannerDays({
+    planner: { days, setDays },
+    persistDays: { mutateAsync, isPending: false },
+    storedDays: initialDays,
+  });
+
+  return {
+    days,
+    setDays,
+    addBlankAndSelect: selected.addBlankAndSelect,
+    closeModal: selected.closeModal,
+    setSelectedActivity: selected.setSelectedActivity,
+  };
+}
+
+describe('useSelectedActivity blank placeholders', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('removes blank placeholders and skips persistence when closing an untouched modal', async () => {
+    vi.useFakeTimers();
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
+
+    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
+
+    await act(async () => {
+      result.current.addBlankAndSelect('day-1');
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(1);
+    expect(result.current.days[0].activities[0].title).toBe('');
+
+    await act(async () => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+    });
+
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
+  it('removes placeholders that received a server-assigned id before closing', async () => {
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
+
+    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
+
+    const serverActivity: Activity = {
+      id: 'server-activity-1',
+      title: '',
+      description: '',
+      duration: 0,
+      color: '#ffffff',
+      budget: 0,
+      category: '',
+    };
+
+    await act(async () => {
+      result.current.setDays([{ id: 'day-1', label: 'Day 1', activities: [serverActivity] }]);
+      result.current.setSelectedActivity({ ...serverActivity, dayId: 'day-1' });
+    });
+
+    await act(async () => {
+      result.current.closeModal();
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(0);
+  });
+});

--- a/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
+++ b/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
@@ -24,10 +24,13 @@ function usePlannerHarness(initialDays: DayPlan[], mutateAsync: ReturnType<typeo
   return {
     days,
     setDays,
+    selectedActivity: selected.selectedActivity,
     addBlankAndSelect: selected.addBlankAndSelect,
     closeModal: selected.closeModal,
-    setSelectedActivity: selected.setSelectedActivity,
     save: selected.save,
+    changeDay: selected.changeDay,
+    changePosition: selected.changePosition,
+    setSelectedActivity: selected.setSelectedActivity,
   };
 }
 
@@ -36,7 +39,7 @@ describe('useSelectedActivity blank placeholders', () => {
     vi.useRealTimers();
   });
 
-  it('removes blank placeholders and skips persistence when closing an untouched modal', async () => {
+  it('does not enqueue persistence when cancelling a brand new card', async () => {
     vi.useFakeTimers();
     const persistSpy = vi.fn().mockResolvedValue(undefined);
     const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
@@ -47,8 +50,7 @@ describe('useSelectedActivity blank placeholders', () => {
       result.current.addBlankAndSelect('day-1');
     });
 
-    expect(result.current.days[0].activities).toHaveLength(1);
-    expect(result.current.days[0].activities[0].title).toBe('');
+    expect(result.current.days[0].activities).toHaveLength(0);
 
     await act(async () => {
       result.current.closeModal();
@@ -64,7 +66,78 @@ describe('useSelectedActivity blank placeholders', () => {
     expect(persistSpy).not.toHaveBeenCalled();
   });
 
-  it('removes placeholders that received a server-assigned id before closing', async () => {
+  it('creates a persisted activity at the reserved index on save', async () => {
+    const idSpy = vi
+      .spyOn(placeholders, 'generateClientActivityId')
+      .mockReturnValue('generated-id');
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const initialDays: DayPlan[] = [
+      {
+        id: 'day-1',
+        label: 'Day 1',
+        activities: [
+          { id: 'a', title: 'Breakfast', color: '#f00' },
+          { id: 'b', title: 'Dinner', color: '#0f0' },
+        ],
+      },
+    ];
+
+    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
+
+    await act(async () => {
+      result.current.addBlankAndSelect('day-1', 1);
+    });
+
+    await act(async () => {
+      result.current.save({ title: 'City tour' });
+    });
+
+    const activities = result.current.days[0].activities;
+    expect(activities).toHaveLength(3);
+    expect(activities[1].id).toBe('generated-id');
+    expect(activities[1].title).toBe('City tour');
+
+    idSpy.mockRestore();
+  });
+
+  it('saves a new card into a different day after changing the selected day', async () => {
+    const idSpy = vi
+      .spyOn(placeholders, 'generateClientActivityId')
+      .mockReturnValue('activity-123');
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const initialDays: DayPlan[] = [
+      { id: 'day-1', label: 'Day 1', activities: [{ id: 'a', title: 'Breakfast', color: '#f00' }] },
+      { id: 'day-2', label: 'Day 2', activities: [{ id: 'b', title: 'Dinner', color: '#0f0' }] },
+    ];
+
+    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
+
+    await act(async () => {
+      result.current.addBlankAndSelect('day-1');
+    });
+
+    const pendingId = result.current.selectedActivity?.id;
+    expect(pendingId).toBeTruthy();
+
+    await act(async () => {
+      if (pendingId) {
+        result.current.changeDay(pendingId, 'day-2');
+      }
+    });
+
+    await act(async () => {
+      result.current.save({ title: 'Museum' });
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(1);
+    expect(result.current.days[1].activities).toHaveLength(2);
+    expect(result.current.days[1].activities[1].id).toBe('activity-123');
+    expect(result.current.days[1].activities[1].title).toBe('Museum');
+
+    idSpy.mockRestore();
+  });
+
+  it('removes blank activities that arrive from the server when closing the modal', async () => {
     const persistSpy = vi.fn().mockResolvedValue(undefined);
     const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
 
@@ -90,33 +163,5 @@ describe('useSelectedActivity blank placeholders', () => {
     });
 
     expect(result.current.days[0].activities).toHaveLength(0);
-  });
-
-  it('replaces a blank placeholder with a persisted activity on save', async () => {
-    const idSpy = vi
-      .spyOn(placeholders, 'generateClientActivityId')
-      .mockReturnValue('generated-id');
-    const persistSpy = vi.fn().mockResolvedValue(undefined);
-    const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
-
-    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
-
-    await act(async () => {
-      result.current.addBlankAndSelect('day-1');
-    });
-
-    expect(result.current.days[0].activities).toHaveLength(1);
-    expect(result.current.days[0].activities[0].id).toMatch(/^blank-/);
-
-    await act(async () => {
-      result.current.save({ title: 'City tour' });
-    });
-
-    expect(result.current.days[0].activities).toHaveLength(1);
-    const activity = result.current.days[0].activities[0];
-    expect(activity.id).toBe('generated-id');
-    expect(activity.title).toBe('City tour');
-
-    idSpy.mockRestore();
   });
 });

--- a/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
+++ b/tests/unit/features/planner/hooks/useSelectedActivity.blank.test.ts
@@ -8,6 +8,7 @@ import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerE
 import { useActivityState } from '@/features/planner/hooks/useActivityState';
 import { useSelectedActivity } from '@/features/planner/hooks/useSelectedActivity';
 import { usePersistedPlannerDays } from '@/features/planner/hooks/usePersistedPlannerDays';
+import * as placeholders from '@/features/planner/domain/utils/activityPlaceholders';
 
 function usePlannerHarness(initialDays: DayPlan[], mutateAsync: ReturnType<typeof vi.fn>) {
   const [days, setDays] = useState<DayPlan[]>(initialDays);
@@ -26,6 +27,7 @@ function usePlannerHarness(initialDays: DayPlan[], mutateAsync: ReturnType<typeo
     addBlankAndSelect: selected.addBlankAndSelect,
     closeModal: selected.closeModal,
     setSelectedActivity: selected.setSelectedActivity,
+    save: selected.save,
   };
 }
 
@@ -88,5 +90,33 @@ describe('useSelectedActivity blank placeholders', () => {
     });
 
     expect(result.current.days[0].activities).toHaveLength(0);
+  });
+
+  it('replaces a blank placeholder with a persisted activity on save', async () => {
+    const idSpy = vi
+      .spyOn(placeholders, 'generateClientActivityId')
+      .mockReturnValue('generated-id');
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const initialDays: DayPlan[] = [{ id: 'day-1', label: 'Day 1', activities: [] }];
+
+    const { result } = renderHook(() => usePlannerHarness(initialDays, persistSpy));
+
+    await act(async () => {
+      result.current.addBlankAndSelect('day-1');
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(1);
+    expect(result.current.days[0].activities[0].id).toMatch(/^blank-/);
+
+    await act(async () => {
+      result.current.save({ title: 'City tour' });
+    });
+
+    expect(result.current.days[0].activities).toHaveLength(1);
+    const activity = result.current.days[0].activities[0];
+    expect(activity.id).toBe('generated-id');
+    expect(activity.title).toBe('City tour');
+
+    idSpy.mockRestore();
   });
 });

--- a/tests/unit/features/planner/services/diffPlanEvents.test.ts
+++ b/tests/unit/features/planner/services/diffPlanEvents.test.ts
@@ -2,14 +2,19 @@
 
 import { describe, expect, it } from 'vitest';
 
+import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
 import { diffPlanEvents } from '@/features/planner/services/diffPlanEvents';
+
+const baseDay = {
+  label: 'Day',
+};
 
 describe('diffPlanEvents', () => {
   it('emits a single move when dragging an activity past neighbours with stale positions', () => {
     const previousDays = [
       {
         id: 'day-1',
-        label: 'Day 1',
+        ...baseDay,
         position: '1000',
         activities: [
           { id: 'activity-a', title: 'A', color: 'red', position: '1000' },
@@ -22,12 +27,58 @@ describe('diffPlanEvents', () => {
     const nextDays = [
       {
         id: 'day-1',
-        label: 'Day 1',
+        ...baseDay,
         position: '1000',
         activities: [
           { id: 'activity-b', title: 'B', color: 'red', position: '2000' },
           { id: 'activity-c', title: 'C', color: 'red', position: '3000' },
           { id: 'activity-a', title: 'A', color: 'red', position: '1000' },
+        ],
+      },
+    ];
+
+    const events = diffPlanEvents('plan-1', previousDays, nextDays);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'activity.moved',
+      payload: {
+        activityId: 'activity-a',
+        fromDayId: 'day-1',
+        toDayId: 'day-1',
+      },
+    });
+  });
+
+  it('emits only a move when transferring an activity between days', () => {
+    const previousDays = [
+      {
+        id: 'day-1',
+        ...baseDay,
+        position: '1000',
+        activities: [{ id: 'activity-a', title: 'A', color: 'red', position: '1000' }],
+      },
+      {
+        id: 'day-2',
+        ...baseDay,
+        position: '2000',
+        activities: [{ id: 'activity-b', title: 'B', color: 'red', position: '2000' }],
+      },
+    ];
+
+    const nextDays = [
+      {
+        id: 'day-1',
+        ...baseDay,
+        position: '1000',
+        activities: [],
+      },
+      {
+        id: 'day-2',
+        ...baseDay,
+        position: '2000',
+        activities: [
+          { id: 'activity-b', title: 'B', color: 'red' },
+          { id: 'activity-a', title: 'A', color: 'red' },
         ],
       },
     ];
@@ -40,8 +91,24 @@ describe('diffPlanEvents', () => {
       payload: {
         activityId: 'activity-a',
         fromDayId: 'day-1',
-        toDayId: 'day-1',
+        toDayId: 'day-2',
       },
     });
+  });
+
+  it('ignores placeholder activities that leak into the next state', () => {
+    const previousDays: DayPlan[] = [{ id: 'day-1', ...baseDay, position: '1000', activities: [] }];
+    const nextDays: DayPlan[] = [
+      {
+        id: 'day-1',
+        ...baseDay,
+        position: '1000',
+        activities: [{ id: 'blank-123', title: '', color: 'red', position: undefined }],
+      },
+    ];
+
+    const events = diffPlanEvents('plan-1', previousDays, nextDays);
+
+    expect(events).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- ensure planner placeholder activities start without a title and centralize the blank marker helper
- remove blank activities before persistence, clean up the modal close logic, and rely on the shared helper inside diffing
- adjust the home feature carousel card to keep server/client markup aligned and add regression coverage for blank modal closures

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d83d79462483228b3570220793d79b