### PR TITLE
fix(a11y): add descriptions to planner dialogs

### DIFF
--- a/src/features/activityDialog/components/ActivityDialog.test.tsx
+++ b/src/features/activityDialog/components/ActivityDialog.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Activity, DayPlan } from "@/features/activity/types";
+
+import { ActivityDialog } from "./ActivityDialog";
+
+vi.mock("./ActivityForm", () => ({
+  ActivityForm: () => <div>Activity form</div>,
+}));
+
+const activity: Activity & { dayId: string } = {
+  id: "activity-1",
+  dayId: "day-1",
+  title: "Visit museum",
+  color: "bg-[var(--color-1)]",
+};
+
+const days: DayPlan[] = [
+  {
+    id: "day-1",
+    label: "Day 1",
+    activities: [activity],
+  },
+];
+
+describe("ActivityDialog", () => {
+  it("provides an accessible description", () => {
+    render(<ActivityDialog activity={activity} days={days} onSave={vi.fn()} onClose={vi.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Edit Activity" })).toHaveAccessibleDescription(
+      "Edit the selected activity title, schedule position, location, notes, budget, and visual details."
+    );
+  });
+});

--- a/src/features/activityDialog/components/ActivityDialog.tsx
+++ b/src/features/activityDialog/components/ActivityDialog.tsx
@@ -137,6 +137,9 @@ export const ActivityDialog = memo(function ActivityDialog({
       }}>
       <DialogContent className="flex w-[95%] max-w-113 flex-col p-0">
         <DialogPrimitive.Title className="sr-only">Edit Activity</DialogPrimitive.Title>
+        <DialogPrimitive.Description className="sr-only">
+          Edit the selected activity title, schedule position, location, notes, budget, and visual details.
+        </DialogPrimitive.Description>
 
         {/* Header */}
         <div

--- a/src/features/members/SharePlannerDialog.test.tsx
+++ b/src/features/members/SharePlannerDialog.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SharePlannerDialog } from "./SharePlannerDialog";
+
+vi.mock("@/features/shareLink/components/LinkSection", () => ({
+  LinkSection: () => <div>Share link controls</div>,
+}));
+
+vi.mock("./components/InviteForm", () => ({
+  InviteForm: () => <div>Invite form</div>,
+}));
+
+vi.mock("./components/MembersSection", () => ({
+  MembersSection: () => <div>Members list</div>,
+}));
+
+describe("SharePlannerDialog", () => {
+  it("provides an accessible description", () => {
+    render(<SharePlannerDialog planId="plan-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Share planner" }));
+
+    expect(screen.getByRole("dialog", { name: "Share planner" })).toHaveAccessibleDescription(
+      "Invite people, manage planner members, and create or revoke a share link."
+    );
+  });
+});

--- a/src/features/members/SharePlannerDialog.tsx
+++ b/src/features/members/SharePlannerDialog.tsx
@@ -22,8 +22,10 @@ export function SharePlannerDialog({ planId }: { planId: string }) {
         <Share2 className="size-4" aria-hidden="true" />
       </DialogTriggerButton>
       <DialogContent>
-        <DialogPrimitive.Title className="sr-only">Share planner</DialogPrimitive.Title>
         <DialogHeader title="Share planner" />
+        <DialogPrimitive.Description className="sr-only">
+          Invite people, manage planner members, and create or revoke a share link.
+        </DialogPrimitive.Description>
         <div className="max-h-[75vh] space-y-4 overflow-y-auto p-4">
           <InviteForm planId={planId} />
           <LinkSection planId={planId} />

--- a/src/shared/ui/dialog/Dialog.tsx
+++ b/src/shared/ui/dialog/Dialog.tsx
@@ -47,17 +47,14 @@ const DialogTriggerButton = React.forwardRef<HTMLButtonElement, DialogTriggerBut
 
 type DialogHeaderProps = {
   title: string;
-  titleId?: string;
   onClose?: () => void;
   className?: string;
 };
 
-function DialogHeader({ title, titleId, onClose, className }: DialogHeaderProps) {
+function DialogHeader({ title, onClose, className }: DialogHeaderProps) {
   return (
     <div className={cn("relative flex items-center justify-between border-b px-4 py-3", className)}>
-      <DialogPrimitive.Title id={titleId} className="text-lg font-semibold">
-        {title}
-      </DialogPrimitive.Title>
+      <DialogPrimitive.Title className="text-lg font-semibold">{title}</DialogPrimitive.Title>
       <DialogPrimitive.Close
         className="text-muted-foreground hover:bg-muted/60 hover:text-foreground inline-flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
         aria-label="Close"


### PR DESCRIPTION
## What does this PR do?
Adds accessible descriptions to planner dialogs so Radix Dialog no longer emits accessibility warnings when the planner page renders dialog content.

Key changes:
- Add `Dialog.Description` to the share planner dialog
- Add `Dialog.Description` to the activity edit dialog
- Keep `Dialog.Title` IDs managed by Radix instead of overriding them manually
- Add focused tests for dialog accessible descriptions

## How should this be tested?
The planner dialogs should expose both an accessible name and description without Radix console warnings. Reviewers should:

1. Run `npm run test -- src/features/members/SharePlannerDialog.test.tsx src/features/activityDialog/components/ActivityDialog.test.tsx`
2. Open a planner page and click “Share planner”. Expected result: no `DialogContent requires a DialogTitle` or missing description warning appears.
3. Open an activity dialog if available. Expected result: the dialog opens normally and no Radix dialog accessibility warning appears.

## Notes
Radix Dialog generates internal IDs for `Dialog.Title` and `Dialog.Description`; overriding those IDs can cause Radix to miss the title and emit warnings even when `aria-labelledby` is present.
