### PR TITLE
Improve touch dragging and immediate planner persistence

### DIFF
--- a/src/features/planner/components/dnd/ActivityCard.tsx
+++ b/src/features/planner/components/dnd/ActivityCard.tsx
@@ -47,7 +47,6 @@ export default function ActivityCard({
   const { editing, draft, setDraft, inputRef, cardRef, overlayRef, start, save, cancel } =
     useActivityCardEditor({
       title,
-      imageUrl,
       onTitleSave,
     });
 

--- a/src/features/planner/components/dnd/SortableItem.tsx
+++ b/src/features/planner/components/dnd/SortableItem.tsx
@@ -78,7 +78,7 @@ export default function SortableItem({
       ref={setNodeRef}
       style={style}
       className={cn(
-        'relative list-none [touch-action:none]',
+        'relative [touch-action:none] list-none',
         isDragging ? 'cursor-grabbing' : 'cursor-grab',
         className
       )}

--- a/src/features/planner/components/dnd/SortableItem.tsx
+++ b/src/features/planner/components/dnd/SortableItem.tsx
@@ -78,7 +78,7 @@ export default function SortableItem({
       ref={setNodeRef}
       style={style}
       className={cn(
-        'relative list-none',
+        'relative list-none [touch-action:none]',
         isDragging ? 'cursor-grabbing' : 'cursor-grab',
         className
       )}

--- a/src/features/planner/hooks/useActivityCardEditor.ts
+++ b/src/features/planner/hooks/useActivityCardEditor.ts
@@ -8,7 +8,6 @@ export function useActivityCardEditor({
   onTitleSave,
 }: {
   title: string;
-  imageUrl?: string;
   onTitleSave?: (s: string) => void;
 }) {
   const [editing, setEditing] = useState(false);

--- a/src/features/planner/hooks/useDragState.ts
+++ b/src/features/planner/hooks/useDragState.ts
@@ -4,6 +4,7 @@
 import { useState, useRef, useEffect, useCallback, type SetStateAction } from 'react';
 import {
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   type DragStartEvent,
@@ -104,7 +105,11 @@ export function useDragState(initialDays: DayPlan[]) {
   // Throttle state updates so drag-over doesn't fire excessively
   const lastTimeRef = useRef<number>(0);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const pointerSensor = useSensor(PointerSensor, { activationConstraint: { distance: 8 } });
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 0, tolerance: 4 },
+  });
+  const sensors = useSensors(pointerSensor, touchSensor);
 
   const lastOverRef = useRef<DragOverEvent['over'] | null>(null);
 

--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -1,7 +1,6 @@
 // src/features/planner/hooks/usePersistedPlannerDays.ts
 'use client';
-import { useCallback, useEffect, useRef } from 'react';
-import { useDebounce } from '@/shared/hooks/useDebounce';
+import { useEffect, useRef } from 'react';
 import type { DayPlan } from '@/features/planner/domain/types/PlannerEntities';
 import { isPlaceholderActivity } from '@/features/planner/domain/utils/activityPlaceholders';
 import type { usePlanner } from './usePlanner';
@@ -16,11 +15,6 @@ interface UsePersistedPlannerDaysParams {
   persistDays: PersistDaysMutation;
   persist?: boolean;
   storedDays?: DayPlan[] | null;
-}
-
-interface PersistQueue {
-  state: DayPlan[];
-  serialized: string;
 }
 
 interface PersistMeta {
@@ -49,7 +43,7 @@ function snapshotDays(days: DayPlan[]) {
 }
 
 /**
- * Persists planner days with debounce, rollback, and lifecycle-aware flushing.
+ * Persists planner days immediately with rollback safeguards.
  *
  * The hook keeps a cloned snapshot of the last saved state so failed mutations can
  * safely roll back even though the planner mutates nested arrays in place.
@@ -61,7 +55,6 @@ export function usePersistedPlannerDays({
   storedDays,
 }: UsePersistedPlannerDaysParams) {
   const { days, setDays } = planner;
-  const debouncedDays = useDebounce(days, 500);
   const metaRef = useRef<PersistMeta | null>(null);
   if (!metaRef.current) {
     const snapshot = snapshotDays(storedDays ?? days);
@@ -71,7 +64,8 @@ export function usePersistedPlannerDays({
       fallback: snapshot.state,
     };
   }
-  const queueRef = useRef<PersistQueue | null>(null);
+  const persistChainRef = useRef<Promise<void>>(Promise.resolve());
+  const lastRequestedRef = useRef<string>(metaRef.current.lastSaved);
 
   useEffect(() => {
     if (storedDays == null) return;
@@ -81,64 +75,46 @@ export function usePersistedPlannerDays({
 
     if (snapshot.state.length === 0 && days.length > 0) {
       meta.lastSaved = snapshot.serialized;
+      lastRequestedRef.current = meta.lastSaved;
       return;
     }
 
     const hasChanged = snapshot.serialized !== meta.lastSaved;
     meta.lastSaved = snapshot.serialized;
     meta.fallback = snapshot.state;
+    lastRequestedRef.current = meta.lastSaved;
     if (hasChanged) {
       setDays(snapshot.state);
     }
   }, [days.length, setDays, storedDays]);
 
-  const { mutateAsync, isPending } = persistDays;
-  const flush = useCallback(async () => {
-    const queued = queueRef.current;
-    const meta = metaRef.current!;
-    if (!queued || isPending) return;
-
-    queueRef.current = null;
-    try {
-      await mutateAsync(queued.state);
-      meta.lastSaved = queued.serialized;
-      meta.fallback = queued.state;
-    } catch {
-      setDays(cloneDays(meta.fallback));
-    } finally {
-      if (queueRef.current) void flush();
-    }
-  }, [isPending, mutateAsync, setDays]);
+  const { mutateAsync } = persistDays;
 
   useEffect(() => {
     const meta = metaRef.current!;
     if (!persist || !meta.ready) return;
-    if (debouncedDays.length === 0) return;
+    if (days.length === 0) return;
 
-    const cleanedDays = removeBlankActivities(debouncedDays);
+    const cleanedDays = removeBlankActivities(days);
+    if (cleanedDays.length === 0) return;
+
     const serialized = JSON.stringify(cleanedDays);
-    if (serialized === meta.lastSaved) return;
+    if (serialized === meta.lastSaved || serialized === lastRequestedRef.current) return;
 
-    queueRef.current = { state: cloneDays(cleanedDays), serialized };
-    void flush();
-  }, [debouncedDays, flush, persist]);
+    const snapshotState = cloneDays(cleanedDays);
+    lastRequestedRef.current = serialized;
 
-  useEffect(() => {
-    if (!persist) return;
+    persistChainRef.current = persistChainRef.current.finally(async () => {
+      try {
+        await mutateAsync(snapshotState);
+        meta.lastSaved = serialized;
+        meta.fallback = snapshotState;
+      } catch {
+        lastRequestedRef.current = meta.lastSaved;
+        setDays(cloneDays(meta.fallback));
+      }
+    });
+  }, [days, mutateAsync, persist, setDays]);
 
-    const flushOnLifecycle = (event?: Event) => {
-      if (!queueRef.current) return;
-      if (event?.type === 'visibilitychange' && document.visibilityState !== 'hidden') return;
-      void flush();
-    };
-
-    window.addEventListener('beforeunload', flushOnLifecycle);
-    document.addEventListener('visibilitychange', flushOnLifecycle);
-    return () => {
-      window.removeEventListener('beforeunload', flushOnLifecycle);
-      document.removeEventListener('visibilitychange', flushOnLifecycle);
-    };
-  }, [flush, persist]);
-
-  return { days, setDays, flush };
+  return { days, setDays };
 }

--- a/src/features/planner/hooks/usePersistedPlannerDays.ts
+++ b/src/features/planner/hooks/usePersistedPlannerDays.ts
@@ -66,6 +66,7 @@ export function usePersistedPlannerDays({
   }
   const persistChainRef = useRef<Promise<void>>(Promise.resolve());
   const lastRequestedRef = useRef<string>(metaRef.current.lastSaved);
+  const needsReplayRef = useRef(false);
 
   useEffect(() => {
     if (storedDays == null) return;
@@ -99,9 +100,13 @@ export function usePersistedPlannerDays({
     if (cleanedDays.length === 0) return;
 
     const serialized = JSON.stringify(cleanedDays);
-    if (serialized === meta.lastSaved || serialized === lastRequestedRef.current) return;
+    const shouldSkip =
+      !needsReplayRef.current &&
+      (serialized === meta.lastSaved || serialized === lastRequestedRef.current);
+    if (shouldSkip) return;
 
     const snapshotState = cloneDays(cleanedDays);
+    needsReplayRef.current = false;
     lastRequestedRef.current = serialized;
 
     persistChainRef.current = persistChainRef.current.finally(async () => {
@@ -111,6 +116,7 @@ export function usePersistedPlannerDays({
         meta.fallback = snapshotState;
       } catch {
         lastRequestedRef.current = meta.lastSaved;
+        needsReplayRef.current = true;
         setDays(cloneDays(meta.fallback));
       }
     });

--- a/src/features/planner/services/supabase/planEventsRepository.ts
+++ b/src/features/planner/services/supabase/planEventsRepository.ts
@@ -1,6 +1,11 @@
 // src/features/planner/services/supabase/planEventsRepository.ts
 
 import { supabase } from '@/shared/lib/supabaseClient';
+import type {
+  PostgrestMaybeSingleResponse,
+  PostgrestResponse,
+  PostgrestSingleResponse,
+} from '@supabase/postgrest-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import type {
@@ -11,6 +16,11 @@ import type {
 import type { Activity, DayPlan } from '@/features/planner/domain/types/PlannerEntities';
 import { normalizePositions } from '@/features/planner/domain/events/gapOrdering';
 import type { Database } from '@/shared/types/supabase';
+
+type PlanSnapshotRow = Database['public']['Tables']['plan_snapshots']['Row'];
+type PlanEventRow = Database['public']['Tables']['plan_events']['Row'];
+type AppendPlanEventsResponse = Database['public']['Functions']['append_plan_events']['Returns'];
+type PlannerRealtimeChannel = ReturnType<SupabaseClient<Database>['channel']>;
 
 const ActivitySchema = z.object({
   id: z.string(),
@@ -50,6 +60,11 @@ const EventRowSchema = z.object({
   payload: z.unknown(),
   created_at: z.string(),
   actor_id: z.string().nullish(),
+});
+
+const AppendEventsResponseSchema = z.object({
+  version: z.number(),
+  inserted_events: z.array(EventRowSchema),
 });
 
 function mapActivity(row: z.infer<typeof ActivitySchema>): Activity {
@@ -115,10 +130,12 @@ export class PlanEventsRepository {
   }
 
   async fetchSnapshot(planId: string): Promise<PlanSnapshot> {
-    const { data, error } = await (this.client.from('plan_snapshots') as any)
+    const response = (await this.client
+      .from('plan_snapshots')
       .select('plan_id, version, state, updated_at')
       .eq('plan_id', planId)
-      .maybeSingle();
+      .maybeSingle()) as PostgrestMaybeSingleResponse<PlanSnapshotRow>;
+    const { data, error } = response;
     if (error) throw error;
 
     const parsed = SnapshotRowSchema.parse(
@@ -133,15 +150,16 @@ export class PlanEventsRepository {
   }
 
   async fetchEvents(planId: string, sinceVersion: number): Promise<PlanEvent[]> {
-    const { data, error } = await (this.client as any)
+    const response = (await this.client
       .from('plan_events')
       .select('event_id, plan_id, version, event_type, payload, created_at, actor_id')
       .eq('plan_id', planId)
       .gt('version', sinceVersion)
-      .order('version', { ascending: true });
+      .order('version', { ascending: true })) as unknown as PostgrestResponse<PlanEventRow>;
+    const { data, error } = response;
     if (error) throw error;
     if (!data) return [];
-    const parsedRows = (data as unknown[]).map((row) => EventRowSchema.parse(row));
+    const parsedRows = data.map((row) => EventRowSchema.parse(row));
     return parsedRows.map(mapEvent);
   }
 
@@ -150,28 +168,26 @@ export class PlanEventsRepository {
     baseVersion: number,
     events: PlanEventInsert[]
   ): Promise<{ events: PlanEvent[]; version: number }> {
-    const { data, error } = await (this.client as any).rpc('append_plan_events', {
+    const response = (await this.client.rpc('append_plan_events', {
       plan_id: planId,
       base_version: baseVersion,
       events,
-    });
+    })) as PostgrestSingleResponse<AppendPlanEventsResponse>;
+    const { data, error } = response;
 
     if (error) throw error;
     if (!data) {
       return { version: baseVersion, events: [] };
     }
-    const { version, inserted_events: inserted } = data as {
-      version: number;
-      inserted_events: z.infer<typeof EventRowSchema>[];
-    };
+    const { version, inserted_events } = AppendEventsResponseSchema.parse(data);
     return {
       version,
-      events: inserted.map((row) => mapEvent(EventRowSchema.parse(row))),
+      events: inserted_events.map(mapEvent),
     };
   }
 
-  subscribeToPlan(planId: string, handler: (event: PlanEvent) => void): any {
-    const channel = (this.client as any)
+  subscribeToPlan(planId: string, handler: (event: PlanEvent) => void): PlannerRealtimeChannel {
+    const channel = this.client
       .channel(`plan-events-${planId}`)
       .on(
         'postgres_changes',

--- a/src/shared/types/supabase-mod.d.ts
+++ b/src/shared/types/supabase-mod.d.ts
@@ -9,12 +9,22 @@ declare module '@supabase/supabase-js' {
     update: (...args: unknown[]) => SupabaseQueryBuilder;
     eq: (...args: unknown[]) => SupabaseQueryBuilder;
     order: (...args: unknown[]) => SupabaseQueryBuilder;
+    gt: (...args: unknown[]) => SupabaseQueryBuilder;
     single: () => Promise<{ data: unknown; error: unknown }>;
+    maybeSingle: () => Promise<{ data: unknown; error: unknown }>;
+  }
+
+  export interface SupabaseRealtimeChannel {
+    on: (...args: unknown[]) => SupabaseRealtimeChannel;
+    subscribe: () => SupabaseRealtimeChannel;
+    unsubscribe: () => void;
   }
 
   export interface SupabaseClient<_DB = unknown> {
     readonly _database?: _DB;
     from: (...args: unknown[]) => SupabaseQueryBuilder;
+    rpc: (...args: unknown[]) => Promise<{ data: unknown; error: unknown }>;
+    channel: (...args: unknown[]) => SupabaseRealtimeChannel;
     auth: {
       getSession: () => Promise<{ data: { session: unknown | null } }>;
       getUser: () => Promise<{ data: { user: { id: string } | null } }>;

--- a/src/shared/types/supabase.ts
+++ b/src/shared/types/supabase.ts
@@ -184,9 +184,86 @@ export interface Database {
           },
         ];
       };
+      plan_events: {
+        Row: {
+          event_id: string;
+          plan_id: string;
+          version: number;
+          event_type: string;
+          payload: Json;
+          actor_id: string | null;
+          created_at: string;
+        };
+        Insert: {
+          event_id?: string;
+          plan_id: string;
+          version: number;
+          event_type: string;
+          payload?: Json;
+          actor_id?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          event_id?: string;
+          plan_id?: string;
+          version?: number;
+          event_type?: string;
+          payload?: Json;
+          actor_id?: string | null;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'plan_events_plan_id_fkey';
+            columns: ['plan_id'];
+            referencedRelation: 'plans';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      plan_snapshots: {
+        Row: {
+          plan_id: string;
+          version: number;
+          state: Json;
+          updated_at: string;
+        };
+        Insert: {
+          plan_id: string;
+          version?: number;
+          state?: Json;
+          updated_at?: string;
+        };
+        Update: {
+          plan_id?: string;
+          version?: number;
+          state?: Json;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'plan_snapshots_plan_id_fkey';
+            columns: ['plan_id'];
+            referencedRelation: 'plans';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: Record<string, unknown>;
-    Functions: Record<string, unknown>;
+    Functions: Record<string, unknown> & {
+      append_plan_events: {
+        Args: {
+          plan_id: string;
+          base_version: number;
+          events: unknown;
+        };
+        Returns: {
+          version: number;
+          inserted_events: unknown;
+        };
+      };
+    };
     Enums: Record<string, unknown>;
     CompositeTypes: Record<string, unknown>;
   };


### PR DESCRIPTION
## Summary
- register touch sensors alongside pointer sensors to make drag gestures start immediately on touch devices
- prevent scroll containers from stealing touch drags and align the activity card editor options with its usage
- persist planner day updates immediately while keeping instant rollback on failed Supabase mutations

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68da87f53b34832295e8ca8081669994