### PR TITLE
Fix Supabase day activity ordering and retain positions

### DIFF
--- a/src/features/planner/services/supabase/planDaysMapper.ts
+++ b/src/features/planner/services/supabase/planDaysMapper.ts
@@ -43,6 +43,7 @@ function mapActivityRow(activity: SupabaseActivityRow) {
     longitude: activity.longitude ?? undefined,
     budget: activity.budget ?? undefined,
     imageUrl: activity.image_url ?? undefined,
+    position: activity.position != null ? String(activity.position) : undefined,
   } satisfies DayPlan['activities'][number];
 }
 
@@ -54,6 +55,14 @@ export function mapPlanDaysFromSupabase(rows: SupabasePlanDayRow[] | null | unde
   return rows.map((day) => ({
     id: day.date,
     label: format(parseISO(day.date), 'EEE, dd MMM'),
-    activities: (day.activities ?? []).map(mapActivityRow),
+    activities: (day.activities ?? [])
+      .slice()
+      .sort((a, b) => {
+        if (a.position == null && b.position == null) return 0;
+        if (a.position == null) return 1;
+        if (b.position == null) return -1;
+        return a.position - b.position;
+      })
+      .map(mapActivityRow),
   }));
 }

--- a/tests/unit/features/planner/services/supabase/planDaysMapper.test.ts
+++ b/tests/unit/features/planner/services/supabase/planDaysMapper.test.ts
@@ -48,6 +48,7 @@ describe('mapPlanDaysFromSupabase', () => {
             id: 'activity-1',
             title: 'Visit the museum',
             color: '#123456',
+            position: '0',
             address: '123 Museum Rd',
             category: 'culture',
             description: 'Explore art exhibits',
@@ -102,6 +103,7 @@ describe('mapPlanDaysFromSupabase', () => {
           id: 'activity-2',
           title: '',
           color: DEFAULT_COLOR,
+          position: '1',
           address: undefined,
           category: undefined,
           description: undefined,
@@ -126,5 +128,52 @@ describe('mapPlanDaysFromSupabase', () => {
     expect(mapPlanDaysFromSupabase(null)).toEqual([]);
     expect(mapPlanDaysFromSupabase(undefined)).toEqual([]);
     expect(mapPlanDaysFromSupabase([])).toEqual([]);
+  });
+
+  it('sorts activities by position before mapping', () => {
+    const rows: SupabasePlanDayRow[] = [
+      {
+        date: '2024-07-08',
+        activities: [
+          {
+            id: 'b',
+            day_id: 'day-1',
+            title: 'second',
+            color: null,
+            address: null,
+            category: null,
+            description: null,
+            start_time: null,
+            duration: null,
+            latitude: null,
+            longitude: null,
+            budget: null,
+            image_url: null,
+            position: 2000,
+          },
+          {
+            id: 'a',
+            day_id: 'day-1',
+            title: 'first',
+            color: null,
+            address: null,
+            category: null,
+            description: null,
+            start_time: null,
+            duration: null,
+            latitude: null,
+            longitude: null,
+            budget: null,
+            image_url: null,
+            position: 1000,
+          },
+        ],
+      },
+    ];
+
+    const [day] = mapPlanDaysFromSupabase(rows);
+
+    expect(day.activities.map((activity) => activity.id)).toEqual(['a', 'b']);
+    expect(day.activities.map((activity) => activity.position)).toEqual(['1000', '2000']);
   });
 });


### PR DESCRIPTION
## Summary
- include Supabase activity positions when mapping planner days
- sort Supabase day activities by their numeric position before converting to domain objects
- expand mapper unit tests to cover position preservation and ordering

## Testing
- npm test -- --run tests/unit/features/planner/services/supabase/planDaysMapper.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e45b760fb083229a978b5245013717