### PR TITLE
Handle planner drag end when drag-over is skipped

### DIFF
--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -9,6 +9,7 @@ import {
   type DragStartEvent,
   type DragOverEvent,
   type DragMoveEvent,
+  type DragEndEvent,
   type UniqueIdentifier,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
@@ -57,6 +58,7 @@ function getDragTarget(
 
 export function useDragState(initialDays: DayPlan[]) {
   const [days, setDaysState] = useState<DayPlan[]>(initialDays);
+  const daysRef = useRef<DayPlan[]>(initialDays);
 
   const dayIndexRef = useRef<Map<string, number>>(new Map());
   const activityIndexRef = useRef<Map<string, { dayIdx: number; actIdx: number }>>(new Map());
@@ -91,10 +93,12 @@ export function useDragState(initialDays: DayPlan[]) {
 
         if (nextDays === prevDays) {
           rebuildCaches(prevDays);
+          daysRef.current = prevDays;
           return prevDays;
         }
 
         rebuildCaches(nextDays);
+        daysRef.current = nextDays;
         return nextDays;
       });
     },
@@ -110,6 +114,68 @@ export function useDragState(initialDays: DayPlan[]) {
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
+  function reorderActivities(
+    prevDays: DayPlan[],
+    activeIdValue: UniqueIdentifier,
+    over: DragOverEvent['over']
+  ): { nextDays: DayPlan[]; didUpdate: boolean } {
+    if (!over) {
+      return { nextDays: prevDays, didUpdate: false };
+    }
+
+    const sourceMeta = activityIndexRef.current.get(String(activeIdValue));
+    if (!sourceMeta) {
+      return { nextDays: prevDays, didUpdate: false };
+    }
+
+    const target = getDragTarget(prevDays, over, dayIndexRef.current, activityIndexRef.current);
+    if (!target) {
+      return { nextDays: prevDays, didUpdate: false };
+    }
+
+    const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
+    const { dstDayIdx, newIndex } = target;
+
+    const srcDay = prevDays[srcDayIdx];
+    const dstDay = prevDays[dstDayIdx];
+    if (!srcDay || !dstDay) {
+      return { nextDays: prevDays, didUpdate: false };
+    }
+
+    if (dstDayIdx === srcDayIdx) {
+      if (newIndex === oldIndex) {
+        return { nextDays: prevDays, didUpdate: false };
+      }
+
+      const nextDays = [...prevDays];
+      nextDays[srcDayIdx] = {
+        ...srcDay,
+        activities: arrayMove(srcDay.activities, oldIndex, newIndex),
+      };
+      return { nextDays, didUpdate: true };
+    }
+
+    const nextDays = [...prevDays];
+    nextDays[srcDayIdx] = {
+      ...srcDay,
+      activities: [...srcDay.activities],
+    };
+    const srcActivities = nextDays[srcDayIdx].activities;
+    const [moved] = srcActivities.splice(oldIndex, 1);
+    if (!moved) {
+      return { nextDays: prevDays, didUpdate: false };
+    }
+
+    nextDays[dstDayIdx] = {
+      ...dstDay,
+      activities: [...dstDay.activities],
+    };
+    const dstActivities = nextDays[dstDayIdx].activities;
+    dstActivities.splice(newIndex, 0, moved);
+
+    return { nextDays, didUpdate: true };
+  }
+
   function handleDragStart(e: DragStartEvent): void {
     setActiveId(e.active.id);
     lastAppliedRef.current = null;
@@ -123,64 +189,30 @@ export function useDragState(initialDays: DayPlan[]) {
   }
 
   const applyDragUpdate = useCallback(
-    (activeIdValue: UniqueIdentifier, over: DragOverEvent['over']) => {
-      if (!over) return;
+    (
+      activeIdValue: UniqueIdentifier,
+      over: DragOverEvent['over'],
+      onApply?: (nextDays: DayPlan[]) => void
+    ): boolean => {
+      if (!over) return false;
 
       let didUpdate = false;
+      let appliedDays: DayPlan[] | null = null;
 
       setDays((prevDays) => {
-        const sourceMeta = activityIndexRef.current.get(String(activeIdValue));
-        if (!sourceMeta) return prevDays;
-
-        const target = getDragTarget(prevDays, over, dayIndexRef.current, activityIndexRef.current);
-        if (!target) return prevDays;
-
-        const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
-        const { dstDayIdx, newIndex } = target;
-
-        const srcDay = prevDays[srcDayIdx];
-        const dstDay = prevDays[dstDayIdx];
-        if (!srcDay || !dstDay) return prevDays;
-
-        if (dstDayIdx === srcDayIdx) {
-          if (newIndex === oldIndex) {
-            return prevDays;
-          }
-
-          const nextDays = [...prevDays];
-          nextDays[srcDayIdx] = {
-            ...srcDay,
-            activities: arrayMove(srcDay.activities, oldIndex, newIndex),
-          };
-          didUpdate = true;
-          return nextDays;
-        }
-
-        const nextDays = [...prevDays];
-        nextDays[srcDayIdx] = {
-          ...srcDay,
-          activities: [...srcDay.activities],
-        };
-        const srcActivities = nextDays[srcDayIdx].activities;
-        const [moved] = srcActivities.splice(oldIndex, 1);
-        if (!moved) return prevDays;
-
-        nextDays[dstDayIdx] = {
-          ...dstDay,
-          activities: [...dstDay.activities],
-        };
-        const dstActivities = nextDays[dstDayIdx].activities;
-        dstActivities.splice(newIndex, 0, moved);
-
-        didUpdate = true;
+        const { nextDays, didUpdate: wasUpdated } = reorderActivities(prevDays, activeIdValue, over);
+        didUpdate = wasUpdated;
+        appliedDays = nextDays;
         return nextDays;
       });
 
       lastAppliedRef.current = { activeId: activeIdValue, overId: over.id ?? null };
 
-      if (!didUpdate) {
-        return;
+      if (didUpdate && appliedDays && onApply) {
+        onApply(appliedDays);
       }
+
+      return didUpdate;
     },
     [setDays]
   );
@@ -239,7 +271,25 @@ export function useDragState(initialDays: DayPlan[]) {
     scheduleDragUpdate(active.id, over);
   }
 
-  function handleDragEnd(): void {
+  function handleDragEnd(e: DragEndEvent, onApply?: (nextDays: DayPlan[]) => void): void {
+    const { active, over } = e;
+
+    if (over && active.id !== over.id) {
+      const overId = over.id ?? null;
+      const lastApplied = lastAppliedRef.current;
+
+      if (!lastApplied || lastApplied.activeId !== active.id || lastApplied.overId !== overId) {
+        const updated = applyDragUpdate(active.id, over, onApply);
+        if (!updated && onApply) {
+          onApply(daysRef.current);
+        }
+      } else if (onApply) {
+        onApply(daysRef.current);
+      }
+    } else if (onApply) {
+      onApply(daysRef.current);
+    }
+
     setActiveId(null);
     if (queuedFrameRef.current != null) {
       if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {

--- a/src/features/planner/hooks/usePlanner.ts
+++ b/src/features/planner/hooks/usePlanner.ts
@@ -4,6 +4,7 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { pointerWithin } from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
 import { DateRange } from 'react-day-picker';
 import { eachDayOfInterval } from 'date-fns';
 
@@ -66,9 +67,10 @@ export function usePlanner(options: UsePlannerOptions = {}) {
     addBlankActivity,
   } = useDnDPlanner(initialDnDDays);
 
-  function persistOnDragEnd() {
-    handleDragEnd();
-    options.persistDays?.mutate(days);
+  function persistOnDragEnd(e: DragEndEvent) {
+    handleDragEnd(e, (nextDays) => {
+      options.persistDays?.mutate(nextDays);
+    });
   }
 
   /**

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/features/planner/hooks/useDnDPlanner.test.ts
 
 import { renderHook, act } from '@testing-library/react';
-import type { DragStartEvent, DragOverEvent } from '@dnd-kit/core';
+import type { DragStartEvent, DragOverEvent, DragEndEvent } from '@dnd-kit/core';
 import { useDnDPlanner } from '@/features/planner/hooks/useDnDPlanner';
 import type { DayPlan, Activity } from '@/features/planner/domain/types/PlannerEntities';
 
@@ -70,13 +70,33 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd applies move when dragOver was skipped', () => {
+    const { result } = setup();
+    const endEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragEndEvent> as DragEndEvent;
+
+    act(() => {
+      result.current.handleDragEnd(endEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
   test('handleDragEnd clears activeId', () => {
     const { result } = setup();
     const startEvent = { active: { id: 'a1' } } as unknown as DragStartEvent;
 
+    const endEvent = {
+      active: { id: 'a1' },
+      over: null,
+    } as Partial<DragEndEvent> as DragEndEvent;
+
     act(() => {
       result.current.handleDragStart(startEvent);
-      result.current.handleDragEnd();
+      result.current.handleDragEnd(endEvent);
     });
 
     expect(result.current.activeId).toBeNull();


### PR DESCRIPTION
## Summary
- extract shared activity reordering logic that can be reused by drag handlers
- update the drag end handler to accept the dnd-kit event, apply the fallback reordering, and notify persistence callbacks
- keep planner persistence in sync with the updated handler and add coverage for the new drag-end behavior

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d8c508694c832283662be83a1a4505