### PR TITLE
fix: add sizes to fill images

### DIFF
--- a/src/features/website/sections/CTAFinal/index.tsx
+++ b/src/features/website/sections/CTAFinal/index.tsx
@@ -27,6 +27,7 @@ export function CtaFinal({ variant = "default" }: CtaFinalProps) {
           aria-hidden="true"
           role="presentation"
           fill
+          sizes="(min-width: 1200px) 1048px, calc(100vw - 48px)"
           className="pointer-events-none object-cover select-none"
           draggable={false}
         />

--- a/src/shared/ui/loading/LoadingScreen.tsx
+++ b/src/shared/ui/loading/LoadingScreen.tsx
@@ -34,6 +34,7 @@ export function LoadingScreen({ text = "Loading..." }: LoadingScreenProps) {
           role="presentation"
           aria-hidden="true"
           fill
+          sizes="128px"
           className="object-contain"
           priority
         />


### PR DESCRIPTION
## What does this PR do?
Adds missing image sizing metadata for `next/image` usages that render with `fill`, removing the E2E runtime warning and giving Next.js enough information to choose appropriate image sizes.

Key changes:
- Add `sizes="128px"` to the loading mascot image
- Add responsive `sizes` to the marketing CTA background image
- Keep the change limited to image performance warnings surfaced during E2E

## How should this be tested?
The affected images should render without Next.js `fill`/`sizes` warnings during runtime. Reviewers should:
1. Run `npx biome check --write src/shared/ui/loading/LoadingScreen.tsx src/features/website/sections/CTAFinal/index.tsx`
2. Run `npm run typecheck:ci`
3. Run the relevant E2E flow and verify the `Image ... has "fill" but is missing "sizes"` warning no longer appears

## Notes
Other E2E stability items, including local dev server conflicts and `ECONNRESET` noise, are intentionally left for deeper follow-up analysis.
