### PR TITLE
Fix feature preview carousel drag detection on desktop

### DIFF
--- a/src/features/home/hooks/usePointerDragScroll.ts
+++ b/src/features/home/hooks/usePointerDragScroll.ts
@@ -11,6 +11,8 @@ export type PointerDragHandlers = {
   onScrollPreview?: (nearestIndex: number) => void;
 };
 
+const MAX_OVERSHOOT_PX = 64;
+
 export function usePointerDragScroll(
   ref: RefObject<HTMLUListElement | null>,
   opts?: PointerDragHandlers,
@@ -113,9 +115,11 @@ export function usePointerDragScroll(
       const max = el.scrollWidth - el.clientWidth;
       if (next < 0 || next > max) {
         const overshoot = next < 0 ? next : next - max;
-        // Move with the drag direction so the bounce feels natural.
-        overshootRef.current = -overshoot * 0.35;
-        el.style.transform = `translateX(${overshootRef.current}px)`;
+        // Clamp the bounce so the preview never stretches beyond its frame.
+        const maxOvershoot = Math.max(12, Math.min(MAX_OVERSHOOT_PX, el.clientWidth * 0.15));
+        const easedOvershoot = Math.max(Math.min(-overshoot * 0.35, maxOvershoot), -maxOvershoot);
+        overshootRef.current = easedOvershoot;
+        el.style.transform = `translateX(${easedOvershoot}px)`;
         next = next < 0 ? 0 : max;
       } else {
         overshootRef.current = 0;

--- a/src/features/home/hooks/usePointerDragScroll.ts
+++ b/src/features/home/hooks/usePointerDragScroll.ts
@@ -43,11 +43,16 @@ export function usePointerDragScroll(
 
       const centers = new Array<number>(count);
       const widths = new Array<number>(count);
+      const parentRect = el.getBoundingClientRect();
+      const scrollLeft = el.scrollLeft;
+
       for (let idx = 0; idx < count; idx += 1) {
         const it = items[idx];
-        const width = it.offsetWidth;
+        const rect = it.getBoundingClientRect();
+        const width = rect.width;
         widths[idx] = width;
-        centers[idx] = it.offsetLeft + width / 2;
+        const offsetLeft = rect.left - parentRect.left + scrollLeft;
+        centers[idx] = offsetLeft + width / 2;
       }
 
       const metrics = { count, centers, widths };

--- a/src/features/home/ui/FeatureCarousel.tsx
+++ b/src/features/home/ui/FeatureCarousel.tsx
@@ -222,26 +222,27 @@ export default function FeatureCarousel({ features }: FeatureCarouselProps) {
             onSelect={handleDotSelect}
             className="mb-3 hidden justify-end md:flex"
           />
-
-          <ul ref={imagesRef} tabIndex={-1} aria-hidden="true" className={IMAGE_LIST_CLASSES}>
-            {features.map((feature, index) => (
-              <li key={feature.title} className={IMAGE_ITEM_CLASSES}>
-                <div className="select-none">
-                  <Image
-                    src={feature.imgSrc}
-                    alt=""
-                    role="presentation"
-                    width={1600}
-                    height={900}
-                    className="block h-auto w-full overflow-hidden rounded-xl object-contain"
-                    priority={index === activeIndex}
-                    draggable={false}
-                    onDragStart={(event) => event.preventDefault()}
-                  />
-                </div>
-              </li>
-            ))}
-          </ul>
+          <div className="overflow-hidden">
+            <ul ref={imagesRef} tabIndex={-1} aria-hidden="true" className={IMAGE_LIST_CLASSES}>
+              {features.map((feature, index) => (
+                <li key={feature.title} className={IMAGE_ITEM_CLASSES}>
+                  <div className="select-none">
+                    <Image
+                      src={feature.imgSrc}
+                      alt=""
+                      role="presentation"
+                      width={1600}
+                      height={900}
+                      className="block h-auto w-full overflow-hidden rounded-xl object-contain"
+                      priority={index === activeIndex}
+                      draggable={false}
+                      onDragStart={(event) => event.preventDefault()}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- measure carousel items using bounding boxes so desktop drag gestures can reliably progress to adjacent slides

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ddae9b2b388322ad862ef6c9cc8106