### PR TITLE
Add unit tests for planner data loading and hooks

### DIFF
--- a/tests/unit/features/planner/hooks/usePlanResource.test.tsx
+++ b/tests/unit/features/planner/hooks/usePlanResource.test.tsx
@@ -1,0 +1,207 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/shared/lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+import { usePlanResource } from '@/features/planner/hooks/internal/usePlanResource';
+import { supabase } from '@/shared/lib/supabaseClient';
+
+function createWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function createBuilder(result: { data: unknown; error: unknown }) {
+  const builder: any = {
+    __updatePayload: undefined as unknown,
+    select: vi.fn(() => builder),
+    update: vi.fn((changes: unknown) => {
+      builder.__updatePayload = changes;
+      return builder;
+    }),
+    eq: vi.fn(() => builder),
+    abortSignal: vi.fn(() => builder),
+    single: vi.fn(async () => result),
+  };
+  return builder;
+}
+
+describe('usePlanResource', () => {
+  beforeEach(() => {
+    vi.mocked(supabase.from).mockReset();
+  });
+
+  it('uses the default fetcher and persist when table and column are provided', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetchBuilder = createBuilder({ data: { title: 'Original' }, error: null });
+    const updateBuilder = createBuilder({ data: { title: 'Updated' }, error: null });
+    const onSuccess = vi.fn();
+
+    let callCount = 0;
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      expect(table).toBe('plans');
+      callCount += 1;
+      return callCount === 1 ? fetchBuilder : updateBuilder;
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePlanResource<string, string>({
+          planId: 'plan-1',
+          resource: 'plan-title',
+          table: 'plans',
+          column: 'title',
+          onSuccess,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.data).toBe('Original'));
+
+    expect(fetchBuilder.select).toHaveBeenCalledWith('title');
+    expect(fetchBuilder.eq).toHaveBeenCalledWith('id', 'plan-1');
+    expect(fetchBuilder.abortSignal).toHaveBeenCalled();
+    expect(client.getQueryData(['plan-title', 'plan-1'])).toBe('Original');
+
+    await act(async () => {
+      await result.current.mutateAsync('Updated');
+    });
+
+    expect(updateBuilder.update).toHaveBeenCalledWith({ title: 'Updated' });
+    expect(updateBuilder.select).toHaveBeenCalledWith('title');
+    expect(updateBuilder.eq).toHaveBeenCalledWith('id', 'plan-1');
+    expect(onSuccess).toHaveBeenCalledWith('Updated', client);
+
+    client.clear();
+  });
+
+  it('defaults to plan_id column for non-plan tables', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const builder = createBuilder({ data: { notes: 'Notes' }, error: null });
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      expect(table).toBe('plan_days');
+      return builder;
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePlanResource<string, string>({
+          planId: 'plan-2',
+          resource: ['plan', 'days'],
+          table: 'plan_days',
+          column: 'notes',
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.data).toBe('Notes'));
+
+    expect(builder.select).toHaveBeenCalledWith('notes');
+    expect(builder.eq).toHaveBeenCalledWith('plan_id', 'plan-2');
+    expect(client.getQueryData(['plan', 'days', 'plan-2'])).toBe('Notes');
+
+    client.clear();
+  });
+
+  it('supports custom fetcher and persist functions', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetcher = vi.fn().mockResolvedValue('Custom Data');
+    const persistFn = vi.fn().mockResolvedValue('Saved');
+
+    const { result } = renderHook(
+      () =>
+        usePlanResource<string, string>({
+          planId: 'plan-3',
+          resource: 'custom',
+          fetcher,
+          persistFn,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith('plan-3', expect.any(AbortSignal)));
+    expect(supabase.from).not.toHaveBeenCalled();
+    expect(result.current.data).toBe('Custom Data');
+
+    await act(async () => {
+      await result.current.mutateAsync('payload');
+    });
+
+    expect(persistFn).toHaveBeenCalledWith('plan-3', 'payload', expect.any(AbortSignal));
+
+    client.clear();
+  });
+
+  it('propagates errors from the default fetcher', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const error = new Error('fetch failed');
+    const builder = createBuilder({ data: null, error: null });
+    builder.single.mockRejectedValue(error);
+
+    vi.mocked(supabase.from).mockImplementation(() => builder);
+
+    const { result } = renderHook(
+      () =>
+        usePlanResource<string>({
+          planId: 'plan-4',
+          resource: 'error-fetch',
+          table: 'plans',
+          retry: false,
+          enabled: false,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    let refetchResult: Awaited<ReturnType<typeof result.current.refetch>>;
+    await act(async () => {
+      refetchResult = await result.current.refetch({ throwOnError: false });
+    });
+
+    expect(supabase.from).toHaveBeenCalledWith('plans');
+    expect(refetchResult!.error).toBe(error);
+
+    client.clear();
+  });
+
+  it('propagates errors from the default persist function', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const error = new Error('persist failed');
+    const fetchBuilder = createBuilder({ data: { title: 'Original' }, error: null });
+    const updateBuilder = createBuilder({ data: null, error });
+
+    let call = 0;
+    vi.mocked(supabase.from).mockImplementation(() => {
+      call += 1;
+      return call === 1 ? fetchBuilder : updateBuilder;
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePlanResource<string, string>({
+          planId: 'plan-5',
+          resource: 'plan-error',
+          table: 'plans',
+          column: 'title',
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.data).toBe('Original'));
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync('Next');
+      })
+    ).rejects.toBe(error);
+
+    client.clear();
+  });
+});

--- a/tests/unit/features/planner/hooks/usePlanResource.test.tsx
+++ b/tests/unit/features/planner/hooks/usePlanResource.test.tsx
@@ -30,9 +30,7 @@ interface MockQueryBuilder<TData> {
   upsert: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
   order: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
   gt: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
-  maybeSingle: ReturnType<
-    typeof vi.fn<() => Promise<{ data: TData; error: unknown }>>
-  >;
+  maybeSingle: ReturnType<typeof vi.fn<() => Promise<{ data: TData; error: unknown }>>>;
   single: ReturnType<typeof vi.fn<() => Promise<{ data: TData; error: unknown }>>>;
 }
 
@@ -80,13 +78,11 @@ describe('usePlanResource', () => {
     const onSuccess = vi.fn();
 
     let callCount = 0;
-    vi.mocked(supabase.from).mockImplementation(
-      ((table: string) => {
-        expect(table).toBe('plans');
-        callCount += 1;
-        return callCount === 1 ? fetchBuilder : updateBuilder;
-      }) as never
-    );
+    vi.mocked(supabase.from).mockImplementation(((table: string) => {
+      expect(table).toBe('plans');
+      callCount += 1;
+      return callCount === 1 ? fetchBuilder : updateBuilder;
+    }) as never);
 
     const { result } = renderHook(
       () =>
@@ -123,12 +119,10 @@ describe('usePlanResource', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const builder = createBuilder({ data: { notes: 'Notes' }, error: null });
 
-    vi.mocked(supabase.from).mockImplementation(
-      ((table: string) => {
-        expect(table).toBe('plan_days');
-        return builder;
-      }) as never
-    );
+    vi.mocked(supabase.from).mockImplementation(((table: string) => {
+      expect(table).toBe('plan_days');
+      return builder;
+    }) as never);
 
     const { result } = renderHook(
       () =>
@@ -216,12 +210,10 @@ describe('usePlanResource', () => {
     const updateBuilder = createBuilder({ data: null, error });
 
     let call = 0;
-    vi.mocked(supabase.from).mockImplementation(
-      (() => {
-        call += 1;
-        return call === 1 ? fetchBuilder : updateBuilder;
-      }) as never
-    );
+    vi.mocked(supabase.from).mockImplementation((() => {
+      call += 1;
+      return call === 1 ? fetchBuilder : updateBuilder;
+    }) as never);
 
     const { result } = renderHook(
       () =>

--- a/tests/unit/features/planner/hooks/usePlanResource.test.tsx
+++ b/tests/unit/features/planner/hooks/usePlanResource.test.tsx
@@ -13,23 +13,58 @@ import { usePlanResource } from '@/features/planner/hooks/internal/usePlanResour
 import { supabase } from '@/shared/lib/supabaseClient';
 
 function createWrapper(client: QueryClient) {
-  return ({ children }: { children: ReactNode }) => (
+  const QueryClientTestWrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
+  QueryClientTestWrapper.displayName = 'QueryClientTestWrapper';
+  return QueryClientTestWrapper;
 }
 
-function createBuilder(result: { data: unknown; error: unknown }) {
-  const builder: any = {
+interface MockQueryBuilder<TData> {
+  __updatePayload: unknown;
+  select: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  update: ReturnType<typeof vi.fn<(changes: unknown) => MockQueryBuilder<TData>>>;
+  eq: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  abortSignal: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  insert: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  upsert: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  order: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  gt: ReturnType<typeof vi.fn<() => MockQueryBuilder<TData>>>;
+  maybeSingle: ReturnType<
+    typeof vi.fn<() => Promise<{ data: TData; error: unknown }>>
+  >;
+  single: ReturnType<typeof vi.fn<() => Promise<{ data: TData; error: unknown }>>>;
+}
+
+function createBuilder<TData>(result: { data: TData; error: unknown }) {
+  const builder = {
     __updatePayload: undefined as unknown,
-    select: vi.fn(() => builder),
-    update: vi.fn((changes: unknown) => {
-      builder.__updatePayload = changes;
-      return builder;
-    }),
-    eq: vi.fn(() => builder),
-    abortSignal: vi.fn(() => builder),
-    single: vi.fn(async () => result),
-  };
+    select: vi.fn<() => MockQueryBuilder<TData>>(),
+    update: vi.fn<(changes: unknown) => MockQueryBuilder<TData>>(),
+    eq: vi.fn<() => MockQueryBuilder<TData>>(),
+    abortSignal: vi.fn<() => MockQueryBuilder<TData>>(),
+    insert: vi.fn<() => MockQueryBuilder<TData>>(),
+    upsert: vi.fn<() => MockQueryBuilder<TData>>(),
+    order: vi.fn<() => MockQueryBuilder<TData>>(),
+    gt: vi.fn<() => MockQueryBuilder<TData>>(),
+    maybeSingle: vi.fn<() => Promise<{ data: TData; error: unknown }>>(),
+    single: vi.fn<() => Promise<{ data: TData; error: unknown }>>(),
+  } as unknown as MockQueryBuilder<TData>;
+
+  builder.select.mockReturnValue(builder);
+  builder.update.mockImplementation((changes: unknown) => {
+    builder.__updatePayload = changes;
+    return builder;
+  });
+  builder.eq.mockReturnValue(builder);
+  builder.abortSignal.mockReturnValue(builder);
+  builder.insert.mockReturnValue(builder);
+  builder.upsert.mockReturnValue(builder);
+  builder.order.mockReturnValue(builder);
+  builder.gt.mockReturnValue(builder);
+  builder.maybeSingle.mockResolvedValue(result);
+  builder.single.mockResolvedValue(result);
+
   return builder;
 }
 
@@ -45,11 +80,13 @@ describe('usePlanResource', () => {
     const onSuccess = vi.fn();
 
     let callCount = 0;
-    vi.mocked(supabase.from).mockImplementation((table: string) => {
-      expect(table).toBe('plans');
-      callCount += 1;
-      return callCount === 1 ? fetchBuilder : updateBuilder;
-    });
+    vi.mocked(supabase.from).mockImplementation(
+      ((table: string) => {
+        expect(table).toBe('plans');
+        callCount += 1;
+        return callCount === 1 ? fetchBuilder : updateBuilder;
+      }) as never
+    );
 
     const { result } = renderHook(
       () =>
@@ -86,10 +123,12 @@ describe('usePlanResource', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const builder = createBuilder({ data: { notes: 'Notes' }, error: null });
 
-    vi.mocked(supabase.from).mockImplementation((table: string) => {
-      expect(table).toBe('plan_days');
-      return builder;
-    });
+    vi.mocked(supabase.from).mockImplementation(
+      ((table: string) => {
+        expect(table).toBe('plan_days');
+        return builder;
+      }) as never
+    );
 
     const { result } = renderHook(
       () =>
@@ -146,7 +185,7 @@ describe('usePlanResource', () => {
     const builder = createBuilder({ data: null, error: null });
     builder.single.mockRejectedValue(error);
 
-    vi.mocked(supabase.from).mockImplementation(() => builder);
+    vi.mocked(supabase.from).mockImplementation((() => builder) as never);
 
     const { result } = renderHook(
       () =>
@@ -154,7 +193,6 @@ describe('usePlanResource', () => {
           planId: 'plan-4',
           resource: 'error-fetch',
           table: 'plans',
-          retry: false,
           enabled: false,
         }),
       { wrapper: createWrapper(client) }
@@ -178,10 +216,12 @@ describe('usePlanResource', () => {
     const updateBuilder = createBuilder({ data: null, error });
 
     let call = 0;
-    vi.mocked(supabase.from).mockImplementation(() => {
-      call += 1;
-      return call === 1 ? fetchBuilder : updateBuilder;
-    });
+    vi.mocked(supabase.from).mockImplementation(
+      (() => {
+        call += 1;
+        return call === 1 ? fetchBuilder : updateBuilder;
+      }) as never
+    );
 
     const { result } = renderHook(
       () =>

--- a/tests/unit/features/planner/server/createPlannerPlan.test.ts
+++ b/tests/unit/features/planner/server/createPlannerPlan.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/server/actions/createPlan', () => ({
+  createPlan: vi.fn(),
+}));
+
+import { createPlannerPlan } from '@/features/planner/server/createPlan';
+import { createPlan } from '@/server/actions/createPlan';
+
+describe('createPlannerPlan', () => {
+  beforeEach(() => {
+    vi.mocked(createPlan).mockReset();
+  });
+
+  it('maps the action result into the marketing payload', async () => {
+    vi.mocked(createPlan).mockResolvedValue({
+      id: 'plan-42',
+      publicSlug: 'trip-42',
+      editToken: 'edit-42',
+    });
+
+    const result = await createPlannerPlan({
+      title: 'Weekend Trip',
+      destination: { name: 'Berlin', latitude: 52.52, longitude: 13.405 },
+      startDate: '2024-04-01',
+      endDate: '2024-04-03',
+    });
+
+    expect(createPlan).toHaveBeenCalledWith(
+      'Weekend Trip',
+      { name: 'Berlin', latitude: 52.52, longitude: 13.405 },
+      '2024-04-01',
+      '2024-04-03'
+    );
+
+    expect(result).toEqual({
+      planId: 'plan-42',
+      publicSlug: 'trip-42',
+      editToken: 'edit-42',
+      recentPlan: {
+        id: 'plan-42',
+        slug: 'trip-42',
+        dest: 'Berlin',
+        start: '2024-04-01',
+        end: '2024-04-03',
+      },
+    });
+  });
+});

--- a/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
+++ b/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/supabaseServer', () => ({
+  supabaseServer: vi.fn(),
+}));
+
+import { notFound } from 'next/navigation';
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { getPublicPlannerExperience } from '@/features/planner/server/getPublicPlannerExperience';
+import type { SupabasePlanDayRow } from '@/features/planner/services/supabase/planDaysMapper';
+
+interface SupabaseResult<T> {
+  data: T;
+  error: unknown;
+}
+
+function createPlanQuery(result: SupabaseResult<{
+  id: string;
+  title: string | null;
+  plan_destinations: { destinations: { name: string } }[] | null;
+} | null>) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    single: vi.fn(async () => result),
+  };
+  return chain;
+}
+
+function createDayQuery(result: SupabaseResult<SupabasePlanDayRow[] | null>) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    order: vi.fn(async () => result),
+  };
+  return chain;
+}
+
+function mockSupabase(planResult: SupabaseResult<{
+  id: string;
+  title: string | null;
+  plan_destinations: { destinations: { name: string } }[] | null;
+} | null>, dayResult: SupabaseResult<SupabasePlanDayRow[] | null>) {
+  const planQuery = createPlanQuery(planResult);
+  const dayQuery = createDayQuery(dayResult);
+  const supabase = {
+    from: vi.fn((table: string) => {
+      if (table === 'plans') return planQuery;
+      if (table === 'plan_days') return dayQuery;
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+  return supabase;
+}
+
+const notFoundError = new Error('NOT_FOUND');
+
+describe('getPublicPlannerExperience', () => {
+  beforeEach(() => {
+    vi.mocked(notFound).mockImplementation(() => {
+      throw notFoundError;
+    });
+    vi.mocked(supabaseServer).mockReset();
+    vi.mocked(notFound).mockClear();
+  });
+
+  it('returns the planner experience with mapped days and fallback destination', async () => {
+    const planResult: SupabaseResult<{
+      id: string;
+      title: string | null;
+      plan_destinations: { destinations: { name: string } }[] | null;
+    } | null> = {
+      data: {
+        id: 'plan-1',
+        title: 'Summer Escape',
+        plan_destinations: [
+          {
+            destinations: {
+              name: 'Paris',
+            },
+          },
+        ],
+      },
+      error: null,
+    };
+
+    const dayResult: SupabaseResult<SupabasePlanDayRow[] | null> = {
+      data: [
+        {
+          date: '2024-01-01',
+          activities: [
+            {
+              id: 'activity-1',
+              day_id: '2024-01-01',
+              title: 'Visit Louvre',
+              color: '#123456',
+              address: 'Paris, France',
+              category: 'Culture',
+              description: 'Explore the museum',
+              start_time: '09:00',
+              duration: 120,
+              latitude: 48.8606,
+              longitude: 2.3376,
+              budget: 50,
+              image_url: null,
+              position: 0,
+            },
+          ],
+        },
+      ],
+      error: null,
+    };
+
+    const supabase = mockSupabase(planResult, dayResult);
+    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+
+    const experience = await getPublicPlannerExperience({ slug: 'summer-escape' });
+
+    expect(notFound).not.toHaveBeenCalled();
+    expect(experience).toEqual({
+      planId: 'plan-1',
+      title: 'Summer Escape',
+      destination: 'Paris',
+      initialDays: [
+        {
+          id: '2024-01-01',
+          label: 'Mon, 01 Jan',
+          activities: [
+            expect.objectContaining({
+              id: 'activity-1',
+              title: 'Visit Louvre',
+              color: '#123456',
+              address: 'Paris, France',
+              category: 'Culture',
+              description: 'Explore the museum',
+              startTime: '09:00',
+              duration: 120,
+              latitude: 48.8606,
+              longitude: 2.3376,
+              budget: 50,
+            }),
+          ],
+        },
+      ],
+    });
+  });
+
+  it('calls notFound when the plan is missing or returns an error', async () => {
+    const planResult = { data: null, error: new Error('plan missing') };
+    const dayResult = { data: null, error: null };
+    const supabase = mockSupabase(planResult, dayResult);
+    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(getPublicPlannerExperience({ slug: 'no-plan' })).rejects.toBe(notFoundError);
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls notFound when no destination is available', async () => {
+    const planResult = {
+      data: {
+        id: 'plan-2',
+        title: 'Untitled',
+        plan_destinations: [],
+      },
+      error: null,
+    };
+    const dayResult = { data: null, error: null };
+    const supabase = mockSupabase(planResult, dayResult);
+    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(getPublicPlannerExperience({ slug: 'missing-dest' })).rejects.toBe(notFoundError);
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns experience without initial days when the day query fails', async () => {
+    const planResult = {
+      data: {
+        id: 'plan-3',
+        title: null,
+        plan_destinations: [
+          {
+            destinations: {
+              name: 'Lisbon',
+            },
+          },
+        ],
+      },
+      error: null,
+    };
+    const dayResult = { data: null, error: new Error('days failure') };
+    const supabase = mockSupabase(planResult, dayResult);
+    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+
+    const experience = await getPublicPlannerExperience({ slug: 'lisbon-plan', dest: 'Lisbon' });
+
+    expect(notFound).not.toHaveBeenCalled();
+    expect(experience).toEqual({
+      planId: 'plan-3',
+      title: undefined,
+      destination: 'Lisbon',
+      initialDays: undefined,
+    });
+  });
+});

--- a/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
+++ b/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
@@ -18,27 +18,58 @@ interface SupabaseResult<T> {
   error: unknown;
 }
 
-function createPlanQuery(
-  result: SupabaseResult<{
-    id: string;
-    title: string | null;
-    plan_destinations: { destinations: { name: string } }[] | null;
-  } | null>
-) {
-  const chain: any = {
-    select: vi.fn(() => chain),
-    eq: vi.fn(() => chain),
-    single: vi.fn(async () => result),
-  };
+type PlanRecord = {
+  id: string;
+  title: string | null;
+  plan_destinations: { destinations: { name: string } }[] | null;
+} | null;
+
+type DayRecord = SupabasePlanDayRow[] | null;
+
+interface PlanQueryChain {
+  select: ReturnType<typeof vi.fn<(columns: string) => PlanQueryChain>>;
+  eq: ReturnType<typeof vi.fn<(column: string, value: unknown) => PlanQueryChain>>;
+  single: ReturnType<typeof vi.fn<() => Promise<SupabaseResult<PlanRecord>>>>;
+}
+
+interface DayQueryChain {
+  select: ReturnType<typeof vi.fn<(columns: string) => DayQueryChain>>;
+  eq: ReturnType<typeof vi.fn<(column: string, value: unknown) => DayQueryChain>>;
+  order: ReturnType<
+    typeof vi.fn<
+      (column: string, options: { ascending: boolean }) => Promise<SupabaseResult<DayRecord>>
+    >
+  >;
+}
+
+function createPlanQuery(result: SupabaseResult<PlanRecord>) {
+  const chain = {
+    select: vi.fn<(columns: string) => PlanQueryChain>(),
+    eq: vi.fn<(column: string, value: unknown) => PlanQueryChain>(),
+    single: vi.fn<() => Promise<SupabaseResult<PlanRecord>>>(),
+  } as unknown as PlanQueryChain;
+
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.single.mockResolvedValue(result);
+
   return chain;
 }
 
-function createDayQuery(result: SupabaseResult<SupabasePlanDayRow[] | null>) {
-  const chain: any = {
-    select: vi.fn(() => chain),
-    eq: vi.fn(() => chain),
-    order: vi.fn(async () => result),
-  };
+function createDayQuery(result: SupabaseResult<DayRecord>) {
+  const chain = {
+    select: vi.fn<(columns: string) => DayQueryChain>(),
+    eq: vi.fn<(column: string, value: unknown) => DayQueryChain>(),
+    order:
+      vi.fn<
+        (column: string, options: { ascending: boolean }) => Promise<SupabaseResult<DayRecord>>
+      >(),
+  } as unknown as DayQueryChain;
+
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.order.mockResolvedValue(result);
+
   return chain;
 }
 

--- a/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
+++ b/tests/unit/features/planner/server/getPublicPlannerExperience.test.ts
@@ -18,11 +18,13 @@ interface SupabaseResult<T> {
   error: unknown;
 }
 
-function createPlanQuery(result: SupabaseResult<{
-  id: string;
-  title: string | null;
-  plan_destinations: { destinations: { name: string } }[] | null;
-} | null>) {
+function createPlanQuery(
+  result: SupabaseResult<{
+    id: string;
+    title: string | null;
+    plan_destinations: { destinations: { name: string } }[] | null;
+  } | null>
+) {
   const chain: any = {
     select: vi.fn(() => chain),
     eq: vi.fn(() => chain),
@@ -40,11 +42,14 @@ function createDayQuery(result: SupabaseResult<SupabasePlanDayRow[] | null>) {
   return chain;
 }
 
-function mockSupabase(planResult: SupabaseResult<{
-  id: string;
-  title: string | null;
-  plan_destinations: { destinations: { name: string } }[] | null;
-} | null>, dayResult: SupabaseResult<SupabasePlanDayRow[] | null>) {
+function mockSupabase(
+  planResult: SupabaseResult<{
+    id: string;
+    title: string | null;
+    plan_destinations: { destinations: { name: string } }[] | null;
+  } | null>,
+  dayResult: SupabaseResult<SupabasePlanDayRow[] | null>
+) {
   const planQuery = createPlanQuery(planResult);
   const dayQuery = createDayQuery(dayResult);
   const supabase = {
@@ -116,7 +121,9 @@ describe('getPublicPlannerExperience', () => {
     };
 
     const supabase = mockSupabase(planResult, dayResult);
-    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce(
+      supabase as unknown as ReturnType<typeof supabaseServer>
+    );
 
     const experience = await getPublicPlannerExperience({ slug: 'summer-escape' });
 
@@ -153,7 +160,9 @@ describe('getPublicPlannerExperience', () => {
     const planResult = { data: null, error: new Error('plan missing') };
     const dayResult = { data: null, error: null };
     const supabase = mockSupabase(planResult, dayResult);
-    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce(
+      supabase as unknown as ReturnType<typeof supabaseServer>
+    );
 
     await expect(getPublicPlannerExperience({ slug: 'no-plan' })).rejects.toBe(notFoundError);
     expect(notFound).toHaveBeenCalledTimes(1);
@@ -170,7 +179,9 @@ describe('getPublicPlannerExperience', () => {
     };
     const dayResult = { data: null, error: null };
     const supabase = mockSupabase(planResult, dayResult);
-    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce(
+      supabase as unknown as ReturnType<typeof supabaseServer>
+    );
 
     await expect(getPublicPlannerExperience({ slug: 'missing-dest' })).rejects.toBe(notFoundError);
     expect(notFound).toHaveBeenCalledTimes(1);
@@ -193,7 +204,9 @@ describe('getPublicPlannerExperience', () => {
     };
     const dayResult = { data: null, error: new Error('days failure') };
     const supabase = mockSupabase(planResult, dayResult);
-    vi.mocked(supabaseServer).mockReturnValueOnce(supabase as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce(
+      supabase as unknown as ReturnType<typeof supabaseServer>
+    );
 
     const experience = await getPublicPlannerExperience({ slug: 'lisbon-plan', dest: 'Lisbon' });
 

--- a/tests/unit/server/actions/createPlan.test.ts
+++ b/tests/unit/server/actions/createPlan.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/shared/lib/supabaseServer', () => ({
+  supabaseServer: vi.fn(),
+}));
+
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { createPlan } from '@/server/actions/createPlan';
+
+describe('createPlan action', () => {
+  beforeEach(() => {
+    vi.mocked(supabaseServer).mockReset();
+  });
+
+  it('sends formatted payload and supports array responses', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [
+        {
+          plan_id: 'plan-1',
+          public_slug: 'slug-1',
+          edit_token: 'token-1',
+        },
+      ],
+      error: null,
+    });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    const result = await createPlan(
+      'Trip to Paris',
+      { name: 'Paris', latitude: 1.23, longitude: 4.56 },
+      '2024-01-01T10:00:00Z',
+      '2024-01-05T12:00:00Z'
+    );
+
+    expect(rpc).toHaveBeenCalledWith('create_full_plan', {
+      _title: 'Trip to Paris',
+      _dest_name: 'Paris',
+      _dest_lat: 1.23,
+      _dest_long: 4.56,
+      _start_date: '2024-01-01',
+      _end_date: '2024-01-05',
+    });
+    expect(result).toEqual({ id: 'plan-1', publicSlug: 'slug-1', editToken: 'token-1' });
+  });
+
+  it('supports object responses from RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        plan_id: 'plan-2',
+        public_slug: 'slug-2',
+        edit_token: 'token-2',
+      },
+      error: null,
+    });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    const result = await createPlan('Title', { name: 'Lisbon' }, '2024-02-01', '2024-02-10');
+
+    expect(rpc).toHaveBeenCalledWith('create_full_plan', {
+      _title: 'Title',
+      _dest_name: 'Lisbon',
+      _dest_lat: null,
+      _dest_long: null,
+      _start_date: '2024-02-01',
+      _end_date: '2024-02-10',
+    });
+    expect(result).toEqual({ id: 'plan-2', publicSlug: 'slug-2', editToken: 'token-2' });
+  });
+
+  it('throws when the RPC returns an error', async () => {
+    const error = new Error('failed');
+    const rpc = vi.fn().mockResolvedValue({ data: null, error });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toBe(error);
+  });
+
+  it('throws when the RPC does not return data', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toThrow(
+      'Failed to create plan'
+    );
+  });
+});

--- a/tests/unit/server/actions/createPlan.test.ts
+++ b/tests/unit/server/actions/createPlan.test.ts
@@ -23,7 +23,9 @@ describe('createPlan action', () => {
       ],
       error: null,
     });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     const result = await createPlan(
       'Trip to Paris',
@@ -52,7 +54,9 @@ describe('createPlan action', () => {
       },
       error: null,
     });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     const result = await createPlan('Title', { name: 'Lisbon' }, '2024-02-01', '2024-02-10');
 
@@ -70,14 +74,18 @@ describe('createPlan action', () => {
   it('throws when the RPC returns an error', async () => {
     const error = new Error('failed');
     const rpc = vi.fn().mockResolvedValue({ data: null, error });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toBe(error);
   });
 
   it('throws when the RPC does not return data', async () => {
     const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toThrow(
       'Failed to create plan'

--- a/tests/unit/server/actions/updatePlan.test.ts
+++ b/tests/unit/server/actions/updatePlan.test.ts
@@ -16,9 +16,15 @@ describe('setPlanDateRange', () => {
     const eq = vi.fn().mockResolvedValue({ error: null });
     const update = vi.fn(() => ({ eq }));
     const from = vi.fn(() => ({ update }));
-    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
-    await setPlanDateRange('plan-1', new Date('2024-03-10T10:30:00Z'), new Date('2024-03-15T15:45:00Z'));
+    await setPlanDateRange(
+      'plan-1',
+      new Date('2024-03-10T10:30:00Z'),
+      new Date('2024-03-15T15:45:00Z')
+    );
 
     expect(from).toHaveBeenCalledWith('plans');
     expect(update).toHaveBeenCalledWith({ start_date: '2024-03-10', end_date: '2024-03-15' });
@@ -30,7 +36,9 @@ describe('setPlanDateRange', () => {
     const eq = vi.fn().mockResolvedValue({ error });
     const update = vi.fn(() => ({ eq }));
     const from = vi.fn(() => ({ update }));
-    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await expect(
       setPlanDateRange('plan-1', new Date('2024-01-01'), new Date('2024-01-02'))
@@ -41,7 +49,9 @@ describe('setPlanDateRange', () => {
     const eq = vi.fn().mockResolvedValue({ error: {} });
     const update = vi.fn(() => ({ eq }));
     const from = vi.fn(() => ({ update }));
-    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await expect(
       setPlanDateRange('plan-1', new Date('2024-01-01'), new Date('2024-01-02'))

--- a/tests/unit/server/actions/updatePlan.test.ts
+++ b/tests/unit/server/actions/updatePlan.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/shared/lib/supabaseServer', () => ({
+  supabaseServer: vi.fn(),
+}));
+
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { setPlanDateRange } from '@/server/actions/updatePlan';
+
+describe('setPlanDateRange', () => {
+  beforeEach(() => {
+    vi.mocked(supabaseServer).mockReset();
+  });
+
+  it('formats dates and updates the plan record', async () => {
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ update }));
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+
+    await setPlanDateRange('plan-1', new Date('2024-03-10T10:30:00Z'), new Date('2024-03-15T15:45:00Z'));
+
+    expect(from).toHaveBeenCalledWith('plans');
+    expect(update).toHaveBeenCalledWith({ start_date: '2024-03-10', end_date: '2024-03-15' });
+    expect(eq).toHaveBeenCalledWith('id', 'plan-1');
+  });
+
+  it('throws with the Supabase error message when available', async () => {
+    const error = { message: 'update failed' };
+    const eq = vi.fn().mockResolvedValue({ error });
+    const update = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ update }));
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(
+      setPlanDateRange('plan-1', new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toThrow('update failed');
+  });
+
+  it('falls back to a generic error message', async () => {
+    const eq = vi.fn().mockResolvedValue({ error: {} });
+    const update = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ update }));
+    vi.mocked(supabaseServer).mockReturnValueOnce({ from } as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(
+      setPlanDateRange('plan-1', new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toThrow('Failed to update plan date range');
+  });
+});

--- a/tests/unit/server/actions/updatePlanTitle.test.ts
+++ b/tests/unit/server/actions/updatePlanTitle.test.ts
@@ -14,7 +14,9 @@ describe('updatePlanTitle', () => {
 
   it('invokes the update_plan_title RPC with provided values', async () => {
     const rpc = vi.fn().mockResolvedValue({ error: null });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await updatePlanTitle('plan-1', 'token-123', 'New Title');
 
@@ -28,7 +30,9 @@ describe('updatePlanTitle', () => {
   it('throws when Supabase returns an error', async () => {
     const error = new Error('rpc failed');
     const rpc = vi.fn().mockResolvedValue({ error });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+      typeof supabaseServer
+    >);
 
     await expect(updatePlanTitle('plan-1', 'token', 'Title')).rejects.toBe(error);
   });

--- a/tests/unit/server/actions/updatePlanTitle.test.ts
+++ b/tests/unit/server/actions/updatePlanTitle.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/shared/lib/supabaseServer', () => ({
+  supabaseServer: vi.fn(),
+}));
+
+import { supabaseServer } from '@/shared/lib/supabaseServer';
+import { updatePlanTitle } from '@/server/actions/updatePlanTitle';
+
+describe('updatePlanTitle', () => {
+  beforeEach(() => {
+    vi.mocked(supabaseServer).mockReset();
+  });
+
+  it('invokes the update_plan_title RPC with provided values', async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    await updatePlanTitle('plan-1', 'token-123', 'New Title');
+
+    expect(rpc).toHaveBeenCalledWith('update_plan_title', {
+      _plan_id: 'plan-1',
+      _edit_token: 'token-123',
+      _new_title: 'New Title',
+    });
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    const error = new Error('rpc failed');
+    const rpc = vi.fn().mockResolvedValue({ error });
+    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+
+    await expect(updatePlanTitle('plan-1', 'token', 'Title')).rejects.toBe(error);
+  });
+});

--- a/tests/unit/shared/hooks/useSupabaseResource.test.tsx
+++ b/tests/unit/shared/hooks/useSupabaseResource.test.tsx
@@ -40,7 +40,11 @@ describe('useSupabaseResource', () => {
   it('uses the persistFn, aborts previous calls, and invalidates the query on success', async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
-    const persistCalls: { payload: string; signal: AbortSignal; resolve: (value: unknown) => void }[] = [];
+    const persistCalls: {
+      payload: string;
+      signal: AbortSignal;
+      resolve: (value: unknown) => void;
+    }[] = [];
 
     const persistFn = vi.fn((payload: string, signal: AbortSignal) => {
       return new Promise((resolve) => {

--- a/tests/unit/shared/hooks/useSupabaseResource.test.tsx
+++ b/tests/unit/shared/hooks/useSupabaseResource.test.tsx
@@ -1,0 +1,142 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
+
+function createWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('useSupabaseResource', () => {
+  it('does not run the fetcher when disabled', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetcher = vi.fn().mockResolvedValue('data');
+
+    renderHook(
+      () =>
+        useSupabaseResource({
+          queryKey: ['resource'],
+          fetcher,
+          enabled: false,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await flushMicrotasks();
+
+    expect(fetcher).not.toHaveBeenCalled();
+    client.clear();
+  });
+
+  it('uses the persistFn, aborts previous calls, and invalidates the query on success', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const persistCalls: { payload: string; signal: AbortSignal; resolve: (value: unknown) => void }[] = [];
+
+    const persistFn = vi.fn((payload: string, signal: AbortSignal) => {
+      return new Promise((resolve) => {
+        persistCalls.push({ payload, signal, resolve });
+      });
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSupabaseResource<string, string>({
+          queryKey: ['resource'],
+          persistFn,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    let firstPromise: Promise<unknown>;
+    await act(async () => {
+      firstPromise = result.current.mutateAsync('first');
+    });
+
+    await waitFor(() => expect(persistFn).toHaveBeenCalledTimes(1));
+    const firstSignal = persistCalls[0].signal;
+
+    let secondPromise: Promise<unknown>;
+    await act(async () => {
+      secondPromise = result.current.mutateAsync('second');
+    });
+
+    await waitFor(() => expect(persistFn).toHaveBeenCalledTimes(2));
+
+    expect(firstSignal.aborted).toBe(true);
+    expect(persistCalls[1]).toMatchObject({ payload: 'second' });
+    expect(persistCalls[1].signal).toBeInstanceOf(AbortSignal);
+
+    persistCalls[0].resolve('first-result');
+    persistCalls[1].resolve('second-result');
+
+    await act(async () => {
+      await Promise.all([firstPromise!, secondPromise!]);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['resource'] });
+
+    client.clear();
+  });
+
+  it('calls the provided onSuccess callback instead of invalidating queries', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const onSuccess = vi.fn();
+    const persistFn = vi.fn().mockResolvedValue('ok');
+
+    const { result } = renderHook(
+      () =>
+        useSupabaseResource<string, string>({
+          queryKey: ['resource'],
+          persistFn,
+          onSuccess,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync('payload');
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith('ok', client);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    client.clear();
+  });
+
+  it('propagates errors from persistFn and calls onError', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const error = new Error('persist failed');
+    const onError = vi.fn();
+    const persistFn = vi.fn().mockRejectedValue(error);
+
+    const { result } = renderHook(
+      () =>
+        useSupabaseResource<string, string>({
+          queryKey: ['resource'],
+          persistFn,
+          onError,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await act(async () => {
+      await expect(result.current.mutateAsync('payload')).rejects.toBe(error);
+    });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(error, 'payload', undefined));
+
+    client.clear();
+  });
+});

--- a/tests/unit/shared/hooks/useSupabaseResource.test.tsx
+++ b/tests/unit/shared/hooks/useSupabaseResource.test.tsx
@@ -6,9 +6,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSupabaseResource } from '@/shared/hooks/useSupabaseResource';
 
 function createWrapper(client: QueryClient) {
-  return ({ children }: { children: ReactNode }) => (
+  const QueryClientTestWrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
+  QueryClientTestWrapper.displayName = 'QueryClientTestWrapper';
+  return QueryClientTestWrapper;
 }
 
 async function flushMicrotasks() {


### PR DESCRIPTION
## Summary
- add coverage for `getPublicPlannerExperience`, including success, missing plan, missing destination, and day query failures
- exercise planner-related server actions and wrapper flow to validate payload formatting and error propagation
- add hook tests for `useSupabaseResource` and `usePlanResource` to verify caching, abort behavior, and error handling

## Testing
- `npx vitest run -c config/vitest.config.ts tests/unit/features/planner/hooks/usePlanResource.test.tsx`
- `npx vitest run -c config/vitest.config.ts tests/unit/shared/hooks/useSupabaseResource.test.tsx tests/unit/features/planner/server/getPublicPlannerExperience.test.ts tests/unit/server/actions/createPlan.test.ts tests/unit/server/actions/updatePlan.test.ts tests/unit/server/actions/updatePlanTitle.test.ts tests/unit/features/planner/server/createPlannerPlan.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68df4c7b8f9c83229317a036753117b7