### PR TITLE
Ensure planner drag end persists final drop target

### DIFF
--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -209,16 +209,22 @@ export function useDragState(initialDays: DayPlan[]) {
 
   function handleDragOver(e: DragOverEvent): void {
     const { active, over } = e;
-    if (over) {
+    const previousOver = lastOverRef.current;
+    let nextOver = over;
+
+    if (over && over.id === active.id) {
+      nextOver = previousOver;
+    } else if (over) {
       lastOverRef.current = over;
     }
-    if (!over || active.id === over.id) return;
+
+    if (!nextOver) return;
 
     setDays((prevDays) => {
       const nextDays = moveActivity(
         prevDays,
         active.id,
-        over,
+        nextOver,
         dayIndexRef.current,
         activityIndexRef.current
       );
@@ -226,7 +232,7 @@ export function useDragState(initialDays: DayPlan[]) {
       if (nextDays !== prevDays) {
         lastMoveRef.current = {
           activeId: String(active.id),
-          overId: over ? String(over.id) : null,
+          overId: nextOver ? String(nextOver.id) : null,
           days: nextDays,
         };
       }
@@ -239,7 +245,8 @@ export function useDragState(initialDays: DayPlan[]) {
     setActiveId(null);
 
     const { active } = e;
-    const over = e.over ?? lastOverRef.current;
+    const storedOver = lastOverRef.current;
+    const over = !e.over || e.over.id === active.id ? (storedOver ?? e.over ?? null) : e.over;
     lastOverRef.current = null;
 
     const currentDays = daysRef.current;
@@ -251,7 +258,7 @@ export function useDragState(initialDays: DayPlan[]) {
       return currentDays;
     }
 
-    if (!e.over && lastMoveRef.current) {
+    if ((!e.over || e.over.id === active.id) && lastMoveRef.current) {
       const lastMove = lastMoveRef.current;
       if (
         lastMove.days === currentDays &&

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -8,6 +8,7 @@ import {
   useSensors,
   type DragStartEvent,
   type DragOverEvent,
+  type DragEndEvent,
   type UniqueIdentifier,
 } from '@dnd-kit/core';
 import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
@@ -31,20 +32,39 @@ function getDragTarget(
 
   const sortable = over.data?.current?.sortable;
   if (sortable) {
-    const dstDayIdx = dayIndexMap.get(String(sortable.containerId));
-    if (dstDayIdx == null) return null;
+    const containerId = String(sortable.containerId);
+    let dstDayIdx = dayIndexMap.get(containerId);
+    if (dstDayIdx == null) {
+      dstDayIdx = days.findIndex((day) => String(day.id) === containerId);
+      if (dstDayIdx === -1) return null;
+    }
     return {
       dstDayIdx,
       newIndex: sortable.index,
     };
   }
 
-  const dayIdx = dayIndexMap.get(String(over.id));
+  const overId = String(over.id);
+  let dayIdx = dayIndexMap.get(overId);
   if (dayIdx != null) {
     return { dstDayIdx: dayIdx, newIndex: days[dayIdx].activities.length };
   }
 
-  const activityMeta = activityIndexMap.get(String(over.id));
+  dayIdx = days.findIndex((day) => String(day.id) === overId);
+  if (dayIdx !== -1) {
+    return { dstDayIdx: dayIdx, newIndex: days[dayIdx].activities.length };
+  }
+
+  let activityMeta = activityIndexMap.get(overId);
+  if (!activityMeta) {
+    for (let dayIdx = 0; dayIdx < days.length; dayIdx += 1) {
+      const actIdx = days[dayIdx].activities.findIndex((activity) => String(activity.id) === overId);
+      if (actIdx !== -1) {
+        activityMeta = { dayIdx, actIdx };
+        break;
+      }
+    }
+  }
   if (!activityMeta) return null;
 
   return {
@@ -53,8 +73,68 @@ function getDragTarget(
   };
 }
 
+function moveActivity(
+  days: DayPlan[],
+  activeId: UniqueIdentifier,
+  over: DragOverEvent['over'],
+  dayIndexMap: Map<string, number>,
+  activityIndexMap: Map<string, { dayIdx: number; actIdx: number }>
+): DayPlan[] {
+  if (!over) return days;
+
+  const activeKey = String(activeId);
+  let sourceMeta = activityIndexMap.get(activeKey);
+  if (!sourceMeta) {
+    for (let dayIdx = 0; dayIdx < days.length; dayIdx += 1) {
+      const actIdx = days[dayIdx].activities.findIndex((activity) => String(activity.id) === activeKey);
+      if (actIdx !== -1) {
+        sourceMeta = { dayIdx, actIdx };
+        break;
+      }
+    }
+  }
+  if (!sourceMeta) return days;
+
+  const target = getDragTarget(days, over, dayIndexMap, activityIndexMap);
+  if (!target) return days;
+
+  const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
+  const { dstDayIdx, newIndex } = target;
+
+  if (dstDayIdx === srcDayIdx && newIndex === oldIndex) {
+    return days;
+  }
+
+  const nextDays = [...days];
+  const srcDay = days[srcDayIdx];
+  const dstDay = days[dstDayIdx];
+  if (!srcDay || !dstDay) return days;
+
+  nextDays[srcDayIdx] = {
+    ...srcDay,
+    activities: [...srcDay.activities],
+  };
+  const srcActivities = nextDays[srcDayIdx].activities;
+  const [moved] = srcActivities.splice(oldIndex, 1);
+  if (!moved) return days;
+
+  let dstActivities = srcActivities;
+  if (dstDayIdx !== srcDayIdx) {
+    nextDays[dstDayIdx] = {
+      ...dstDay,
+      activities: [...dstDay.activities],
+    };
+    dstActivities = nextDays[dstDayIdx].activities;
+  }
+
+  dstActivities.splice(newIndex, 0, moved);
+
+  return nextDays;
+}
+
 export function useDragState(initialDays: DayPlan[]) {
   const [days, setDaysState] = useState<DayPlan[]>(initialDays);
+  const daysRef = useRef<DayPlan[]>(initialDays);
 
   const dayIndexRef = useRef<Map<string, number>>(new Map());
   const activityIndexRef = useRef<Map<string, { dayIdx: number; actIdx: number }>>(new Map());
@@ -81,10 +161,12 @@ export function useDragState(initialDays: DayPlan[]) {
 
         if (nextDays === prevDays) {
           rebuildCaches(prevDays);
+          daysRef.current = prevDays;
           return prevDays;
         }
 
         rebuildCaches(nextDays);
+        daysRef.current = nextDays;
         return nextDays;
       });
     },
@@ -115,50 +197,34 @@ export function useDragState(initialDays: DayPlan[]) {
     if (now - lastTimeRef.current < 16) return;
     lastTimeRef.current = now;
 
-    setDays((prevDays) => {
-      const sourceMeta = activityIndexRef.current.get(String(active.id));
-      if (!sourceMeta) return prevDays;
-
-      const target = getDragTarget(prevDays, over, dayIndexRef.current, activityIndexRef.current);
-      if (!target) return prevDays;
-
-      const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
-      const { dstDayIdx, newIndex } = target;
-
-      if (dstDayIdx === srcDayIdx && newIndex === oldIndex) {
-        return prevDays;
-      }
-
-      const nextDays = [...prevDays];
-      const srcDay = prevDays[srcDayIdx];
-      const dstDay = prevDays[dstDayIdx];
-      if (!srcDay || !dstDay) return prevDays;
-
-      nextDays[srcDayIdx] = {
-        ...srcDay,
-        activities: [...srcDay.activities],
-      };
-      const srcActivities = nextDays[srcDayIdx].activities;
-      const [moved] = srcActivities.splice(oldIndex, 1);
-      if (!moved) return prevDays;
-
-      let dstActivities = srcActivities;
-      if (dstDayIdx !== srcDayIdx) {
-        nextDays[dstDayIdx] = {
-          ...dstDay,
-          activities: [...dstDay.activities],
-        };
-        dstActivities = nextDays[dstDayIdx].activities;
-      }
-
-      dstActivities.splice(newIndex, 0, moved);
-
-      return nextDays;
-    });
+    setDays((prevDays) =>
+      moveActivity(prevDays, active.id, over, dayIndexRef.current, activityIndexRef.current)
+    );
   }
 
-  function handleDragEnd(): void {
+  function handleDragEnd(e: DragEndEvent): DayPlan[] {
     setActiveId(null);
+
+    const { active, over } = e;
+    if (!over || active.id === over.id) {
+      return days;
+    }
+
+    const currentDays = daysRef.current;
+    const updated = moveActivity(
+      currentDays,
+      active.id,
+      over,
+      dayIndexRef.current,
+      activityIndexRef.current
+    );
+
+    if (updated !== currentDays) {
+      daysRef.current = updated;
+      setDays(updated);
+    }
+
+    return updated;
   }
 
   return {

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -147,6 +147,46 @@ function moveActivity(
   return nextDays;
 }
 
+function getCollisionFallback(
+  collisions: DragEndEvent['collisions'],
+  activeId: UniqueIdentifier
+): DragOverEvent['over'] | null {
+  if (!collisions || collisions.length === 0) {
+    return null;
+  }
+
+  const activeKey = String(activeId);
+
+  for (const collision of collisions) {
+    if (!collision || String(collision.id) === activeKey) {
+      continue;
+    }
+
+    const droppable = collision.data?.droppableContainer;
+    if (!droppable) {
+      continue;
+    }
+
+    const rect = droppable.rect.current ?? {
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    };
+
+    return {
+      id: droppable.id,
+      data: droppable.data,
+      disabled: droppable.disabled,
+      rect,
+    } as DragOverEvent['over'];
+  }
+
+  return null;
+}
+
 export function useDragState(initialDays: DayPlan[]) {
   const [days, setDaysState] = useState<DayPlan[]>(initialDays);
   const daysRef = useRef<DayPlan[]>(initialDays);
@@ -246,8 +286,20 @@ export function useDragState(initialDays: DayPlan[]) {
 
     const { active } = e;
     const storedOver = lastOverRef.current;
-    const over = !e.over || e.over.id === active.id ? (storedOver ?? e.over ?? null) : e.over;
-    lastOverRef.current = null;
+    let over: DragOverEvent['over'] | null = e.over;
+    let derivedOver: DragOverEvent['over'] | null = null;
+
+    if (!over || over.id === active.id) {
+      if (storedOver && storedOver.id !== active.id) {
+        over = storedOver;
+      } else {
+        derivedOver = getCollisionFallback(e.collisions, active.id);
+        if (derivedOver) {
+          over = derivedOver;
+          lastOverRef.current = derivedOver;
+        }
+      }
+    }
 
     const currentDays = daysRef.current;
     const activeKey = String(active.id);
@@ -255,6 +307,9 @@ export function useDragState(initialDays: DayPlan[]) {
 
     if (!over || active.id === over.id) {
       lastMoveRef.current = null;
+      if (!derivedOver) {
+        lastOverRef.current = null;
+      }
       return currentDays;
     }
 
@@ -284,6 +339,7 @@ export function useDragState(initialDays: DayPlan[]) {
     }
 
     lastMoveRef.current = null;
+    lastOverRef.current = null;
     return updated;
   }
 

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -58,7 +58,9 @@ function getDragTarget(
   let activityMeta = activityIndexMap.get(overId);
   if (!activityMeta) {
     for (let dayIdx = 0; dayIdx < days.length; dayIdx += 1) {
-      const actIdx = days[dayIdx].activities.findIndex((activity) => String(activity.id) === overId);
+      const actIdx = days[dayIdx].activities.findIndex(
+        (activity) => String(activity.id) === overId
+      );
       if (actIdx !== -1) {
         activityMeta = { dayIdx, actIdx };
         break;
@@ -86,7 +88,9 @@ function moveActivity(
   let sourceMeta = activityIndexMap.get(activeKey);
   if (!sourceMeta) {
     for (let dayIdx = 0; dayIdx < days.length; dayIdx += 1) {
-      const actIdx = days[dayIdx].activities.findIndex((activity) => String(activity.id) === activeKey);
+      const actIdx = days[dayIdx].activities.findIndex(
+        (activity) => String(activity.id) === activeKey
+      );
       if (actIdx !== -1) {
         sourceMeta = { dayIdx, actIdx };
         break;

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -194,15 +194,12 @@ export function useDragState(initialDays: DayPlan[]) {
   }, [initialDays, setDays]);
 
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
-  // Throttle state updates so drag-over doesn't fire excessively
-  const lastTimeRef = useRef<number>(0);
   const lastOverRef = useRef<DragOverEvent['over']>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   function handleDragStart(e: DragStartEvent): void {
     setActiveId(e.active.id);
-    lastTimeRef.current = 0;
     lastOverRef.current = null;
   }
 
@@ -212,10 +209,6 @@ export function useDragState(initialDays: DayPlan[]) {
       lastOverRef.current = over;
     }
     if (!over || active.id === over.id) return;
-    const now = Date.now();
-    // Avoid rapid re-renders but keep drag responsive
-    if (now - lastTimeRef.current < 16) return;
-    lastTimeRef.current = now;
 
     setDays((prevDays) =>
       moveActivity(prevDays, active.id, over, dayIndexRef.current, activityIndexRef.current)

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -103,7 +103,8 @@ function moveActivity(
   if (!target) return days;
 
   const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
-  const { dstDayIdx, newIndex } = target;
+  const { dstDayIdx } = target;
+  let { newIndex } = target;
 
   if (dstDayIdx === srcDayIdx && newIndex === oldIndex) {
     return days;
@@ -131,7 +132,17 @@ function moveActivity(
     dstActivities = nextDays[dstDayIdx].activities;
   }
 
-  dstActivities.splice(newIndex, 0, moved);
+  const isSameDay = dstDayIdx === srcDayIdx;
+  const overId = over ? String(over.id) : null;
+  const isContainerTarget = overId != null && overId === String(dstDay.id);
+
+  if (isSameDay && isContainerTarget && newIndex > oldIndex) {
+    newIndex -= 1;
+  }
+
+  const clampedIndex = Math.max(0, Math.min(newIndex, dstActivities.length));
+
+  dstActivities.splice(clampedIndex, 0, moved);
 
   return nextDays;
 }

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -185,16 +185,21 @@ export function useDragState(initialDays: DayPlan[]) {
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
   // Throttle state updates so drag-over doesn't fire excessively
   const lastTimeRef = useRef<number>(0);
+  const lastOverRef = useRef<DragOverEvent['over']>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   function handleDragStart(e: DragStartEvent): void {
     setActiveId(e.active.id);
     lastTimeRef.current = 0;
+    lastOverRef.current = null;
   }
 
   function handleDragOver(e: DragOverEvent): void {
     const { active, over } = e;
+    if (over) {
+      lastOverRef.current = over;
+    }
     if (!over || active.id === over.id) return;
     const now = Date.now();
     // Avoid rapid re-renders but keep drag responsive
@@ -209,7 +214,10 @@ export function useDragState(initialDays: DayPlan[]) {
   function handleDragEnd(e: DragEndEvent): DayPlan[] {
     setActiveId(null);
 
-    const { active, over } = e;
+    const { active } = e;
+    const over = e.over ?? lastOverRef.current;
+    lastOverRef.current = null;
+
     if (!over || active.id === over.id) {
       return days;
     }

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -195,12 +195,16 @@ export function useDragState(initialDays: DayPlan[]) {
 
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
   const lastOverRef = useRef<DragOverEvent['over']>(null);
+  const lastMoveRef = useRef<{ activeId: string; overId: string | null; days: DayPlan[] } | null>(
+    null
+  );
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   function handleDragStart(e: DragStartEvent): void {
     setActiveId(e.active.id);
     lastOverRef.current = null;
+    lastMoveRef.current = null;
   }
 
   function handleDragOver(e: DragOverEvent): void {
@@ -210,9 +214,25 @@ export function useDragState(initialDays: DayPlan[]) {
     }
     if (!over || active.id === over.id) return;
 
-    setDays((prevDays) =>
-      moveActivity(prevDays, active.id, over, dayIndexRef.current, activityIndexRef.current)
-    );
+    setDays((prevDays) => {
+      const nextDays = moveActivity(
+        prevDays,
+        active.id,
+        over,
+        dayIndexRef.current,
+        activityIndexRef.current
+      );
+
+      if (nextDays !== prevDays) {
+        lastMoveRef.current = {
+          activeId: String(active.id),
+          overId: over ? String(over.id) : null,
+          days: nextDays,
+        };
+      }
+
+      return nextDays;
+    });
   }
 
   function handleDragEnd(e: DragEndEvent): DayPlan[] {
@@ -222,11 +242,27 @@ export function useDragState(initialDays: DayPlan[]) {
     const over = e.over ?? lastOverRef.current;
     lastOverRef.current = null;
 
+    const currentDays = daysRef.current;
+    const activeKey = String(active.id);
+    const overId = over ? String(over.id) : null;
+
     if (!over || active.id === over.id) {
-      return days;
+      lastMoveRef.current = null;
+      return currentDays;
     }
 
-    const currentDays = daysRef.current;
+    if (!e.over && lastMoveRef.current) {
+      const lastMove = lastMoveRef.current;
+      if (
+        lastMove.days === currentDays &&
+        lastMove.activeId === activeKey &&
+        lastMove.overId === overId
+      ) {
+        lastMoveRef.current = null;
+        return currentDays;
+      }
+    }
+
     const updated = moveActivity(
       currentDays,
       active.id,
@@ -240,6 +276,7 @@ export function useDragState(initialDays: DayPlan[]) {
       setDays(updated);
     }
 
+    lastMoveRef.current = null;
     return updated;
   }
 

--- a/src/features/planner/hooks/usePlanner.ts
+++ b/src/features/planner/hooks/usePlanner.ts
@@ -3,7 +3,7 @@
 
 import { useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { pointerWithin } from '@dnd-kit/core';
+import { pointerWithin, type DragEndEvent } from '@dnd-kit/core';
 import { DateRange } from 'react-day-picker';
 import { eachDayOfInterval } from 'date-fns';
 
@@ -65,9 +65,9 @@ export function usePlanner(options: UsePlannerOptions = {}) {
     addBlankActivity,
   } = useDnDPlanner(initialDnDDays);
 
-  function persistOnDragEnd() {
-    handleDragEnd();
-    options.persistDays?.mutate(days);
+  function persistOnDragEnd(event: DragEndEvent) {
+    const updatedDays = handleDragEnd(event);
+    options.persistDays?.mutate(updatedDays ?? days);
   }
 
   /**

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -197,6 +197,36 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd reuses the stored hover when the final over matches the active card', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const moveToDayTwo = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as unknown as DragOverEvent;
+    const hoverActive = {
+      active: { id: 'a1' },
+      over: { id: 'a1' },
+    } as unknown as DragOverEvent;
+    const endEvent = {
+      active: { id: 'a1' },
+      over: { id: 'a1' },
+    } as unknown as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      result.current.handleDragOver(moveToDayTwo);
+      result.current.handleDragOver(hoverActive);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(updated?.[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
   test('handleDragEnd keeps same-day reorder when drop finishes outside a column', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -197,6 +197,57 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd uses collision fallback when no hover was stored', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const endEvent = {
+      active: { id: 'a1' },
+      over: null,
+      collisions: [
+        {
+          id: 'day2',
+          data: {
+            droppableContainer: {
+              id: 'day2',
+              key: 'day2',
+              disabled: false,
+              node: { current: null },
+              data: {
+                current: {
+                  sortable: {
+                    containerId: 'day2',
+                    index: 1,
+                  },
+                },
+              },
+              rect: {
+                current: {
+                  width: 0,
+                  height: 0,
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  left: 0,
+                },
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(updated?.[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
   test('handleDragEnd reuses the stored hover when the final over matches the active card', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -34,7 +34,7 @@ describe('useDnDPlanner', () => {
     const overEvent = {
       active: { id: 'a1' },
       over: { id: 'a2' },
-    } as Partial<DragOverEvent> as DragOverEvent;
+    } as unknown as DragOverEvent;
 
     act(() => {
       result.current.handleDragOver(overEvent);
@@ -43,12 +43,37 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
   });
 
+  test('handleDragOver drops to the end of the same day when moving downward', () => {
+    const { result } = setup();
+    const overEvent = {
+      active: { id: 'a1' },
+      over: {
+        id: 'day1',
+        data: {
+          current: {
+            sortable: {
+              containerId: 'day1',
+              index: 3,
+            },
+          },
+        },
+      },
+    } as unknown as DragOverEvent;
+
+    act(() => {
+      result.current.handleDragOver(overEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1']);
+  });
+
   test('handleDragOver moves activity across days', () => {
     const { result } = setup();
     const overEvent = {
       active: { id: 'a1' },
       over: { id: 'day2' },
-    } as Partial<DragOverEvent> as DragOverEvent;
+    } as unknown as DragOverEvent;
 
     act(() => {
       result.current.handleDragOver(overEvent);
@@ -61,7 +86,7 @@ describe('useDnDPlanner', () => {
   test('handleDragEnd clears activeId', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
-    const endEvent = { active: { id: 'a1' }, over: null } as Partial<DragEndEvent> as DragEndEvent;
+    const endEvent = { active: { id: 'a1' }, over: null } as unknown as DragEndEvent;
 
     act(() => {
       result.current.handleDragStart(startEvent);
@@ -77,7 +102,7 @@ describe('useDnDPlanner', () => {
     const endEvent = {
       active: { id: 'a1' },
       over: { id: 'day2' },
-    } as Partial<DragEndEvent> as DragEndEvent;
+    } as unknown as DragEndEvent;
 
     let updated: DayPlan[] | undefined;
     act(() => {
@@ -91,14 +116,43 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd keeps indices aligned when dropping lower in the same column', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const endEvent = {
+      active: { id: 'a1' },
+      over: {
+        id: 'day1',
+        data: {
+          current: {
+            sortable: {
+              containerId: 'day1',
+              index: 3,
+            },
+          },
+        },
+      },
+    } as unknown as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1']);
+  });
+
   test('handleDragEnd falls back to the last hovered column when over is null', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
     const overEvent = {
       active: { id: 'a1' },
       over: { id: 'day2' },
-    } as Partial<DragOverEvent> as DragOverEvent;
-    const endEvent = { active: { id: 'a1' }, over: null } as Partial<DragEndEvent> as DragEndEvent;
+    } as unknown as DragOverEvent;
+    const endEvent = { active: { id: 'a1' }, over: null } as unknown as DragEndEvent;
 
     let updated: DayPlan[] | undefined;
     act(() => {

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -197,6 +197,26 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd keeps same-day reorder when drop finishes outside a column', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const overEvent = {
+      active: { id: 'a1' },
+      over: { id: 'a2' },
+    } as unknown as DragOverEvent;
+    const endEvent = { active: { id: 'a1' }, over: null } as unknown as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      result.current.handleDragOver(overEvent);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+  });
+
   test('updates days when initialDays changes', () => {
     const first: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
     const second: DayPlan[] = [

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/features/planner/hooks/useDnDPlanner.test.ts
 
 import { renderHook, act } from '@testing-library/react';
-import type { DragStartEvent, DragOverEvent } from '@dnd-kit/core';
+import type { DragStartEvent, DragOverEvent, DragEndEvent } from '@dnd-kit/core';
 import { useDnDPlanner } from '@/features/planner/hooks/useDnDPlanner';
 import type { DayPlan, Activity } from '@/features/planner/domain/types/PlannerEntities';
 
@@ -61,13 +61,34 @@ describe('useDnDPlanner', () => {
   test('handleDragEnd clears activeId', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const endEvent = { active: { id: 'a1' }, over: null } as Partial<DragEndEvent> as DragEndEvent;
 
     act(() => {
       result.current.handleDragStart(startEvent);
-      result.current.handleDragEnd();
+      result.current.handleDragEnd(endEvent);
     });
 
     expect(result.current.activeId).toBeNull();
+  });
+
+  test('handleDragEnd applies the final drop target', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const endEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragEndEvent> as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(updated?.[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
   test('updates days when initialDays changes', () => {

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -83,6 +83,36 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragOver applies rapid successive targets immediately', () => {
+    const { result } = setup();
+    const toDayTwo = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as unknown as DragOverEvent;
+    const backToDayOne = {
+      active: { id: 'a1' },
+      over: {
+        id: 'day1',
+        data: {
+          current: {
+            sortable: {
+              containerId: 'day1',
+              index: 1,
+            },
+          },
+        },
+      },
+    } as unknown as DragOverEvent;
+
+    act(() => {
+      result.current.handleDragOver(toDayTwo);
+      result.current.handleDragOver(backToDayOne);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1']);
+  });
+
   test('handleDragEnd clears activeId', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -91,6 +91,28 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd falls back to the last hovered column when over is null', () => {
+    const { result } = setup();
+    const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
+    const overEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragOverEvent> as DragOverEvent;
+    const endEvent = { active: { id: 'a1' }, over: null } as Partial<DragEndEvent> as DragEndEvent;
+
+    let updated: DayPlan[] | undefined;
+    act(() => {
+      result.current.handleDragStart(startEvent);
+      result.current.handleDragOver(overEvent);
+      updated = result.current.handleDragEnd(endEvent);
+    });
+
+    expect(updated?.[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(updated?.[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
   test('updates days when initialDays changes', () => {
     const first: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
     const second: DayPlan[] = [


### PR DESCRIPTION
## Summary
- extract shared moveActivity helper in the drag state hook and keep caches in sync
- apply the shared movement logic on drag end so the last drop target is persisted
- update planner persistence and unit tests to exercise the new drag end contract

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d89ec682f48322b50a99ef6d2dc4f4