### PR TITLE
Persist recent plans synchronously

### DIFF
--- a/src/shared/hooks/useLocalStorage.ts
+++ b/src/shared/hooks/useLocalStorage.ts
@@ -1,7 +1,8 @@
 // src/shared/hooks/useLocalStorage.ts
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 /**
  * Syncs state with localStorage for the given key.
@@ -11,6 +12,7 @@ export function useLocalStorage<T>(key: string, initial: T) {
   const [value, setValue] = useState<T>(initial);
   const [ready, setReady] = useState(false);
   const initialized = useRef(false);
+  const latestValue = useRef(value);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -28,6 +30,28 @@ export function useLocalStorage<T>(key: string, initial: T) {
   }, [key]);
 
   useEffect(() => {
+    latestValue.current = value;
+  }, [value]);
+
+  const setStoredValue = useCallback<Dispatch<SetStateAction<T>>>((nextValue) => {
+    const resolvedValue =
+      typeof nextValue === 'function'
+        ? (nextValue as (current: T) => T)(latestValue.current)
+        : nextValue;
+
+    latestValue.current = resolvedValue;
+    setValue(resolvedValue);
+
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(resolvedValue));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
     if (!initialized.current || typeof window === 'undefined') return;
     try {
       window.localStorage.setItem(key, JSON.stringify(value));
@@ -36,5 +60,5 @@ export function useLocalStorage<T>(key: string, initial: T) {
     }
   }, [key, value]);
 
-  return [value, setValue, ready] as const;
+  return [value, setStoredValue, ready] as const;
 }

--- a/tests/unit/features/home/ContinuePlanningBanner.test.tsx
+++ b/tests/unit/features/home/ContinuePlanningBanner.test.tsx
@@ -3,9 +3,10 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { hydrateRoot, type Root } from 'react-dom/client';
-import { screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 
 import ContinuePlanningBanner from '@/features/home/components/ContinuePlanningBanner';
+import { useRecentPlan } from '@/features/planner/contracts/marketing/useRecentPlan';
 
 vi.mock('next/link', () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => (
@@ -56,5 +57,36 @@ describe('ContinuePlanningBanner hydration', () => {
 
     consoleError.mockRestore();
     act(() => root.unmount());
+  });
+
+  it('saves the recent plan to localStorage immediately', () => {
+    const plan = {
+      id: '2',
+      slug: 'immediate',
+      dest: 'Lisbon',
+      start: '2023-02-01',
+      end: '2023-02-05',
+    };
+
+    function SaveRecentPlanButton() {
+      const { saveRecentPlan } = useRecentPlan();
+
+      return (
+        <button type="button" onClick={() => saveRecentPlan(plan)}>
+          Save plan
+        </button>
+      );
+    }
+
+    const { unmount } = render(<SaveRecentPlanButton />);
+
+    expect(window.localStorage.getItem('recent_plan')).toBe(JSON.stringify(null));
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save plan' }));
+      unmount();
+    });
+
+    expect(window.localStorage.getItem('recent_plan')).toBe(JSON.stringify(plan));
   });
 });


### PR DESCRIPTION
## Summary
- update the localStorage hook to write immediately when the setter is invoked
- ensure recent plan consumers keep using the enhanced setter and add coverage for unmounted saves

## Testing
- npm run test -- ContinuePlanningBanner

------
https://chatgpt.com/codex/tasks/task_e_68d89f2c0f2c8322ac38b3953344b88c