### PR TITLE
refactor(ui): isolate radix primitives behind shared components

### DIFF
--- a/src/features/activityDialog/components/ActivityDialog.tsx
+++ b/src/features/activityDialog/components/ActivityDialog.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import * as DialogPrimitive from "@radix-ui/react-dialog";
 import Image from "next/image";
 import { memo, useCallback, useEffect, useId, useState } from "react";
 
 import { ACTIVITY_COLORS } from "@/features/activity/constants";
 import { useActivityColors } from "@/features/activity/hooks/useActivityColors";
 import type { Activity } from "@/features/activity/types";
-import { Dialog, DialogContent } from "@/shared/ui/dialog";
+import { Dialog, DialogContent, DialogHeader } from "@/shared/ui/dialog";
 import { ChevronDown, Palette, Trash2, X } from "@/shared/ui/icon";
 import { Popover, PopoverContent, PopoverHeader, PopoverTriggerButton } from "@/shared/ui/popover";
 
@@ -136,10 +135,11 @@ export const ActivityDialog = memo(function ActivityDialog({
         }
       }}>
       <DialogContent className="flex w-[95%] max-w-113 flex-col p-0">
-        <DialogPrimitive.Title className="sr-only">Edit Activity</DialogPrimitive.Title>
-        <DialogPrimitive.Description className="sr-only">
-          Edit the selected activity title, schedule position, location, notes, budget, and visual details.
-        </DialogPrimitive.Description>
+        <DialogHeader
+          visuallyHidden
+          title="Edit Activity"
+          description="Edit the selected activity title, schedule position, location, notes, budget, and visual details."
+        />
 
         {/* Header */}
         <div

--- a/src/features/members/SharePlannerDialog.tsx
+++ b/src/features/members/SharePlannerDialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { useState } from "react";
 
 import { LinkSection } from "@/features/shareLink/components/LinkSection";
@@ -22,10 +21,10 @@ export function SharePlannerDialog({ planId }: { planId: string }) {
         <Share2 className="size-4" aria-hidden="true" />
       </DialogTriggerButton>
       <DialogContent>
-        <DialogHeader title="Share planner" />
-        <DialogPrimitive.Description className="sr-only">
-          Invite people, manage planner members, and create or revoke a share link.
-        </DialogPrimitive.Description>
+        <DialogHeader
+          title="Share planner"
+          description="Invite people, manage planner members, and create or revoke a share link."
+        />
         <div className="max-h-[75vh] space-y-4 overflow-y-auto p-4">
           <InviteForm planId={planId} />
           <LinkSection planId={planId} />

--- a/src/features/website/sections/PlanningFAQ/index.tsx
+++ b/src/features/website/sections/PlanningFAQ/index.tsx
@@ -1,8 +1,8 @@
-import * as Accordion from "@radix-ui/react-accordion";
 import { CTAButton } from "@/features/website/ui/button";
 import { Eyebrow, H2, P } from "@/features/website/ui/typography";
 import { Container, Section } from "@/features/website/ui/wrapper";
-import { CircleQuestionMark, Plus } from "@/shared/ui/icon";
+import { Accordion } from "@/shared/ui/accordion";
+import { CircleQuestionMark } from "@/shared/ui/icon";
 
 export interface FaqItem {
   question: string;
@@ -14,6 +14,12 @@ export interface FaqProps {
 }
 
 export function Faq({ items }: FaqProps) {
+  const accordionItems = items.map((item) => ({
+    value: item.question,
+    trigger: item.question,
+    content: <P>{item.answer}</P>,
+  }));
+
   return (
     <Section>
       <Container>
@@ -25,26 +31,7 @@ export function Faq({ items }: FaqProps) {
         <P> These are some of our most frequently asked questions.</P>
         <CTAButton />
       </Container>
-      <Accordion.Root type="single" collapsible className="space-y-4 text-left">
-        {items.map((item) => (
-          <Accordion.Item key={item.question} value={item.question} className="overflow-hidden border-b">
-            <Accordion.Header>
-              <Accordion.Trigger className="group text-foreground focus-visible:ring-primary/60 flex w-full items-center justify-between gap-4 py-4 text-left text-lg leading-[1.3] font-semibold transition-colors duration-300 ease-out focus-visible:ring-2 focus-visible:outline-hidden">
-                <span className="flex-1">{item.question}</span>
-                <Plus
-                  className="size-5 shrink-0 transition-transform duration-300 ease-out group-data-[state=open]:rotate-45"
-                  aria-hidden="true"
-                />
-              </Accordion.Trigger>
-            </Accordion.Header>
-            <Accordion.Content className="text-muted-foreground data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden transition-all duration-300 ease-out">
-              <div className="pb-5">
-                <P>{item.answer}</P>
-              </div>
-            </Accordion.Content>
-          </Accordion.Item>
-        ))}
-      </Accordion.Root>
+      <Accordion items={accordionItems} />
     </Section>
   );
 }

--- a/src/shared/types/modules.d.ts
+++ b/src/shared/types/modules.d.ts
@@ -8,5 +8,3 @@ declare module "@next/mdx" {
 
   export default function createMDX(options?: CreateMDXOptions): (nextConfig: NextConfig) => NextConfig;
 }
-
-declare module "@radix-ui/react-navigation-menu";

--- a/src/shared/ui/accordion/Accordion.test.tsx
+++ b/src/shared/ui/accordion/Accordion.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Accordion } from "@/shared/ui/accordion";
+
+const items = [
+  {
+    value: "first",
+    trigger: "First question",
+    content: "First answer",
+  },
+  {
+    value: "second",
+    trigger: "Second question",
+    content: "Second answer",
+  },
+];
+
+function AccordionExample() {
+  return <Accordion items={items} />;
+}
+
+describe("Accordion", () => {
+  it("opens and closes a collapsible item", () => {
+    render(<AccordionExample />);
+
+    const trigger = screen.getByRole("button", { name: "First question" });
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("keeps only one item open in single mode", () => {
+    render(<AccordionExample />);
+
+    const first = screen.getByRole("button", { name: "First question" });
+    const second = screen.getByRole("button", { name: "Second question" });
+
+    fireEvent.click(first);
+    fireEvent.click(second);
+
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    expect(second).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/shared/ui/accordion/Accordion.tsx
+++ b/src/shared/ui/accordion/Accordion.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import type { ReactNode } from "react";
+
+import { Plus } from "@/shared/ui/icon";
+
+type AccordionItem = {
+  value: string;
+  trigger: ReactNode;
+  content: ReactNode;
+};
+
+type AccordionProps = {
+  items: ReadonlyArray<AccordionItem>;
+};
+
+function Accordion({ items }: AccordionProps) {
+  return (
+    <AccordionPrimitive.Root type="single" collapsible className="space-y-4 text-left">
+      {items.map((item) => (
+        <AccordionPrimitive.Item key={item.value} value={item.value} className="overflow-hidden border-b">
+          <AccordionPrimitive.Header>
+            <AccordionPrimitive.Trigger className="group text-foreground focus-visible:ring-primary/60 flex w-full items-center justify-between gap-4 py-4 text-left text-lg leading-[1.3] font-semibold transition-colors duration-300 ease-out focus-visible:ring-2 focus-visible:outline-hidden">
+              <span className="flex-1">{item.trigger}</span>
+              <Plus
+                className="size-5 shrink-0 transition-transform duration-300 ease-out group-data-[state=open]:rotate-45"
+                aria-hidden="true"
+              />
+            </AccordionPrimitive.Trigger>
+          </AccordionPrimitive.Header>
+          <AccordionPrimitive.Content className="text-muted-foreground data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden transition-all duration-300 ease-out">
+            <div className="pb-5">{item.content}</div>
+          </AccordionPrimitive.Content>
+        </AccordionPrimitive.Item>
+      ))}
+    </AccordionPrimitive.Root>
+  );
+}
+
+export type { AccordionItem, AccordionProps };
+export { Accordion };

--- a/src/shared/ui/accordion/index.ts
+++ b/src/shared/ui/accordion/index.ts
@@ -1,0 +1,2 @@
+export type { AccordionItem, AccordionProps } from "./Accordion";
+export { Accordion } from "./Accordion";

--- a/src/shared/ui/dialog/ConfirmationDialog.test.tsx
+++ b/src/shared/ui/dialog/ConfirmationDialog.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmationDialog } from "@/shared/ui/dialog/ConfirmationDialog";
+
+describe("ConfirmationDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens with an accessible title and description", () => {
+    render(
+      <ConfirmationDialog
+        trigger={<button type="button">Delete trip</button>}
+        title="Delete planner"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete trip" }));
+
+    expect(screen.getByRole("dialog", { name: "Delete planner" })).toHaveAccessibleDescription(
+      "This action cannot be undone."
+    );
+  });
+
+  it("confirms the action and closes after success", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ConfirmationDialog
+        trigger={<button type="button">Delete trip</button>}
+        title="Delete planner"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete trip" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Delete planner" })).toBeNull());
+  });
+
+  it("keeps the dialog open when confirmation fails", async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error("Deletion failed"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <ConfirmationDialog
+        trigger={<button type="button">Delete trip</button>}
+        title="Delete planner"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete trip" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+
+    expect(screen.getByRole("dialog", { name: "Delete planner" })).toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalledWith("Confirmation action failed:", {
+      message: "Deletion failed",
+    });
+  });
+});

--- a/src/shared/ui/dialog/Dialog.tsx
+++ b/src/shared/ui/dialog/Dialog.tsx
@@ -47,21 +47,35 @@ const DialogTriggerButton = React.forwardRef<HTMLButtonElement, DialogTriggerBut
 
 type DialogHeaderProps = {
   title: string;
+  description: string;
+  visuallyHidden?: boolean;
   onClose?: () => void;
   className?: string;
 };
 
-function DialogHeader({ title, onClose, className }: DialogHeaderProps) {
+function DialogHeader({ title, description, visuallyHidden = false, onClose, className }: DialogHeaderProps) {
+  if (visuallyHidden) {
+    return (
+      <>
+        <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
+        <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description>
+      </>
+    );
+  }
+
   return (
-    <div className={cn("relative flex items-center justify-between border-b px-4 py-3", className)}>
-      <DialogPrimitive.Title className="text-lg font-semibold">{title}</DialogPrimitive.Title>
-      <DialogPrimitive.Close
-        className="text-muted-foreground hover:bg-muted/60 hover:text-foreground inline-flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
-        aria-label="Close"
-        onClick={onClose}>
-        <X className="size-4" aria-hidden="true" />
-      </DialogPrimitive.Close>
-    </div>
+    <>
+      <div className={cn("relative flex items-center justify-between border-b px-4 py-3", className)}>
+        <DialogPrimitive.Title className="text-lg font-semibold">{title}</DialogPrimitive.Title>
+        <DialogPrimitive.Close
+          className="text-muted-foreground hover:bg-muted/60 hover:text-foreground inline-flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
+          aria-label="Close"
+          onClick={onClose}>
+          <X className="size-4" aria-hidden="true" />
+        </DialogPrimitive.Close>
+      </div>
+      <DialogPrimitive.Description className="sr-only">{description}</DialogPrimitive.Description>
+    </>
   );
 }
 

--- a/src/shared/ui/dialog/index.ts
+++ b/src/shared/ui/dialog/index.ts
@@ -1,4 +1,8 @@
 export type { ConfirmationDialogProps } from "./ConfirmationDialog";
 export { ConfirmationDialog } from "./ConfirmationDialog";
-export type { DialogContentProps, DialogHeaderProps, DialogTriggerButtonProps } from "./Dialog";
+export type {
+  DialogContentProps,
+  DialogHeaderProps,
+  DialogTriggerButtonProps,
+} from "./Dialog";
 export { Dialog, DialogContent, DialogHeader, DialogTriggerButton } from "./Dialog";


### PR DESCRIPTION
## What does this PR do?
Moves feature-level Radix usage for dialogs and the FAQ accordion behind smaller shared UI components. This keeps the current behavior while narrowing the migration surface for replacing Radix primitives in a follow-up PR.

Key changes:
- Add a focused shared `Accordion` wrapper for the website FAQ section
- Update the FAQ section to render accordion items through `shared/ui/accordion`
- Extend the shared `DialogHeader` to always provide an accessible description
- Support visually hidden dialog headers through the same `DialogHeader` component
- Update `ActivityDialog` and `SharePlannerDialog` to use shared dialog primitives instead of importing Radix directly
- Add unit coverage for accordion behavior and confirmation dialog flows

## How should this be tested?
The affected UI should keep the same user-facing behavior while no longer importing Radix directly from feature components. Reviewers should:
1. Verify the FAQ accordion opens, collapses, and keeps only one item open at a time
2. Verify `SharePlannerDialog` opens with the expected accessible title and description
3. Verify `ActivityDialog` opens with its visually hidden accessible title and description
4. Verify `ConfirmationDialog` opens, closes after a successful confirmation, and stays open after a failed confirmation
5. Confirm type checking and the focused unit tests pass

## Notes
This PR intentionally does not replace Radix dependencies yet. It only isolates the dialog and accordion usage that should be easier to migrate in the next PR.
