### PR TITLE
Ensure drag end finalizes planner reordering

### DIFF
--- a/src/features/planner/hooks/useDnDPlanner.ts
+++ b/src/features/planner/hooks/useDnDPlanner.ts
@@ -21,8 +21,7 @@ export function useDnDPlanner(initialDays: DayPlan[]) {
     handleDragStart,
     handleDragOver,
     handleDragEnd,
-  } =
-    useDragState(initialDays);
+  } = useDragState(initialDays);
 
   const { addActivity, removeActivity, updateActivity, addBlankActivity } =
     useActivityState(setDays);

--- a/src/features/planner/hooks/useDnDPlanner.ts
+++ b/src/features/planner/hooks/useDnDPlanner.ts
@@ -12,7 +12,16 @@ import { useActivityState } from './useActivityState';
  */
 
 export function useDnDPlanner(initialDays: DayPlan[]) {
-  const { days, setDays, activeId, sensors, handleDragStart, handleDragOver, handleDragEnd } =
+  const {
+    days,
+    setDays,
+    getDaysSnapshot,
+    activeId,
+    sensors,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+  } =
     useDragState(initialDays);
 
   const { addActivity, removeActivity, updateActivity, addBlankActivity } =
@@ -21,6 +30,7 @@ export function useDnDPlanner(initialDays: DayPlan[]) {
   return {
     days,
     setDays,
+    getDaysSnapshot,
     activeId,
     sensors,
     handleDragStart,

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -106,13 +106,16 @@ export function useDragState(initialDays: DayPlan[]) {
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
+  const lastOverRef = useRef<DragOverEvent['over'] | null>(null);
+
   function handleDragStart(e: DragStartEvent): void {
     setActiveId(e.active.id);
     lastTimeRef.current = 0;
+    lastOverRef.current = null;
   }
 
   const applyDragUpdate = useCallback(
-    (activeId: UniqueIdentifier, over: DragOverEvent['over']) => {
+    (activeId: UniqueIdentifier, over: DragOverEvent['over'] | null) => {
       if (!over) return;
 
       setDays((prevDays) => {
@@ -153,6 +156,8 @@ export function useDragState(initialDays: DayPlan[]) {
 
         dstActivities.splice(newIndex, 0, moved);
 
+        lastOverRef.current = over;
+
         return nextDays;
       });
     },
@@ -162,6 +167,7 @@ export function useDragState(initialDays: DayPlan[]) {
   function handleDragOver(e: DragOverEvent): void {
     const { active, over } = e;
     if (!over || active.id === over.id) return;
+    lastOverRef.current = over;
     const now = Date.now();
     // Avoid rapid re-renders but keep drag responsive
     if (now - lastTimeRef.current < 16) return;
@@ -171,10 +177,13 @@ export function useDragState(initialDays: DayPlan[]) {
   }
 
   function handleDragEnd(e?: DragEndEvent): void {
-    if (e?.active && e?.over && e.active.id !== e.over.id) {
-      applyDragUpdate(e.active.id, e.over);
+    const active = e?.active;
+    const over = e?.over ?? lastOverRef.current;
+    if (active && over && active.id !== over.id) {
+      applyDragUpdate(active.id, over);
     }
     setActiveId(null);
+    lastOverRef.current = null;
   }
 
   return {

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -8,6 +8,7 @@ import {
   useSensors,
   type DragStartEvent,
   type DragOverEvent,
+  type DragEndEvent,
   type UniqueIdentifier,
 } from '@dnd-kit/core';
 import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
@@ -55,6 +56,7 @@ function getDragTarget(
 
 export function useDragState(initialDays: DayPlan[]) {
   const [days, setDaysState] = useState<DayPlan[]>(initialDays);
+  const daysRef = useRef<DayPlan[]>(initialDays);
 
   const dayIndexRef = useRef<Map<string, number>>(new Map());
   const activityIndexRef = useRef<Map<string, { dayIdx: number; actIdx: number }>>(new Map());
@@ -80,10 +82,12 @@ export function useDragState(initialDays: DayPlan[]) {
           typeof value === 'function' ? (value as (prev: DayPlan[]) => DayPlan[])(prevDays) : value;
 
         if (nextDays === prevDays) {
+          daysRef.current = prevDays;
           rebuildCaches(prevDays);
           return prevDays;
         }
 
+        daysRef.current = nextDays;
         rebuildCaches(nextDays);
         return nextDays;
       });
@@ -107,6 +111,54 @@ export function useDragState(initialDays: DayPlan[]) {
     lastTimeRef.current = 0;
   }
 
+  const applyDragUpdate = useCallback(
+    (activeId: UniqueIdentifier, over: DragOverEvent['over']) => {
+      if (!over) return;
+
+      setDays((prevDays) => {
+        const sourceMeta = activityIndexRef.current.get(String(activeId));
+        if (!sourceMeta) return prevDays;
+
+        const target = getDragTarget(prevDays, over, dayIndexRef.current, activityIndexRef.current);
+        if (!target) return prevDays;
+
+        const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
+        const { dstDayIdx, newIndex } = target;
+
+        if (dstDayIdx === srcDayIdx && newIndex === oldIndex) {
+          return prevDays;
+        }
+
+        const nextDays = [...prevDays];
+        const srcDay = prevDays[srcDayIdx];
+        const dstDay = prevDays[dstDayIdx];
+        if (!srcDay || !dstDay) return prevDays;
+
+        nextDays[srcDayIdx] = {
+          ...srcDay,
+          activities: [...srcDay.activities],
+        };
+        const srcActivities = nextDays[srcDayIdx].activities;
+        const [moved] = srcActivities.splice(oldIndex, 1);
+        if (!moved) return prevDays;
+
+        let dstActivities = srcActivities;
+        if (dstDayIdx !== srcDayIdx) {
+          nextDays[dstDayIdx] = {
+            ...dstDay,
+            activities: [...dstDay.activities],
+          };
+          dstActivities = nextDays[dstDayIdx].activities;
+        }
+
+        dstActivities.splice(newIndex, 0, moved);
+
+        return nextDays;
+      });
+    },
+    [setDays]
+  );
+
   function handleDragOver(e: DragOverEvent): void {
     const { active, over } = e;
     if (!over || active.id === over.id) return;
@@ -115,55 +167,20 @@ export function useDragState(initialDays: DayPlan[]) {
     if (now - lastTimeRef.current < 16) return;
     lastTimeRef.current = now;
 
-    setDays((prevDays) => {
-      const sourceMeta = activityIndexRef.current.get(String(active.id));
-      if (!sourceMeta) return prevDays;
-
-      const target = getDragTarget(prevDays, over, dayIndexRef.current, activityIndexRef.current);
-      if (!target) return prevDays;
-
-      const { dayIdx: srcDayIdx, actIdx: oldIndex } = sourceMeta;
-      const { dstDayIdx, newIndex } = target;
-
-      if (dstDayIdx === srcDayIdx && newIndex === oldIndex) {
-        return prevDays;
-      }
-
-      const nextDays = [...prevDays];
-      const srcDay = prevDays[srcDayIdx];
-      const dstDay = prevDays[dstDayIdx];
-      if (!srcDay || !dstDay) return prevDays;
-
-      nextDays[srcDayIdx] = {
-        ...srcDay,
-        activities: [...srcDay.activities],
-      };
-      const srcActivities = nextDays[srcDayIdx].activities;
-      const [moved] = srcActivities.splice(oldIndex, 1);
-      if (!moved) return prevDays;
-
-      let dstActivities = srcActivities;
-      if (dstDayIdx !== srcDayIdx) {
-        nextDays[dstDayIdx] = {
-          ...dstDay,
-          activities: [...dstDay.activities],
-        };
-        dstActivities = nextDays[dstDayIdx].activities;
-      }
-
-      dstActivities.splice(newIndex, 0, moved);
-
-      return nextDays;
-    });
+    applyDragUpdate(active.id, over);
   }
 
-  function handleDragEnd(): void {
+  function handleDragEnd(e?: DragEndEvent): void {
+    if (e?.active && e?.over && e.active.id !== e.over.id) {
+      applyDragUpdate(e.active.id, e.over);
+    }
     setActiveId(null);
   }
 
   return {
     days,
     setDays,
+    getDaysSnapshot: () => daysRef.current,
     activeId,
     sensors,
     handleDragStart,

--- a/src/features/planner/hooks/usePlanner.ts
+++ b/src/features/planner/hooks/usePlanner.ts
@@ -54,6 +54,7 @@ export function usePlanner(options: UsePlannerOptions = {}) {
   const {
     days,
     setDays,
+    getDaysSnapshot,
     activeId,
     sensors,
     handleDragStart,
@@ -65,9 +66,9 @@ export function usePlanner(options: UsePlannerOptions = {}) {
     addBlankActivity,
   } = useDnDPlanner(initialDnDDays);
 
-  function persistOnDragEnd() {
-    handleDragEnd();
-    options.persistDays?.mutate(days);
+  function persistOnDragEnd(event?: Parameters<typeof handleDragEnd>[0]) {
+    handleDragEnd(event);
+    options.persistDays?.mutate(getDaysSnapshot());
   }
 
   /**

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -99,6 +99,26 @@ describe('useDnDPlanner', () => {
     expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
+  test('handleDragEnd falls back to last known target when drop lacks over data', () => {
+    const { result } = setup();
+    const overEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragOverEvent> as DragOverEvent;
+    const endEvent = {
+      active: { id: 'a1' },
+      over: null,
+    } as Partial<DragEndEvent> as DragEndEvent;
+
+    act(() => {
+      result.current.handleDragOver(overEvent);
+      result.current.handleDragEnd(endEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
+  });
+
   test('updates days when initialDays changes', () => {
     const first: DayPlan[] = [{ id: 'd1', label: 'Day 1', activities: [] }];
     const second: DayPlan[] = [

--- a/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
+++ b/tests/unit/features/planner/hooks/useDnDPlanner.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/features/planner/hooks/useDnDPlanner.test.ts
 
 import { renderHook, act } from '@testing-library/react';
-import type { DragStartEvent, DragOverEvent } from '@dnd-kit/core';
+import type { DragStartEvent, DragOverEvent, DragEndEvent } from '@dnd-kit/core';
 import { useDnDPlanner } from '@/features/planner/hooks/useDnDPlanner';
 import type { DayPlan, Activity } from '@/features/planner/domain/types/PlannerEntities';
 
@@ -68,6 +68,35 @@ describe('useDnDPlanner', () => {
     });
 
     expect(result.current.activeId).toBeNull();
+  });
+
+  test('handleDragEnd reorders when dropping over another activity', () => {
+    const { result } = setup();
+    const endEvent = {
+      active: { id: 'a1' },
+      over: { id: 'a2' },
+    } as Partial<DragEndEvent> as DragEndEvent;
+
+    act(() => {
+      result.current.handleDragEnd(endEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2', 'a1']);
+  });
+
+  test('handleDragEnd moves activity across days on drop', () => {
+    const { result } = setup();
+    const endEvent = {
+      active: { id: 'a1' },
+      over: { id: 'day2' },
+    } as Partial<DragEndEvent> as DragEndEvent;
+
+    act(() => {
+      result.current.handleDragEnd(endEvent);
+    });
+
+    expect(result.current.days[0].activities.map((a) => a.id)).toEqual(['a2']);
+    expect(result.current.days[1].activities.map((a) => a.id)).toEqual(['b1', 'a1']);
   });
 
   test('updates days when initialDays changes', () => {


### PR DESCRIPTION
## Summary
- rerun the reordering logic during drag end and keep a local snapshot in `useDragState` so drops immediately update the UI
- plumb the latest planner snapshot through `useDnDPlanner` and `usePlanner` to persist the newly ordered days on drop
- extend the drag-and-drop hook tests to cover drop-time reordering without intermediate hover events
- remove the `docs/drag-delay-audit.md` follow-up audit note now that the fix is in place

## Testing
- npm run format:check *(fails: prettier flags existing style issues in `src/features/planner/hooks/useDnDPlanner.ts`)*
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d942c63d3c832280da99878c65e15a