### PR TITLE
fix(planner): preserve activities when shortening plan dates

### DIFF
--- a/src/features/events/lib/diffEvents.test.ts
+++ b/src/features/events/lib/diffEvents.test.ts
@@ -3,7 +3,13 @@ import { describe, expect, it } from "vitest";
 import type { DayPlan } from "@/features/activity/types";
 
 import { diffEvents } from "../lib/diffEvents";
-import type { ActivityCreatedPayload, ActivityUpdatedPayload, DayCreatedPayload } from "../types";
+import { reduceEvents } from "../lib/eventReducer";
+import type {
+  ActivityCreatedPayload,
+  ActivityUpdatedPayload,
+  DayCreatedPayload,
+  EventRecord,
+} from "../types";
 
 const baseDay = {
   label: "Day",
@@ -94,6 +100,50 @@ describe("diffEvents", () => {
         toDayId: "day-2",
       },
     });
+  });
+
+  it("moves activities before removing shortened range days", () => {
+    const previousDays: DayPlan[] = [
+      { id: "2024-01-01", label: "Day 1", position: "1000", activities: [] },
+      { id: "2024-01-02", label: "Day 2", position: "2000", activities: [] },
+      { id: "2024-01-03", label: "Day 3", position: "3000", activities: [] },
+      { id: "2024-01-04", label: "Day 4", position: "4000", activities: [] },
+      {
+        id: "2024-01-05",
+        label: "Day 5",
+        position: "5000",
+        activities: [{ id: "activity-a", title: "A", color: "red", position: "1000" }],
+      },
+    ];
+    const nextDays: DayPlan[] = [
+      { id: "2024-01-01", label: "Day 1", position: "1000", activities: [] },
+      { id: "2024-01-02", label: "Day 2", position: "2000", activities: [] },
+      { id: "2024-01-03", label: "Day 3", position: "3000", activities: [] },
+      {
+        id: "2024-01-04",
+        label: "Day 4",
+        position: "4000",
+        activities: [{ id: "activity-a", title: "A", color: "red", position: "1000" }],
+      },
+    ];
+
+    const events = diffEvents("plan-1", previousDays, nextDays);
+    const eventTypes = events.map((event) => event.type);
+
+    expect(eventTypes).toEqual(["activity.moved", "day.removed"]);
+
+    const records: EventRecord[] = events.map((event, index) => ({
+      ...event,
+      version: index + 1,
+      createdAt: new Date(0).toISOString(),
+    }));
+    const result = reduceEvents(
+      { version: 0, days: previousDays, updatedAt: new Date(0).toISOString() },
+      records
+    );
+
+    expect(result.days).toHaveLength(4);
+    expect(result.days.at(-1)?.activities.map((activity) => activity.id)).toEqual(["activity-a"]);
   });
 
   it("ignores placeholder activities that leak into the next state", () => {

--- a/src/features/events/lib/diffEvents.ts
+++ b/src/features/events/lib/diffEvents.ts
@@ -87,6 +87,7 @@ export function diffEvents(
   actorId?: string | null
 ): EventInsert[] {
   const events: EventInsert[] = [];
+  const removedDayEvents: EventInsert[] = [];
   const prevDaysWithPositions = ensurePositions(previousDays);
   const prevDayMap = new Map(prevDaysWithPositions.map((day) => [day.id, day]));
   const prevActivityMap = new Map<string, { dayId: string; activity: Activity }>();
@@ -101,7 +102,7 @@ export function diffEvents(
   const nextDayIds = new Set(nextDays.map((day) => day.id));
   for (const day of prevDaysWithPositions) {
     if (!nextDayIds.has(day.id)) {
-      events.push({
+      removedDayEvents.push({
         id: generateId(),
         planId,
         type: "day.removed",
@@ -277,5 +278,5 @@ export function diffEvents(
     });
   }
 
-  return events;
+  return [...events, ...removedDayEvents];
 }

--- a/src/features/plan/hooks/PlannerContext.test.tsx
+++ b/src/features/plan/hooks/PlannerContext.test.tsx
@@ -1,156 +1,292 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { createDayPlan } from "@tests/utils/factories";
 import type React from "react";
-import type { Mock } from "vitest";
-import { vi } from "vitest";
-import type { DayPlan } from "@/features/activity/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Activity, DayPlan } from "@/features/activity/types";
+import { usePlanCollaboration } from "@/features/events/hooks/usePlanCollaboration";
 import { PlannerProvider, usePlannerContext } from "@/features/plan/hooks/PlannerContext";
+import { updatePlanDates } from "@/features/plan/lib/updatePlanDates";
 
-// Mock hooks used inside PlannerContext
-vi.mock("@/features/activity/hooks/state/planner/usePlanner", () => {
-  const React = require("react");
-  return {
-    usePlanner: ({ initialDays }: { initialDays?: DayPlan[] }) => {
-      const [days, setDays] = React.useState(initialDays ?? []);
-      return {
-        planId: "p1",
-        dest: "rome",
-        days,
-        setDays,
-        currentRange: undefined,
-        handleRangeChange: vi.fn(),
-        activeId: null,
-        sensors: [],
-        collisionDetection: vi.fn(),
-        handleDragStart: vi.fn(),
-        handleDragOver: vi.fn(),
-        handleDragEnd: vi.fn(),
-        addActivity: vi.fn(),
-        removeActivity: vi.fn(),
-        updateActivity: vi.fn(),
-        addBlankActivity: (dayIndex: number) =>
-          setDays((prev: DayPlan[]) => {
-            const day = prev[dayIndex];
-            if (!day) return prev;
-            const next = [...prev];
-            next[dayIndex] = {
-              ...day,
-              activities: [
-                ...day.activities,
-                {
-                  id: Math.random().toString(),
-                  title: "New",
-                  category: "general",
-                  color: "bg-[var(--color-1)]",
-                },
-              ],
-            };
-            return next;
-          }),
-      };
-    },
-  };
-});
-
-vi.mock("@/features/activity/hooks/state/planner/useSelectedActivity", () => ({
-  useSelectedActivity: () => ({
-    selectedActivity: null,
-    setSelectedActivity: vi.fn(),
-    changeDay: vi.fn(),
-    addBlankAndSelect: vi.fn(),
-    closeDialog: vi.fn(),
-    save: vi.fn(),
-    deleteActivity: vi.fn(),
-    changeColor: vi.fn(),
-  }),
-}));
 vi.mock("@/features/events/hooks/usePlanCollaboration", () => ({
-  usePlanCollaboration: () => ({
+  usePlanCollaboration: vi.fn(),
+}));
+
+vi.mock("@/features/plan/lib/updatePlanDates", () => ({
+  updatePlanDates: vi.fn(),
+}));
+
+const mockUsePlanCollaboration = vi.mocked(usePlanCollaboration);
+const mockUpdatePlanDates = vi.mocked(updatePlanDates);
+
+type PersistDays = ReturnType<typeof usePlanCollaboration>["persistDays"];
+
+let storedDays: DayPlan[] | undefined;
+let persistDays: PersistDays;
+
+function activity(overrides: Partial<Activity> = {}): Activity {
+  return {
+    id: "activity-1",
+    title: "Museum",
+    color: "blue",
+    position: "1000",
+    description: "",
+    duration: 60,
+    category: "sightseeing",
+    ...overrides,
+  };
+}
+
+function day(id: string, activities: Activity[] = []): DayPlan {
+  return {
+    id,
+    label: `Day ${id}`,
+    position: id,
+    activities,
+  };
+}
+
+function renderPlannerContext(
+  props: Partial<React.ComponentProps<typeof PlannerProvider>> = {},
+  options: { children?: React.ReactNode } = {}
+) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PlannerProvider planId="plan-1" initialDays={[day("2024-01-01")]} {...props}>
+      {options.children ?? children}
+    </PlannerProvider>
+  );
+
+  return renderHook(() => usePlannerContext(), { wrapper });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storedDays = undefined;
+  persistDays = {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  };
+  mockUsePlanCollaboration.mockImplementation((_planId, options) => ({
     data: storedDays,
     persistDays,
     isLoading: false,
-    error: null,
-    version: 1,
-  }),
-}));
-vi.mock("@/features/search/hooks/useDebounce", () => ({
-  useDebounce: <T,>(value: T) => value,
-}));
-// Mock usePlanCollaboration hook state
-let persistDays: {
-  mutateAsync: Mock<() => Promise<unknown>>;
-  mutate: Mock<() => unknown>;
-  isPending: boolean;
-};
-let storedDays: DayPlan[] | undefined;
-
-beforeEach(() => {
-  storedDays = undefined;
-  persistDays = {
-    mutateAsync: vi.fn(),
-    mutate: vi.fn(),
-    isPending: false,
-  };
+    error: undefined,
+    version: options?.enabled === false ? 0 : 1,
+  }));
+  mockUpdatePlanDates.mockResolvedValue(undefined);
+  vi.stubGlobal("fetch", vi.fn());
 });
 
 describe("PlannerProvider synchronization", () => {
-  const initialDays: DayPlan[] = [createDayPlan({ id: "2023-01-01", label: "Day 1" })];
+  it("waits for collaboration state before persisting day changes", () => {
+    const initialDays = [day("2024-01-01")];
+    const { result, rerender } = renderPlannerContext({ initialDays });
 
-  it("syncs after storedDays load and activity addition", async () => {
-    persistDays = {
-      mutateAsync: vi.fn(() => {
-        persistDays.isPending = true;
-        return Promise.resolve().finally(() => {
-          persistDays.isPending = false;
-        });
-      }),
-      mutate: vi.fn(),
-      isPending: false,
-    };
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <PlannerProvider planId="p1" initialDays={initialDays}>
-        {children}
-      </PlannerProvider>
-    );
-
-    const { result, rerender } = renderHook(() => usePlannerContext(), { wrapper });
-
-    // Modify before stored days are loaded
     act(() => result.current.addBlankActivity(0));
-    expect(persistDays.mutateAsync).not.toHaveBeenCalled();
 
-    // Simulate stored days arriving
+    expect(persistDays.mutate).not.toHaveBeenCalled();
+
     storedDays = initialDays;
     rerender();
 
-    // Subsequent changes should trigger persistence
     act(() => result.current.addBlankActivity(0));
-    await waitFor(() => expect(persistDays.mutate).toHaveBeenCalledTimes(1));
+
+    expect(persistDays.mutate).toHaveBeenCalledTimes(1);
+    expect(persistDays.mutate).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "2024-01-01",
+          activities: expect.arrayContaining([expect.objectContaining({ title: "" })]),
+        }),
+      ])
+    );
   });
 
-  it("reverts local state when persistence fails", async () => {
-    persistDays = {
-      mutateAsync: vi.fn(() => {
-        persistDays.isPending = true;
-        return Promise.reject(new Error("fail")).finally(() => {
-          persistDays.isPending = false;
-        });
-      }),
-      mutate: vi.fn(),
-      isPending: false,
-    };
-    storedDays = initialDays;
+  it("uses stored days when collaboration data is available", () => {
+    storedDays = [day("2024-02-01", [activity({ id: "stored-activity" })])];
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <PlannerProvider planId="p1" initialDays={initialDays}>
-        {children}
-      </PlannerProvider>
+    const { result } = renderPlannerContext({ initialDays: [day("2024-01-01")] });
+
+    expect(result.current.days).toEqual(storedDays);
+    expect(result.current.currentRange?.from?.toISOString()).toContain("2024-02-01");
+  });
+});
+
+describe("PlannerProvider date ranges", () => {
+  it("shortens the visible range and moves orphaned activities to the new last day", () => {
+    const lastDayActivity = activity({ id: "last-day-activity" });
+    const initialDays = [
+      day("2024-01-01"),
+      day("2024-01-02"),
+      day("2024-01-03"),
+      day("2024-01-04"),
+      day("2024-01-05", [lastDayActivity]),
+    ];
+    const { result } = renderPlannerContext({ initialDays, editToken: "token-1" });
+
+    act(() => {
+      result.current.handleRangeChange({
+        from: new Date("2024-01-01T00:00:00"),
+        to: new Date("2024-01-04T00:00:00"),
+      });
+    });
+
+    expect(result.current.days).toHaveLength(4);
+    expect(result.current.days[3].id).toBe("2024-01-04");
+    expect(result.current.days[3].activities).toEqual([lastDayActivity]);
+    expect(mockUpdatePlanDates).toHaveBeenCalledWith(
+      "plan-1",
+      "token-1",
+      new Date("2024-01-01T00:00:00"),
+      new Date("2024-01-04T00:00:00")
+    );
+  });
+
+  it("does not persist date changes without edit permission or edit token", () => {
+    const { result: readOnlyResult } = renderPlannerContext({ canEdit: false, editToken: "token-1" });
+    act(() => {
+      readOnlyResult.current.handleRangeChange({ from: new Date("2024-01-01T00:00:00") });
+    });
+
+    const { result: missingTokenResult } = renderPlannerContext();
+    act(() => {
+      missingTokenResult.current.handleRangeChange({ from: new Date("2024-01-02T00:00:00") });
+    });
+
+    expect(mockUpdatePlanDates).not.toHaveBeenCalled();
+  });
+
+  it("ignores incomplete range changes", () => {
+    const { result } = renderPlannerContext();
+
+    act(() => result.current.handleRangeChange(undefined));
+
+    expect(result.current.days).toEqual([day("2024-01-01")]);
+    expect(mockUpdatePlanDates).not.toHaveBeenCalled();
+  });
+});
+
+describe("PlannerProvider activity editing", () => {
+  it("adds activities with title and suggestion data", async () => {
+    const { result } = renderPlannerContext();
+
+    await act(async () => {
+      await result.current.addActivityWithTitle("2024-01-01", "Coffee", 0, {
+        address: "Main Street",
+        category: "food",
+      });
+    });
+
+    expect(result.current.days[0].activities[0]).toEqual(
+      expect.objectContaining({
+        title: "Coffee",
+        address: "Main Street",
+        category: "food",
+      })
+    );
+  });
+
+  it("selects, updates, moves, reorders, and deletes an activity", () => {
+    const selected = activity({ id: "selected", title: "Dinner" });
+    const initialDays = [day("2024-01-01", [selected]), day("2024-01-02")];
+    const { result } = renderPlannerContext({ initialDays });
+
+    act(() => result.current.setSelectedActivity({ ...selected, dayId: "2024-01-01" }));
+    expect(result.current.selectedActivity).toEqual(expect.objectContaining({ id: "selected" }));
+
+    act(() => result.current.save({ title: "Late dinner" }));
+    expect(result.current.days[0].activities[0].title).toBe("Late dinner");
+    expect(result.current.selectedActivity?.title).toBe("Late dinner");
+
+    act(() => result.current.changeColor("green"));
+    expect(result.current.days[0].activities[0].color).toBe("green");
+
+    act(() => result.current.changeDay("2024-01-02"));
+    expect(result.current.days[0].activities).toEqual([]);
+    expect(result.current.days[1].activities[0].id).toBe("selected");
+    expect(result.current.selectedActivity?.dayId).toBe("2024-01-02");
+
+    act(() => result.current.deleteActivity());
+    expect(result.current.days[1].activities).toEqual([]);
+    expect(result.current.selectedActivity).toBeNull();
+  });
+
+  it("handles blank editor operations when no day or activity is selected", () => {
+    const { result } = renderPlannerContext();
+
+    act(() => result.current.addBlankActivity(99));
+    act(() => result.current.addBlankAndSelect(99));
+    act(() => result.current.changeDay("missing-day"));
+    act(() => result.current.changePosition(0));
+    act(() => result.current.save({ title: "Ignored" }));
+    act(() => result.current.deleteActivity());
+    act(() => result.current.closeDialog());
+
+    expect(result.current.days).toEqual([day("2024-01-01")]);
+    expect(result.current.selectedActivity).toBeNull();
+  });
+
+  it("adds a blank activity and opens it in the editor", () => {
+    const { result } = renderPlannerContext();
+
+    act(() => result.current.addBlankAndSelect(0));
+
+    expect(result.current.days[0].activities).toHaveLength(1);
+    expect(result.current.selectedActivity).toEqual(
+      expect.objectContaining({
+        dayId: "2024-01-01",
+        title: "",
+      })
     );
 
-    const { result } = renderHook(() => usePlannerContext(), { wrapper });
+    act(() => result.current.setSelectedActivity(null));
+    expect(result.current.selectedActivity).toBeNull();
+  });
+});
 
-    act(() => result.current.addBlankActivity(0));
-    await waitFor(() => persistDays.mutateAsync.mock.calls.length === 1);
-    await waitFor(() => result.current.days[0].activities.length === 0);
+describe("PlannerProvider destination coordinates", () => {
+  it("geocodes destination names", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ latitude: 10, longitude: 20 }] }),
+    } as Response);
+
+    const { result } = renderPlannerContext({ dest: "Rome" });
+
+    await waitFor(() => expect(result.current.destCoords).toEqual({ lat: 10, lng: 20 }));
+    expect(fetch).toHaveBeenCalledWith("/api/places/city-country?text=Rome", {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("keeps coordinates empty when destination is missing or geocoding fails", async () => {
+    const { result } = renderPlannerContext({ dest: "Rome" });
+
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network"));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(result.current.destCoords).toBeNull();
+
+    expect(result.current.destCoords).toBeNull();
+  });
+});
+
+describe("PlannerProvider access flags", () => {
+  it("exposes planner metadata and access control flags", () => {
+    const { result } = renderPlannerContext({
+      planId: "plan-2",
+      dest: "Paris",
+      viewerUserId: "user-1",
+      isOwner: true,
+      isAdmin: true,
+      canManageMembers: true,
+    });
+
+    expect(result.current.planId).toBe("plan-2");
+    expect(result.current.dest).toBe("Paris");
+    expect(result.current.viewerUserId).toBe("user-1");
+    expect(result.current.canEdit).toBe(true);
+    expect(result.current.isOwner).toBe(true);
+    expect(result.current.isAdmin).toBe(true);
+    expect(result.current.canManageMembers).toBe(true);
   });
 });

--- a/src/features/plan/hooks/PlannerContext.tsx
+++ b/src/features/plan/hooks/PlannerContext.tsx
@@ -83,6 +83,7 @@ interface PlannerProviderProps {
   isOwner?: boolean;
   isAdmin?: boolean;
   canManageMembers?: boolean;
+  editToken?: string;
 }
 
 /**
@@ -118,6 +119,7 @@ export function usePlannerContextValue({
   isOwner = false,
   isAdmin = false,
   canManageMembers = false,
+  editToken,
 }: PlannerProviderProps): PlannerContextValue {
   // Collaboration hook for persistence
   const { data: storedDays, persistDays } = usePlanCollaboration(planId, {
@@ -211,15 +213,15 @@ export function usePlannerContextValue({
         setDays(synced);
 
         // Persist date range to server
-        if (persist && canEdit) {
+        if (persist && canEdit && editToken) {
           const to = range.to ?? range.from;
-          updatePlanDates(planId, range.from, to).catch((err) => {
+          updatePlanDates(planId, editToken, range.from, to).catch((err) => {
             console.error("Failed to persist plan dates:", err);
           });
         }
       }
     },
-    [days, setDays, persist, canEdit, planId]
+    [days, setDays, persist, canEdit, editToken, planId]
   );
 
   // Activity CRUD operations

--- a/src/features/plan/lib/updatePlanDates.test.ts
+++ b/src/features/plan/lib/updatePlanDates.test.ts
@@ -13,54 +13,50 @@ describe("updatePlanDates", () => {
     vi.mocked(createSupabaseServerClient).mockReset();
   });
 
-  it("formats dates and updates the plan record", async () => {
-    const single = vi.fn().mockResolvedValue({ error: null });
-    const select = vi.fn(() => ({ single }));
-    const eq = vi.fn(() => ({ select }));
-    const update = vi.fn(() => ({ eq }));
-    const from = vi.fn(() => ({ update }));
+  it("invokes the update_plan_dates RPC with formatted dates", async () => {
+    const rpc = vi.fn().mockResolvedValue({ error: null });
 
     vi.mocked(createSupabaseServerClient).mockReturnValueOnce({
-      from,
+      rpc,
     } as unknown as ReturnType<typeof createSupabaseServerClient>);
 
-    await updatePlanDates("plan-1", new Date("2024-03-10T12:00:00"), new Date("2024-03-15T12:00:00"));
+    await updatePlanDates(
+      "plan-1",
+      "token-123",
+      new Date("2024-03-10T12:00:00"),
+      new Date("2024-03-15T12:00:00")
+    );
 
-    expect(from).toHaveBeenCalledWith("plans");
-    expect(update).toHaveBeenCalledWith({ start_date: "2024-03-10", end_date: "2024-03-15" });
-    expect(eq).toHaveBeenCalledWith("id", "plan-1");
+    expect(rpc).toHaveBeenCalledWith("update_plan_dates", {
+      _plan_id: "plan-1",
+      _edit_token: "token-123",
+      _start_date: "2024-03-10",
+      _end_date: "2024-03-15",
+    });
   });
 
   it("throws with the Supabase error message when available", async () => {
     const error = { message: "update failed" };
-    const single = vi.fn().mockResolvedValue({ error });
-    const select = vi.fn(() => ({ single }));
-    const eq = vi.fn(() => ({ select }));
-    const update = vi.fn(() => ({ eq }));
-    const from = vi.fn(() => ({ update }));
+    const rpc = vi.fn().mockResolvedValue({ error });
 
     vi.mocked(createSupabaseServerClient).mockReturnValueOnce({
-      from,
+      rpc,
     } as unknown as ReturnType<typeof createSupabaseServerClient>);
 
-    await expect(updatePlanDates("plan-1", new Date("2024-01-01"), new Date("2024-01-02"))).rejects.toThrow(
-      "Supabase error during updatePlanDates (planId=plan-1). update failed"
-    );
+    await expect(
+      updatePlanDates("plan-1", "token", new Date("2024-01-01"), new Date("2024-01-02"))
+    ).rejects.toThrow("Supabase error during updatePlanDates (planId=plan-1). update failed");
   });
 
   it("falls back to a generic error message", async () => {
-    const single = vi.fn().mockResolvedValue({ error: {} });
-    const select = vi.fn(() => ({ single }));
-    const eq = vi.fn(() => ({ select }));
-    const update = vi.fn(() => ({ eq }));
-    const from = vi.fn(() => ({ update }));
+    const rpc = vi.fn().mockResolvedValue({ error: {} });
 
     vi.mocked(createSupabaseServerClient).mockReturnValueOnce({
-      from,
+      rpc,
     } as unknown as ReturnType<typeof createSupabaseServerClient>);
 
-    await expect(updatePlanDates("plan-1", new Date("2024-01-01"), new Date("2024-01-02"))).rejects.toThrow(
-      "Supabase error during updatePlanDates (planId=plan-1)."
-    );
+    await expect(
+      updatePlanDates("plan-1", "token", new Date("2024-01-01"), new Date("2024-01-02"))
+    ).rejects.toThrow("Supabase error during updatePlanDates (planId=plan-1).");
   });
 });

--- a/src/features/plan/lib/updatePlanDates.ts
+++ b/src/features/plan/lib/updatePlanDates.ts
@@ -5,17 +5,14 @@ import { format } from "date-fns";
 import { formatSupabaseError } from "@/shared/lib/supabaseErrors";
 import { createSupabaseServerClient } from "@/shared/lib/supabaseServer";
 
-export async function updatePlanDates(planId: string, from: Date, to: Date) {
+export async function updatePlanDates(planId: string, editToken: string, from: Date, to: Date) {
   const supabase = createSupabaseServerClient();
-  const { error } = await supabase
-    .from("plans")
-    .update({
-      start_date: format(from, "yyyy-MM-dd"),
-      end_date: format(to, "yyyy-MM-dd"),
-    })
-    .eq("id", planId)
-    .select("id")
-    .single();
+  const { error } = await supabase.rpc("update_plan_dates", {
+    _plan_id: planId,
+    _edit_token: editToken,
+    _start_date: format(from, "yyyy-MM-dd"),
+    _end_date: format(to, "yyyy-MM-dd"),
+  });
   if (error) {
     throw formatSupabaseError({
       operation: "updatePlanDates",

--- a/src/modules/planner/components/PlannerWorkspace.tsx
+++ b/src/modules/planner/components/PlannerWorkspace.tsx
@@ -236,7 +236,8 @@ export function PlannerWorkspace({
       viewerUserId={viewerUserId}
       isOwner={isOwner}
       isAdmin={isAdmin}
-      canManageMembers={canManageMembers}>
+      canManageMembers={canManageMembers}
+      editToken={editToken}>
       <PlannerWorkspaceContent
         persist={persist}
         title={title}

--- a/supabase/migrations/20260504140500_update_plan_dates_rpc.sql
+++ b/supabase/migrations/20260504140500_update_plan_dates_rpc.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION public.update_plan_dates(
+  _plan_id uuid,
+  _edit_token uuid,
+  _start_date date,
+  _end_date date
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE public.plans
+  SET start_date = _start_date,
+      end_date = _end_date
+  WHERE id = _plan_id
+    AND edit_token = _edit_token;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+  IF updated_count = 0 THEN
+    RAISE EXCEPTION 'Unable to update plan dates'
+      USING ERRCODE = 'P0001';
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_plan_dates(uuid, uuid, date, date) TO anon, authenticated;

--- a/tests/e2e/mocks/supabase/index.ts
+++ b/tests/e2e/mocks/supabase/index.ts
@@ -103,6 +103,12 @@ type RpcParams = {
     _edit_token: string;
     _new_title?: string | null;
   };
+  update_plan_dates: {
+    _plan_id: string;
+    _edit_token: string;
+    _start_date?: string | null;
+    _end_date?: string | null;
+  };
   create_plan_share_link: {
     _plan_id: string;
   };
@@ -578,6 +584,16 @@ class MockSupabaseClientImpl {
         if (rpcParams._plan_id === this.plan.plan_id) {
           this.plan.title = rpcParams._new_title ?? this.plan.title;
           this.syncPlanRow();
+        }
+        return { data: null, error: null };
+      }
+      case "update_plan_dates": {
+        const rpcParams = params as RpcParams["update_plan_dates"];
+        if (rpcParams._plan_id === this.plan.plan_id) {
+          this.syncPlanRow({
+            start_date: rpcParams._start_date ?? this.plans[0]?.start_date ?? null,
+            end_date: rpcParams._end_date ?? this.plans[0]?.end_date ?? null,
+          });
         }
         return { data: null, error: null };
       }


### PR DESCRIPTION
## What does this PR do?
Prevents planned activities from being lost when a trip date range is shortened. Date range updates now use the same edit-token permission model as title edits, so shared editors can persist plan dates without hitting Supabase row-return errors.

Key changes:
- Move activities before emitting removed-day events when shortening a plan
- Persist plan date changes through `update_plan_dates`
- Add a Supabase RPC for token-validated date updates
- Pass the edit token into the planner date range persistence flow
- Add regression coverage for shortening a 5-day plan to 4 days

## How should this be tested?
Shortening a plan should keep activities from removed days by moving them onto the new final day. Reviewers should:
1. Create or open a plan with activities on the final day
2. Reduce the plan date range by one day
3. Verify the final-day activities are still visible on the new last day
4. Refresh the page and verify the activities and dates persist
5. Confirm no `PGRST116` error appears in the browser console

## Notes
The Supabase migration must be applied before or with this deploy so `update_plan_dates` exists in production.
