### PR TITLE
Group Dependabot updates by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
       prefix-development: '⬆️'
     labels:
       - dependencies
+    groups:
+      dependencies:
+        dependency-type: 'production'
+      devDependencies:
+        dependency-type: 'development'


### PR DESCRIPTION
## Summary
- group Dependabot production dependencies under a dedicated group
- add a development dependencies group to consolidate related updates

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e45d41b58c8322a1497899172e6fc5