### PR TITLE
Add shared plan validation schemas and improve plan actions

### DIFF
--- a/src/features/planner/server/createPlan.ts
+++ b/src/features/planner/server/createPlan.ts
@@ -2,19 +2,14 @@
 'use server';
 
 import { createPlan as createPlanAction } from '@/server/actions/createPlan';
+import type {
+  CreatePlanInput,
+  PlanDestinationInput,
+} from '@/server/actions/planSchemas';
 
-export interface PlannerDestination {
-  name: string;
-  latitude?: number;
-  longitude?: number;
-}
+export type PlannerDestination = PlanDestinationInput;
 
-export interface CreatePlannerPlanInput {
-  title: string;
-  destination: PlannerDestination;
-  startDate: string;
-  endDate: string;
-}
+export type CreatePlannerPlanInput = CreatePlanInput;
 
 export interface PlannerRecentPlanPayload {
   id: string;
@@ -56,8 +51,8 @@ export async function createPlannerPlan({
       id,
       slug: publicSlug,
       dest: destination.name,
-      start: startDate,
-      end: endDate,
+      start: typeof startDate === 'string' ? startDate : new Date(startDate).toISOString(),
+      end: typeof endDate === 'string' ? endDate : new Date(endDate).toISOString(),
     },
   };
 }

--- a/src/features/planner/server/createPlan.ts
+++ b/src/features/planner/server/createPlan.ts
@@ -2,10 +2,7 @@
 'use server';
 
 import { createPlan as createPlanAction } from '@/server/actions/createPlan';
-import type {
-  CreatePlanInput,
-  PlanDestinationInput,
-} from '@/server/actions/planSchemas';
+import type { CreatePlanInput, PlanDestinationInput } from '@/server/actions/planSchemas';
 
 export type PlannerDestination = PlanDestinationInput;
 

--- a/src/server/actions/createPlan.ts
+++ b/src/server/actions/createPlan.ts
@@ -1,25 +1,48 @@
 // src/server/actions/createPlan.ts
 'use server';
+
 import { supabaseServer } from '@/shared/lib/supabaseServer';
 
-interface DestinationInfo {
-  name: string;
-  latitude?: number;
-  longitude?: number;
-}
+import {
+  createPlanSchema,
+  getFriendlyZodMessage,
+  type CreatePlanInput,
+  type PlanDestinationInput,
+} from './planSchemas';
 
-export async function createPlan(title: string, dest: DestinationInfo, start: string, end: string) {
+export type { PlanDestinationInput } from './planSchemas';
+
+export async function createPlan(
+  title: CreatePlanInput['title'],
+  dest: PlanDestinationInput,
+  start: CreatePlanInput['startDate'],
+  end: CreatePlanInput['endDate']
+) {
+  let parsed;
+  try {
+    parsed = createPlanSchema.parse({
+      title,
+      destination: dest,
+      startDate: start,
+      endDate: end,
+    });
+  } catch (error) {
+    throw new Error(getFriendlyZodMessage(error, 'Invalid plan details.'));
+  }
+
+  const { title: safeTitle, destination, startDate, endDate } = parsed;
   const supabase = supabaseServer();
 
-  const startDate = start.slice(0, 10);
-  const endDate = end.slice(0, 10);
+  const startISODate = startDate.toISOString().slice(0, 10);
+  const endISODate = endDate.toISOString().slice(0, 10);
+
   const { data, error } = await supabase.rpc('create_full_plan', {
-    _title: title,
-    _dest_name: dest.name,
-    _dest_lat: dest.latitude ?? null,
-    _dest_long: dest.longitude ?? null,
-    _start_date: startDate,
-    _end_date: endDate,
+    _title: safeTitle,
+    _dest_name: destination.name,
+    _dest_lat: destination.latitude ?? null,
+    _dest_long: destination.longitude ?? null,
+    _start_date: startISODate,
+    _end_date: endISODate,
   });
 
   if (error || !data) throw error ?? new Error('Failed to create plan');

--- a/src/server/actions/planSchemas.ts
+++ b/src/server/actions/planSchemas.ts
@@ -1,0 +1,150 @@
+import { z, ZodError, ZodIssueCode } from 'zod';
+
+const trimmedString = (fieldLabel: string) =>
+  z
+    .string({
+      required_error: `${fieldLabel} is required.`,
+      invalid_type_error: `${fieldLabel} must be a string.`,
+    })
+    .trim()
+    .min(1, `${fieldLabel} cannot be empty.`);
+
+const coordinateNumber = (fieldLabel: string) =>
+  z
+    .number({ invalid_type_error: `${fieldLabel} must be a number.` })
+    .refine((value) => Number.isFinite(value), `${fieldLabel} must be a finite number.`);
+
+const coerceDate = (fieldLabel: string) =>
+  z.preprocess(
+    (value) => {
+      if (value === undefined || value === null) return value;
+      if (value instanceof Date) return value;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) return undefined;
+        return new Date(trimmed);
+      }
+      if (typeof value === 'number') return new Date(value);
+      return value;
+    },
+    z
+      .date({
+        required_error: `${fieldLabel} is required.`,
+        invalid_type_error: `${fieldLabel} must be a valid date.`,
+      })
+      .refine((value) => !Number.isNaN(value.getTime()), {
+        message: `${fieldLabel} must be a valid date.`,
+      })
+  );
+
+const withDateOrderValidation = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.superRefine((value, ctx) => {
+    const { startDate, endDate } = value as { startDate: Date; endDate: Date };
+    if (startDate > endDate) {
+      ctx.addIssue({
+        code: ZodIssueCode.custom,
+        message: 'End date must be on or after the start date.',
+        path: ['endDate'],
+      });
+    }
+  });
+
+export const planTitleSchema = trimmedString('Plan title');
+
+export const destinationNameSchema = trimmedString('Destination name');
+
+const latitudeSchema = coordinateNumber('Latitude');
+const longitudeSchema = coordinateNumber('Longitude');
+
+export const planDestinationSchema = z
+  .object({
+    name: destinationNameSchema,
+    latitude: latitudeSchema.optional(),
+    longitude: longitudeSchema.optional(),
+  })
+  .refine(
+    (value) =>
+      (value.latitude === undefined && value.longitude === undefined) ||
+      (value.latitude !== undefined && value.longitude !== undefined),
+    {
+      message: 'Both latitude and longitude are required when providing coordinates.',
+      path: ['longitude'],
+    }
+  );
+
+const startDateSchema = coerceDate('Start date');
+const endDateSchema = coerceDate('End date');
+
+export const planDateRangeSchema = withDateOrderValidation(
+  z.object({
+    startDate: startDateSchema,
+    endDate: endDateSchema,
+  })
+);
+
+export const planIdSchema = trimmedString('Plan id');
+
+export const planEditTokenSchema = trimmedString('Edit token');
+
+export const createPlanSchema = withDateOrderValidation(
+  z.object({
+    title: planTitleSchema,
+    destination: planDestinationSchema,
+    startDate: startDateSchema,
+    endDate: endDateSchema,
+  })
+);
+
+export const updatePlanTitleSchema = z.object({
+  planId: planIdSchema,
+  editToken: planEditTokenSchema,
+  title: planTitleSchema,
+});
+
+export const setPlanDateRangeSchema = withDateOrderValidation(
+  z.object({
+    planId: planIdSchema,
+    startDate: startDateSchema,
+    endDate: endDateSchema,
+  })
+);
+
+export type PlanDestinationInput = z.input<typeof planDestinationSchema>;
+export type PlanDestination = z.output<typeof planDestinationSchema>;
+export type PlanDateRange = z.output<typeof planDateRangeSchema>;
+export type CreatePlanData = z.output<typeof createPlanSchema>;
+export type UpdatePlanTitleData = z.output<typeof updatePlanTitleSchema>;
+export type SetPlanDateRangeData = z.output<typeof setPlanDateRangeSchema>;
+
+export type PlanDateValue = string | number | Date;
+
+export interface PlanDateRangeInput {
+  startDate: PlanDateValue;
+  endDate: PlanDateValue;
+}
+
+export interface CreatePlanInput extends PlanDateRangeInput {
+  title: string;
+  destination: PlanDestinationInput;
+}
+
+export interface UpdatePlanTitleInput {
+  planId: string;
+  editToken: string;
+  title: string;
+}
+
+export interface SetPlanDateRangeInput extends PlanDateRangeInput {
+  planId: string;
+}
+
+export function getFriendlyZodMessage(error: unknown, fallbackMessage: string) {
+  if (error instanceof ZodError) {
+    const message = error.issues
+      .map((issue) => issue.message)
+      .filter(Boolean)
+      .join('; ');
+    return message || fallbackMessage;
+  }
+  return fallbackMessage;
+}

--- a/src/server/actions/updatePlan.ts
+++ b/src/server/actions/updatePlan.ts
@@ -2,17 +2,36 @@
 'use server';
 
 import { supabaseServer } from '@/shared/lib/supabaseServer';
-import { format } from 'date-fns';
 
-export async function setPlanDateRange(planId: string, from: Date, to: Date) {
+import {
+  getFriendlyZodMessage,
+  setPlanDateRangeSchema,
+  type SetPlanDateRangeInput,
+} from './planSchemas';
+
+export async function setPlanDateRange(
+  planId: SetPlanDateRangeInput['planId'],
+  from: SetPlanDateRangeInput['startDate'],
+  to: SetPlanDateRangeInput['endDate']
+) {
+  let parsed;
+  try {
+    parsed = setPlanDateRangeSchema.parse({ planId, startDate: from, endDate: to });
+  } catch (error) {
+    throw new Error(getFriendlyZodMessage(error, 'Invalid date range.'));
+  }
+
   const supabase = supabaseServer();
+  const startISODate = parsed.startDate.toISOString().slice(0, 10);
+  const endISODate = parsed.endDate.toISOString().slice(0, 10);
+
   const { error } = await supabase
     .from('plans')
     .update({
-      start_date: format(from, 'yyyy-MM-dd'),
-      end_date: format(to, 'yyyy-MM-dd'),
+      start_date: startISODate,
+      end_date: endISODate,
     })
-    .eq('id', planId);
+    .eq('id', parsed.planId);
   if (error) {
     throw new Error(error.message ?? 'Failed to update plan date range');
   }

--- a/src/server/actions/updatePlanTitle.ts
+++ b/src/server/actions/updatePlanTitle.ts
@@ -3,12 +3,29 @@
 
 import { supabaseServer } from '@/shared/lib/supabaseServer';
 
-export async function updatePlanTitle(planId: string, editToken: string, newTitle: string) {
+import {
+  getFriendlyZodMessage,
+  updatePlanTitleSchema,
+  type UpdatePlanTitleInput,
+} from './planSchemas';
+
+export async function updatePlanTitle(
+  planId: UpdatePlanTitleInput['planId'],
+  editToken: UpdatePlanTitleInput['editToken'],
+  newTitle: UpdatePlanTitleInput['title']
+) {
+  let parsed;
+  try {
+    parsed = updatePlanTitleSchema.parse({ planId, editToken, title: newTitle });
+  } catch (error) {
+    throw new Error(getFriendlyZodMessage(error, 'Invalid data for updating the plan title.'));
+  }
+
   const supabase = supabaseServer();
   const { error } = await supabase.rpc('update_plan_title', {
-    _plan_id: planId,
-    _edit_token: editToken,
-    _new_title: newTitle,
+    _plan_id: parsed.planId,
+    _edit_token: parsed.editToken,
+    _new_title: parsed.title,
   });
   if (error) throw error;
 }

--- a/tests/unit/server/actions/createPlan.test.ts
+++ b/tests/unit/server/actions/createPlan.test.ts
@@ -7,13 +7,19 @@ vi.mock('@/shared/lib/supabaseServer', () => ({
 import { supabaseServer } from '@/shared/lib/supabaseServer';
 import { createPlan } from '@/server/actions/createPlan';
 
+function mockSupabaseRpc(response: unknown) {
+  const rpc = vi.fn().mockResolvedValue(response);
+  vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+  return rpc;
+}
+
 describe('createPlan action', () => {
   beforeEach(() => {
     vi.mocked(supabaseServer).mockReset();
   });
 
   it('sends formatted payload and supports array responses', async () => {
-    const rpc = vi.fn().mockResolvedValue({
+    const rpc = mockSupabaseRpc({
       data: [
         {
           plan_id: 'plan-1',
@@ -23,13 +29,10 @@ describe('createPlan action', () => {
       ],
       error: null,
     });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
-      typeof supabaseServer
-    >);
 
     const result = await createPlan(
-      'Trip to Paris',
-      { name: 'Paris', latitude: 1.23, longitude: 4.56 },
+      '  Trip to Paris  ',
+      { name: '  Paris  ', latitude: 1.23, longitude: 4.56 },
       '2024-01-01T10:00:00Z',
       '2024-01-05T12:00:00Z'
     );
@@ -46,7 +49,7 @@ describe('createPlan action', () => {
   });
 
   it('supports object responses from RPC', async () => {
-    const rpc = vi.fn().mockResolvedValue({
+    const rpc = mockSupabaseRpc({
       data: {
         plan_id: 'plan-2',
         public_slug: 'slug-2',
@@ -54,9 +57,6 @@ describe('createPlan action', () => {
       },
       error: null,
     });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
-      typeof supabaseServer
-    >);
 
     const result = await createPlan('Title', { name: 'Lisbon' }, '2024-02-01', '2024-02-10');
 
@@ -73,22 +73,30 @@ describe('createPlan action', () => {
 
   it('throws when the RPC returns an error', async () => {
     const error = new Error('failed');
-    const rpc = vi.fn().mockResolvedValue({ data: null, error });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
-      typeof supabaseServer
-    >);
+    mockSupabaseRpc({ data: null, error });
 
     await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toBe(error);
   });
 
   it('throws when the RPC does not return data', async () => {
-    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
-    vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
-      typeof supabaseServer
-    >);
+    mockSupabaseRpc({ data: null, error: null });
 
     await expect(createPlan('x', { name: 'Y' }, '2024-01-01', '2024-01-02')).rejects.toThrow(
       'Failed to create plan'
     );
+  });
+
+  it('throws a friendly error when destination name is empty', async () => {
+    await expect(
+      createPlan('Trip', { name: '   ' }, '2024-03-01', '2024-03-02')
+    ).rejects.toThrow('Destination name cannot be empty.');
+    expect(supabaseServer).not.toHaveBeenCalled();
+  });
+
+  it('throws a friendly error when end date is before start date', async () => {
+    await expect(
+      createPlan('Trip', { name: 'Tokyo' }, '2024-05-05', '2024-05-01')
+    ).rejects.toThrow('End date must be on or after the start date.');
+    expect(supabaseServer).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/server/actions/createPlan.test.ts
+++ b/tests/unit/server/actions/createPlan.test.ts
@@ -9,7 +9,9 @@ import { createPlan } from '@/server/actions/createPlan';
 
 function mockSupabaseRpc(response: unknown) {
   const rpc = vi.fn().mockResolvedValue(response);
-  vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<typeof supabaseServer>);
+  vi.mocked(supabaseServer).mockReturnValueOnce({ rpc } as unknown as ReturnType<
+    typeof supabaseServer
+  >);
   return rpc;
 }
 
@@ -87,16 +89,16 @@ describe('createPlan action', () => {
   });
 
   it('throws a friendly error when destination name is empty', async () => {
-    await expect(
-      createPlan('Trip', { name: '   ' }, '2024-03-01', '2024-03-02')
-    ).rejects.toThrow('Destination name cannot be empty.');
+    await expect(createPlan('Trip', { name: '   ' }, '2024-03-01', '2024-03-02')).rejects.toThrow(
+      'Destination name cannot be empty.'
+    );
     expect(supabaseServer).not.toHaveBeenCalled();
   });
 
   it('throws a friendly error when end date is before start date', async () => {
-    await expect(
-      createPlan('Trip', { name: 'Tokyo' }, '2024-05-05', '2024-05-01')
-    ).rejects.toThrow('End date must be on or after the start date.');
+    await expect(createPlan('Trip', { name: 'Tokyo' }, '2024-05-05', '2024-05-01')).rejects.toThrow(
+      'End date must be on or after the start date.'
+    );
     expect(supabaseServer).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add shared Zod schemas for plan validation and friendly error formatting
- validate create, title update, and date range actions before calling Supabase while normalizing ISO dates
- reuse the shared plan types in the planner server module and extend unit tests with invalid input coverage

## Testing
- npm run test -- tests/unit/server/actions/createPlan.test.ts
- npm run test -- tests/unit/server/actions/updatePlan.test.ts
- npm run test -- tests/unit/features/planner/server/createPlannerPlan.test.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1e29457948322b545da06dab978e1