### PR TITLE
Prevent empty collaboration snapshots from wiping planner days

### DIFF
--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -77,14 +77,20 @@ export function usePersistedPlannerDays({
     if (storedDays == null) return;
     const snapshot = snapshotDays(storedDays);
     const meta = metaRef.current!;
-    const hasChanged = snapshot.serialized !== meta.lastSaved;
     meta.ready = true;
+
+    if (snapshot.state.length === 0 && days.length > 0) {
+      meta.lastSaved = snapshot.serialized;
+      return;
+    }
+
+    const hasChanged = snapshot.serialized !== meta.lastSaved;
     meta.lastSaved = snapshot.serialized;
     meta.fallback = snapshot.state;
     if (hasChanged) {
       setDays(snapshot.state);
     }
-  }, [setDays, storedDays]);
+  }, [days.length, setDays, storedDays]);
 
   const { mutateAsync, isPending } = persistDays;
   const flush = useCallback(async () => {

--- a/tests/unit/features/planner/hooks/useDnDPlanner.persistence.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.persistence.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react';
+import type { DragStartEvent, DragOverEvent } from '@dnd-kit/core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DayPlan, Activity } from '@/features/planner/domain/types/PlannerEntities';
+import { useDnDPlanner } from '@/features/planner/hooks/useDnDPlanner';
+import { usePersistedPlannerDays } from '@/features/planner/hooks/usePersistedPlannerDays';
+
+describe('useDnDPlanner with persistence', () => {
+  const a1: Activity = { id: 'a1', title: 'A1', color: 'bg-[var(--color-1)]' };
+  const b1: Activity = { id: 'b1', title: 'B1', color: 'bg-[var(--color-1)]' };
+  const initial: DayPlan[] = [
+    { id: 'day1', label: 'Day 1', activities: [a1] },
+    { id: 'day2', label: 'Day 2', activities: [b1] },
+  ];
+
+  function setup() {
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const wrapper = renderHook(() => {
+      const planner = useDnDPlanner(initial);
+      usePersistedPlannerDays({
+        planner,
+        persistDays: { mutateAsync: persistSpy, isPending: false },
+        persist: false,
+      });
+      return planner;
+    });
+    return { persistSpy, ...wrapper };
+  }
+
+  it('keeps days length after dragging across columns', () => {
+    const { result } = setup();
+
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const overEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragOverEvent> as DragOverEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      result.current.handleDragOver(overEvent);
+    });
+
+    expect(result.current.days).toHaveLength(2);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual([]);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
+  it('does not clear existing days when stored snapshot is empty', () => {
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ stored }: { stored: DayPlan[] | undefined }) => {
+        const planner = useDnDPlanner(initial);
+        usePersistedPlannerDays({
+          planner,
+          persistDays: { mutateAsync: persistSpy, isPending: false },
+          persist: false,
+          storedDays: stored,
+        });
+        return planner.days;
+      },
+      { initialProps: { stored: undefined as DayPlan[] | undefined } }
+    );
+
+    expect(result.current).toHaveLength(2);
+
+    rerender({ stored: [] });
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].activities.map((a) => a.id)).toEqual(['a1']);
+    expect(result.current[1].activities.map((a) => a.id)).toEqual(['b1']);
+  });
+});


### PR DESCRIPTION
## Summary
- guard `usePersistedPlannerDays` against replacing populated local state with an empty snapshot from realtime collaboration
- add a regression test ensuring drag-and-drop planner state persists when no stored days are returned

## Testing
- npm run lint (warnings only for existing `any` usage in planEventsRepository)
- npm run typecheck
- npm run test *(fails: tests/unit/a11y/planner-page.a11y.test.tsx timeout)*
- npm run test -- tests/unit/features/planner/hooks/useDnDPlanner.persistence.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d895928d0c83229271db3f192cc9b5